### PR TITLE
feat: docs/ modular web build (safe add only)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+  <title>KHY Stage Game (Modularized)</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <!-- === Error Overlay (mobile-friendly) === -->
+  <div id="bootError" style="display:none;position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,.85);color:#ffb4b4;font:14px ui-monospace,Menlo,Consolas,monospace;padding:16px;overflow:auto">
+    <div style="max-width:900px;margin:auto">
+      <h3 style="margin:0 0 8px;color:#fecaca">Error</h3>
+      <pre id="bootErrorMsg" style="white-space:pre-wrap"></pre>
+      <button style="margin-top:12px;padding:8px 12px;background:#1f2937;color:#fff;border:1px solid #374151;border-radius:8px" onclick="this.closest('#bootError').style.display='none'">Dismiss</button>
+    </div>
+  </div>
+  <script>
+    window.addEventListener('error', (e)=>{
+      const b=document.getElementById('bootError'), m=document.getElementById('bootErrorMsg');
+      if(b&&m){ m.textContent=(e.message||'Unknown error')+'\n'+(e.filename?e.filename+':'+e.lineno:''); b.style.display='block'; }
+    });
+  </script>
+
+  <main class="stack">
+    <section class="widget widget--clear">
+      <div class="stage" id="gameStage">
+        <canvas id="game" style="border:1px solid #888;" width="720" height="460" aria-label="Stick figure canvas"></canvas>
+
+        <!-- HUD: health / stamina / footing -->
+        <div class="health-bar">
+          <div class="health-fill" id="healthFill"></div>
+          <div class="health-label" id="healthLabel">HP: 100</div>
+        </div>
+        <div class="stamina-bar">
+          <div class="stamina-fill" id="staminaFill"></div>
+          <div class="stamina-label" id="staminaLabel">STAMINA</div>
+        </div>
+        <div class="footing-bar">
+          <div class="footing-fill" id="footingFill"></div>
+          <div class="footing-label" id="footingLabel">FOOTING</div>
+        </div>
+
+        <!-- Door Interaction Prompt -->
+        <div class="interact-prompt" id="interactPrompt">Press E to Enter</div>
+
+        <!-- Transition Overlay + area name -->
+        <div class="transition-overlay" id="transitionOverlay"></div>
+        <div class="area-name" id="areaName"></div>
+
+        <!-- Controls overlay -->
+        <div class="controls-overlay">
+          <div class="top-ui">
+            <button type="button" id="btnHelp" class="ui-btn">❓ Help</button>
+            <button type="button" id="btnFullscreen" class="ui-btn">⤢ Full</button>
+          </div>
+
+          <div class="help-panel" id="helpPanel">
+            <h4>Controls</h4>
+            <div><span class="key">Joystick</span> - Move & Aim</div>
+            <div><span class="key">Green</span> - Jump</div>
+            <div><span class="key">Red</span> - Attack A (Combo)</div>
+            <div><span class="key">Orange</span> - Attack B (Quick)</div>
+            <div style="margin-top: 8px; padding-top: 8px; border-top: 1px solid #444;">
+              <span class="key">Keyboard:</span> WASD move, E/F attack
+            </div>
+          </div>
+
+          <!-- Virtual Joystick -->
+          <div class="joystick-area" id="joystickArea">
+            <div class="joystick-base"></div>
+            <div class="joystick-stick" id="joystickStick"></div>
+          </div>
+
+          <!-- Action Buttons -->
+          <div class="action-buttons">
+            <button type="button" id="btnJump" class="action-btn jump">↑</button>
+            <button type="button" id="btnAttackA" class="action-btn attack-a">A</button>
+            <button type="button" id="btnAttackB" class="action-btn attack-b">B</button>
+          </div>
+
+          <!-- Interact Button -->
+          <button type="button" id="btnInteract" class="interact-btn">E</button>
+        </div>
+      </div>
+
+      <div id="aiHud" style="position:absolute; top:8px; left:8px; z-index:50; padding:6px 8px; background:rgba(10,10,14,.7); color:#7dd3fc; font:12px/1.3 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; border:1px solid rgba(125,211,252,.3); border-radius:8px; display:none; pointer-events:none;">
+        NPC HUD
+      </div>
+    </section>
+
+    <section class="widget">
+      <div class="settings" id="settingsGrid">
+        <div class="box" id="appSettingsBox">
+          <div class="label">App Settings</div>
+          <div class="fields">
+            <label>Fighter <select id="fighterSelect"></select></label>
+            <label>Character scale <input id="actorScale" type="range" min="0.50" max="1.10" step="0.02" value="0.70"></label>
+            <label>Ground height <input id="groundRatio" type="range" min="0.60" max="0.92" step="0.01" value="0.70"></label>
+            <label>Hand collider size <input id="handMultiplier" type="range" min="1.0" max="4.0" step="0.1" value="2.0"></label>
+            <label>Foot collider size <input id="footMultiplier" type="range" min="0.5" max="2.0" step="0.1" value="1.0"></label>
+            <label>Authored weight <input id="wAuth" type="range" min="0" max="1" step="0.05" value="0.6"></label>
+            <label>Physics weight <input id="wPhys" type="range" min="0" max="1" step="0.05" value="0.4"></label>
+            <label class="row">Calves-only IK <input id="ikCalvesOnly" type="checkbox" checked style="margin-left:auto;"></label>
+            <label class="row">Facing locks during attack <input id="lockFacing" type="checkbox" checked style="margin-left:auto;"></label>
+          </div>
+          <div class="row" style="margin-top:6px;">
+            <span class="pill">Walk overwrites Stance + lerps back</span>
+            <span class="pill">Flip on direction (initial press)</span>
+            <span class="pill">Calf ragdoll mid-air (non-attack)</span>
+          </div>
+        </div>
+        <div class="box" id="statusBox">
+          <div class="label">Game Status</div>
+          <div id="statusInfo" style="font-size: 12px; color: #86efac;">
+            Booting…
+          </div>
+        </div>
+
+        <div class="box" id="comboBox">
+          <div class="label">Combo Settings</div>
+          <div id="comboFields" class="fields"></div>
+        </div>
+
+        <div class="box" id="hitBox">
+          <div class="label">Manual Hit Count</div>
+          <input id="hitSlider" type="range" min="0" max="4" step="1" value="0" style="width: 100%;">
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- External fighter/config (unchanged) -->
+  <script src="https://cdn.jsdelivr.net/gh/Oolnokk/SoKEmpirePrologue@1b50d8fbb33d17147eef3473e562a7258ed65ce5/config/config.js"></script>
+  <!-- Local shims and modules -->
+  <script src="./js/config-shims.js"></script>
+  <script type="module" src="./js/app.js"></script>
+</body>
+</html>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,0 +1,43 @@
+// app.js — minimal bootstrap (no external modules required)
+const $$ = (sel, el=document) => el.querySelector(sel);
+const on = (el, ev, fn) => el && el.addEventListener(ev, fn);
+
+function setText(id, txt){ const el = document.getElementById(id); if(el) el.textContent = txt; }
+function show(el, v){ if(!el) return; el.style.display = v ? '' : 'none'; }
+
+// HUD init
+const statusInfo = $$('#statusInfo');
+if (statusInfo) statusInfo.textContent = 'Booted';
+
+// Help panel
+const helpPanel = $$('#helpPanel');
+on($$('#btnHelp'), 'click', () => {
+  const v = getComputedStyle(helpPanel).display !== 'none';
+  show(helpPanel, !v);
+});
+
+// Fullscreen
+on($$('#btnFullscreen'), 'click', async () => {
+  const c = $$('#game');
+  if (!document.fullscreenElement) { await c?.requestFullscreen?.(); }
+  else { await document.exitFullscreen(); }
+});
+
+// Simple draw loop
+const ctx = $$('#game')?.getContext('2d');
+let t0 = performance.now();
+function frame(t){
+  const dt = (t - t0) / 1000; t0 = t;
+  if (ctx){
+    ctx.clearRect(0,0,ctx.canvas.width,ctx.canvas.height);
+    ctx.fillStyle = '#0b1220';
+    ctx.fillRect(0,0,ctx.canvas.width,ctx.canvas.height);
+    ctx.fillStyle = '#93c5fd';
+    ctx.fillText('KHY Modular Demo', 14, 22);
+  }
+  requestAnimationFrame(frame);
+}
+requestAnimationFrame(frame);
+
+// Show interact prompt briefly as a sanity check
+setTimeout(()=>{ show($$('#interactPrompt'), true); setTimeout(()=>show($$('#interactPrompt'), false), 1800); }, 600);

