### PR TITLE
Fix sprite asset destructuring regression

### DIFF
--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -292,7 +292,7 @@ export function renderSprites(ctx){
   const fname = pickFighterName(C);
   const rig = getBones(C, GLOB, fname);
   if (!rig || RENDER.hideSprites) return;
-  const { imgs, style, offsets } = ensureFighterSprites(C, fname);
+  const { assets, style, offsets } = ensureFighterSprites(C, fname);
   const facingFlip = (GLOB.FIGHTERS?.player?.facingSign || 1) < 0;
 
   const zOf = buildZMap(C);


### PR DESCRIPTION
## Summary
- fix renderSprites to destructure the assets object returned by ensureFighterSprites
- ensure sprite rendering uses the resolved asset map again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906f6c222208326a740ecd4a503672f