### PR TITLE
Fix relative import path for clear override module

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,4 +1,4 @@
-import '_clearOverride.js?v=1';
+import './_clearOverride.js?v=1';
 import { initPresets, ensureAltSequenceUsesKickAlt } from './presets.js?v=6';
 import { initFighters } from './fighter.js?v=6';
 import { initControls } from './controls.js?v=6';


### PR DESCRIPTION
## Summary
- ensure the `_clearOverride` helper is imported via a relative path so the module resolves when loading `app.js`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69068bd1c148832686f5712b5aa4422b