--- a/docs/js/config-shims.js
+++ b/docs/js/config-shims.js
@@ -1,0 +1,10 @@
+// config-shims.js — provides minimal back-compat for window.CONFIG
+(function(){
+  const ready = () => { try { document.dispatchEvent(new Event('config:ready')); } catch(_){} };
+  if (!window.CONFIG) {
+    window.CONFIG = { fighters:{}, durations:{}, poses:{}, attacks:{} };
+    setTimeout(ready, 0);
+  } else {
+    ready();
+  }
+})();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,45 @@
+/* Minimal styles for HUD and layout */
+:root{ --bg:#0b0f16; --fg:#e5e7eb; --muted:#9ca3af; --accent:#60a5fa; }
+*{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font:14px ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif}
+
+.stack{display:grid;gap:12px;padding:12px;max-width:1200px;margin:auto}
+.widget{background:#111827;border:1px solid #1f2937;border-radius:14px;padding:12px;box-shadow:0 6px 30px rgba(0,0,0,.25)}
+.widget--clear{background:transparent;border:none;box-shadow:none;padding:0}
+
+.stage{position:relative;max-width:100%;aspect-ratio:16/10;margin:auto}
+.stage canvas{background:#0a0f14;border-radius:8px;display:block;width:100%;height:auto}
+
+.health-bar,.stamina-bar,.footing-bar{position:absolute;left:8px;right:8px;height:10px;border-radius:6px;overflow:hidden;border:1px solid #1f2937;background:#0b1220}
+.health-bar{top:8px}.stamina-bar{top:26px}.footing-bar{top:44px}
+.health-fill{height:100%;width:70%;background:linear-gradient(90deg,#ef4444,#f59e0b)}
+.stamina-fill{height:100%;width:50%;background:linear-gradient(90deg,#22d3ee,#3b82f6)}
+.footing-fill{height:100%;width:60%;background:linear-gradient(90deg,#34d399,#10b981)}
+.health-label,.stamina-label,.footing-label{position:absolute;top:-18px;font:12px/1.2 ui-monospace,monospace;color:#93c5fd;text-shadow:0 1px 0 #000}
+.health-label{left:8px}.stamina-label{left:8px}.footing-label{right:8px}
+
+.interact-prompt{position:absolute;bottom:12px;left:12px;background:rgba(17,24,39,.7);backdrop-filter:blur(4px);border:1px solid #334155;padding:6px 8px;border-radius:8px;font:12px ui-monospace,monospace;color:#e5e7eb;display:none}
+.transition-overlay{position:absolute;inset:0;background:#000;opacity:0;pointer-events:none;transition:opacity .3s ease}
+.area-name{position:absolute;top:60px;left:12px;font-weight:600;color:#93c5fd}
+
+.controls-overlay{position:absolute;inset:0;pointer-events:none}
+.top-ui{position:absolute;top:8px;right:8px;display:flex;gap:6px;pointer-events:auto}
+.ui-btn{padding:6px 8px;border-radius:10px;border:1px solid #374151;background:#0b1220;color:#e5e7eb}
+.help-panel{position:absolute;top:40px;right:8px;min-width:220px;background:#0b1220;border:1px solid #1f2937;border-radius:12px;padding:10px;display:none}
+.key{display:inline-block;min-width:72px;color:#a7f3d0}
+
+.joystick-area{position:absolute;bottom:12px;left:12px;width:140px;height:140px;border-radius:12px;background:rgba(17,24,39,.6);border:1px solid #334155;pointer-events:auto}
+.joystick-base{position:absolute;inset:0;border-radius:inherit;border:1px dashed #334155}
+.joystick-stick{position:absolute;left:50%;top:50%;width:44px;height:44px;margin:-22px;border-radius:50%;background:#111827;border:1px solid #374151;box-shadow:0 4px 14px rgba(0,0,0,.5)}
+
+.action-buttons{position:absolute;bottom:12px;right:12px;display:flex;gap:8px;pointer-events:auto}
+.action-btn{width:48px;height:48px;border-radius:12px;border:1px solid #374151;background:#0b1220;color:#e5e7eb;font-weight:700}
+.action-btn.jump{font-size:20px}
+.interact-btn{position:absolute;bottom:70px;right:12px;width:48px;height:48px;border-radius:12px;border:1px solid #374151;background:#0b1220;color:#e5e7eb;font-weight:700;pointer-events:auto}
+
+.settings{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:10px}
+.box{border:1px solid #1f2937;background:#0b1220;border-radius:12px;padding:10px}
+.label{font-size:12px;color:#a5b4fc;margin-bottom:6px}
+.fields{display:grid;gap:6px}
+.pill{display:inline-block;margin-right:6px;margin-bottom:6px;font-size:11px;padding:4px 6px;border-radius:16px;border:1px solid #334155;color:#9ca3af}
+
+@media (hover:none){ .help-panel{font-size:14px} }


### PR DESCRIPTION
This PR non-destructively adds a minimal, modular web build under `docs/` so the game can run on GitHub Pages.

### Files added
- `docs/index.html` — boots the app, loads your existing `config/config.js` from the repo via jsDelivr pin.
- `docs/styles.css` — HUD + layout.
- `docs/js/app.js` — minimal loop + UI wiring.
- `docs/js/config-shims.js` — back-compat shim for `window.CONFIG`.

> Set **Settings → Pages** to "Deploy from a branch" → `main` / `/docs`.

Follow-ups I can open in another PR:
- Port richer controls, fighter, and presets modules.
- Add `.nojekyll` if we move assets to root later.