### PR TITLE
Align sprite rotation basis with toggleable angle zero

### DIFF
--- a/docs/js/render.js
+++ b/docs/js/render.js
@@ -1,9 +1,49 @@
 // render.js — v19-accurate rig math wired for sprites.js (compat arrays extended)
-// Angles in radians. 0 = up. Forward = (sin,-cos). Perp = (cos,sin).
+// Angle basis is centralized so sprites.js can stay in sync (toggle via window.ANGLE_ZERO).
 
-function segPos(x, y, len, ang) { return [x + len * Math.sin(ang), y - len * Math.cos(ang)]; }
-function withAX(x, y, ang, off) { if (!off) return [x, y]; const ax = off.ax || 0, ay = off.ay || 0; const dx = ax * Math.sin(ang) + ay * Math.cos(ang); const dy = ax * -Math.cos(ang) + ay * Math.sin(ang); return [x + dx, y + dy]; }
+function angleZero(){ const z = (typeof window !== 'undefined' && window.ANGLE_ZERO) ? String(window.ANGLE_ZERO).toLowerCase() : 'right'; return (z === 'up') ? 'up' : 'right'; }
+function basis(ang){ const c = Math.cos(ang), s = Math.sin(ang); if (angleZero() === 'right') { return { fx:c, fy:s, rx:-s, ry:c }; } return { fx:s, fy:-c, rx:c, ry:s }; }
+function segPos(x, y, len, ang) { const b = basis(ang); return [x + len * b.fx, y + len * b.fy]; }
+function withAX(x, y, ang, off, len, units) {
+  if (!off) return [x, y];
+  let ax = 0, ay = 0;
+  if (Array.isArray(off)) {
+    ax = +off[0] || 0;
+    ay = +off[1] || 0;
+  } else if (typeof off === 'object') {
+    ax = +((off.ax ?? off.x) ?? 0) || 0;
+    ay = +((off.ay ?? off.y) ?? 0) || 0;
+  } else {
+    return [x, y];
+  }
+
+  const lenVal = +len;
+  const hasLen = Number.isFinite(lenVal) && lenVal !== 0;
+  const L = hasLen ? Math.abs(lenVal) : 1;
+  const unitStr = (units || off?.units || '').toString().toLowerCase();
+  if (unitStr === 'percent' || unitStr === '%' || unitStr === 'pct') {
+    ax *= L;
+    ay *= L;
+  }
+
+  const b = basis(ang);
+  const dx = ax * b.fx + ay * b.rx;
+  const dy = ax * b.fy + ay * b.ry;
+  return [x + dx, y + dy];
+}
 function rad(v) { return v == null ? 0 : v; }
+function angleFromDelta(dx, dy){
+  if (angleZero() === 'right') { return Math.atan2(dy, dx); }
+  return Math.atan2(dx, -dy);
+}
+
+if (typeof window !== 'undefined') {
+  window.ANGLE_ZERO = angleZero();
+  window.BONE_BASIS = basis;
+  window.BONE_SEG_POS = segPos;
+  window.BONE_WITH_AX = withAX;
+  window.BONE_ANGLE_FROM_DELTA = angleFromDelta;
+}
 
 function pickFighterConfig(C, name) { const f = (C.fighters && (C.fighters[name] || C.fighters[Object.keys(C.fighters||{})[0] || ''])) || {}; return f; }
 function lengths(C, fcfg) { const s = (C.actor?.scale ?? 1) * (fcfg.actor?.scale ?? 1); const P = C.parts || {}; const Pf = fcfg.parts || {}; return { torso:(Pf.torso?.len ?? P.torso?.len ?? 60)*s, armU:(Pf.arm?.upper ?? P.arm?.upper ?? 50)*s, armL:(Pf.arm?.lower ?? P.arm?.lower ?? 50)*s, legU:(Pf.leg?.upper ?? P.leg?.upper ?? 40)*s, legL:(Pf.leg?.lower ?? P.leg?.lower ?? 40)*s, hbW:(Pf.hitbox?.w ?? P.hitbox?.w ?? 120)*s, hbH:(Pf.hitbox?.h ?? P.hitbox?.h ?? 160)*s, hbR:(Pf.hitbox?.r ?? P.hitbox?.r ?? 60)*s, scale:s }; }
@@ -89,4 +129,56 @@ function toCompatArrays(obj){ const B=obj.B; const end=(b)=>segPos(b.x,b.y,b.len
 
 function drawStick(ctx, B) { ctx.lineCap='round'; ctx.lineWidth=3; ctx.strokeStyle='#a8b3c3'; const seg=(sx,sy,len,ang)=>{ const [ex,ey]=segPos(sx,sy,len,ang); ctx.beginPath(); ctx.moveTo(sx,sy); ctx.lineTo(ex,ey); ctx.stroke(); }; seg(B.torso.x,B.torso.y,B.torso.len,B.torso.ang); seg(B.arm_L_upper.x,B.arm_L_upper.y,B.arm_L_upper.len,B.arm_L_upper.ang); seg(B.arm_L_lower.x,B.arm_L_lower.y,B.arm_L_lower.len,B.arm_L_lower.ang); seg(B.arm_R_upper.x,B.arm_R_upper.y,B.arm_R_upper.len,B.arm_R_upper.ang); seg(B.arm_R_lower.x,B.arm_R_lower.y,B.arm_R_lower.len,B.arm_R_lower.ang); seg(B.leg_L_upper.x,B.leg_L_upper.y,B.leg_L_upper.len,B.leg_L_upper.ang); seg(B.leg_L_lower.x,B.leg_L_lower.y,B.leg_L_lower.len,B.leg_L_lower.ang); seg(B.leg_R_upper.x,B.leg_R_upper.y,B.leg_R_upper.len,B.leg_R_upper.ang); seg(B.leg_R_lower.x,B.leg_R_lower.y,B.leg_R_lower.len,B.leg_R_lower.ang); }
 
-export function renderAll(ctx){ const G=(window.GAME ||= {}); const C=(window.CONFIG || {}); if(!ctx||!G.FIGHTERS) return; const fName=(G.selectedFighter && C.fighters?.[G.selectedFighter])? G.selectedFighter : (C.fighters?.TLETINGAN? 'TLETINGAN' : Object.keys(C.fighters||{})[0] || 'default'); const player=computeAnchorsForFighter(G.FIGHTERS.player,C,fName); const npc=computeAnchorsForFighter(G.FIGHTERS.npc,C,fName); (G.ANCHORS_OBJ ||= {}); G.ANCHORS_OBJ.player=player.B; G.ANCHORS_OBJ.npc=npc.B; (G.ANCHORS ||= {}); G.ANCHORS.player=toCompatArrays(player); G.ANCHORS.npc=toCompatArrays(npc); const camX=G.CAMERA?.x||0; ctx.save(); ctx.translate(-camX,0); drawStick(ctx, player.B); ctx.restore(); }
+
+
+function drawCompass(ctx, x, y, r, label){
+  if (!ctx) return;
+  ctx.save();
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = '#6b7280';
+  ctx.fillStyle = '#9aa6b2';
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, Math.PI * 2);
+  ctx.stroke();
+  const A = [0, Math.PI/2, Math.PI, Math.PI * 1.5];
+  const T = ['0', '90', '180', '270'];
+  for (let i = 0; i < A.length; i++) {
+    const b = basis(A[i]);
+    const ex = x + r * b.fx;
+    const ey = y + r * b.fy;
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.lineTo(ex, ey);
+    ctx.stroke();
+    ctx.fillText(T[i], ex - 6, ey - 4);
+  }
+  if (label) { ctx.fillText(label, x - r, y + r + 14); }
+  ctx.restore();
+}
+
+function ensureAngleZeroToggle(){
+  if (typeof document === 'undefined') return;
+  if (document.getElementById('angleZeroChk')) return;
+  const grid = document.getElementById('settingsGrid');
+  if (!grid) return;
+  const label = document.createElement('label');
+  label.style.fontSize = '12px';
+  label.style.display = 'inline-flex';
+  label.style.gap = '8px';
+  label.style.alignItems = 'center';
+  label.innerHTML = `Angle zero = <b id="angleZeroLbl">${angleZero()}</b>`;
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.id = 'angleZeroChk';
+  checkbox.checked = angleZero() === 'right';
+  checkbox.addEventListener('change', (e)=>{
+    const mode = e.target.checked ? 'right' : 'up';
+    if (typeof window !== 'undefined') { window.ANGLE_ZERO = mode; }
+    const lbl = document.getElementById('angleZeroLbl');
+    if (lbl) lbl.textContent = mode;
+  });
+  label.appendChild(checkbox);
+  grid.appendChild(label);
+}
+
+export function renderAll(ctx){ const G=(window.GAME ||= {}); const C=(window.CONFIG || {}); if(!ctx||!G.FIGHTERS) return; const fName=(G.selectedFighter && C.fighters?.[G.selectedFighter])? G.selectedFighter : (C.fighters?.TLETINGAN? 'TLETINGAN' : Object.keys(C.fighters||{})[0] || 'default'); const player=computeAnchorsForFighter(G.FIGHTERS.player,C,fName); const npc=computeAnchorsForFighter(G.FIGHTERS.npc,C,fName); (G.ANCHORS_OBJ ||= {}); G.ANCHORS_OBJ.player=player.B; G.ANCHORS_OBJ.npc=npc.B; (G.ANCHORS ||= {}); G.ANCHORS.player=toCompatArrays(player); G.ANCHORS.npc=toCompatArrays(npc); const camX=G.CAMERA?.x||0; ctx.save(); ctx.translate(-camX,0); drawStick(ctx, player.B); ctx.restore(); drawCompass(ctx, 60, 80, 28, `zero=${angleZero()}`); ensureAngleZeroToggle(); }

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -7,10 +7,32 @@ const GLOB = (window.GAME ||= {});
 const RENDER = (window.RENDER ||= {});
 RENDER.MIRROR ||= {}; // per-part mirror flags like 'ARM_L_UPPER': true
 
+function angleZero(){ const z = (typeof window !== 'undefined' && window.ANGLE_ZERO) ? String(window.ANGLE_ZERO).toLowerCase() : 'right'; return (z === 'up') ? 'up' : 'right'; }
+function basisFor(ang){
+  const fn = (typeof window !== 'undefined' && typeof window.BONE_BASIS === 'function') ? window.BONE_BASIS : null;
+  if (fn) return fn(ang);
+  const c = Math.cos(ang), s = Math.sin(ang);
+  if (angleZero() === 'right') { return { fx:c, fy:s, rx:-s, ry:c }; }
+  return { fx:s, fy:-c, rx:c, ry:s };
+}
 function rad(deg){ return (deg||0) * Math.PI / 180; }
 function dist(a,b){ const dx=b[0]-a[0], dy=b[1]-a[1]; return Math.sqrt(dx*dx+dy*dy); }
-function angle(a,b){ return Math.atan2(b[0]-a[0], -(b[1]-a[1])); } // (sin,-cos) canonical
-function withAX(x,y,ang,ax,ay,unitsLen){ const L=(unitsLen||1); const u=(ax||0)*L, v=(ay||0)*L; const dx=u*Math.sin(ang)+v*Math.cos(ang); const dy=u*-Math.cos(ang)+v*Math.sin(ang); return [x+dx,y+dy]; }
+function angle(a,b){
+  const dx = b[0]-a[0];
+  const dy = b[1]-a[1];
+  const fn = (typeof window !== 'undefined' && typeof window.BONE_ANGLE_FROM_DELTA === 'function') ? window.BONE_ANGLE_FROM_DELTA : null;
+  if (fn) return fn(dx, dy);
+  if (angleZero() === 'right') { return Math.atan2(dy, dx); }
+  return Math.atan2(dx, -dy);
+}
+function withAX(x,y,ang,ax,ay,unitsLen){
+  const L=(unitsLen||1);
+  const u=(ax||0)*L, v=(ay||0)*L;
+  const b = basisFor(ang);
+  const dx = u*b.fx + v*b.rx;
+  const dy = u*b.fy + v*b.ry;
+  return [x+dx,y+dy];
+}
 function load(url){ if(!url) return null; if(CACHE[url]) return CACHE[url]; const img=new Image(); img.crossOrigin='anonymous'; img.src=url; CACHE[url]=img; return img; }
 
 function pickFighterName(C){ if(GLOB.selectedFighter && C.fighters?.[GLOB.selectedFighter]) return GLOB.selectedFighter; if (C.fighters?.TLETINGAN) return 'TLETINGAN'; const k=Object.keys(C.fighters||{}); return k.length?k[0]:'default'; }
@@ -137,8 +159,9 @@ function drawBoneSprite(ctx, img, bone, styleKey, style, offsets, facingFlip){
   const anchor = anchorMap[styleKey] || 'mid';
   const t = (anchor === 'start') ? 0.0 : 0.5;
   // base anchor on bone
-  let px = bone.x + bone.len * t * Math.sin(bone.ang);
-  let py = bone.y - bone.len * t * Math.cos(bone.ang);
+  const bAxis = basisFor(bone.ang);
+  let px = bone.x + bone.len * t * bAxis.fx;
+  let py = bone.y + bone.len * t * bAxis.fy;
 
   // 1) apply fighter offsets.origin (absolute units) in bone-space
   const off = originOffset(styleKey, offsets);
@@ -167,7 +190,9 @@ function drawBoneSprite(ctx, img, bone, styleKey, style, offsets, facingFlip){
   w *= sx; h *= sy;
 
   // rotation with +PI baseline (v19)
-  const theta = bone.ang + rad(xform.rotDeg || 0) + Math.PI;
+  const zeroMode = angleZero();
+  const angleComp = (zeroMode === 'right') ? -Math.PI/2 : 0;
+  const theta = bone.ang + rad(xform.rotDeg || 0) + Math.PI + angleComp;
 
   ctx.save();
   ctx.translate(posX, posY);


### PR DESCRIPTION
## Summary
- centralize the bone angle basis in `render.js`, expose helpers on `window`, and add a small compass plus toggle UI to inspect the current basis
- update `sprites.js` to consume the shared basis, fix anchor/offset math, and compensate sprite rotation based on the declared zero angle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906b683239c83268c880e9b9ac702cb