### PR TITLE
Refactor combat system to use modular abilities

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -1,4 +1,19 @@
 // khyunchained CONFIG with sprite anchor mapping (torso/start) & optional debug
+
+const abilityKnockback = (base, { clamp } = {}) => {
+  return (context, opponent) => {
+    if (!opponent?.pos) return;
+    const facing = context?.character?.facingRad ?? context?.character?.facing ?? 0;
+    const dir = Math.cos(facing) >= 0 ? 1 : -1;
+    const multiplier = context?.multipliers?.knockback ?? 1;
+    let delta = base * multiplier * dir;
+    if (Number.isFinite(clamp)) {
+      delta = Math.max(-clamp, Math.min(clamp, delta));
+    }
+    opponent.pos.x += delta;
+  };
+};
+
 window.CONFIG = {
   actor: { scale: 0.70 },
   groundRatio: 0.70,
@@ -384,6 +399,73 @@ window.CONFIG = {
     sequence: ['HACK','HACK','HACK','TOSS'],
     timerDuration: 2800,
     type: 'sharp'
+  },
+
+  abilitySystem: {
+    thresholds: { tapMaxMs: 200, chargeStageMs: 200 },
+    defaults: { comboWindowMs: 3000 },
+    attacks: {
+      ComboJab: { preset: 'ComboKICK1', tags: ['combo', 'light'] },
+      ComboCross: { preset: 'ComboPUNCH1', tags: ['combo', 'light'] },
+      ComboHook: { preset: 'ComboKICK2', tags: ['combo', 'light'] },
+      ComboUpper: { preset: 'ComboPUNCH2', tags: ['combo', 'light'] },
+      QuickKick: { preset: 'KICK', tags: ['quick', 'light'] },
+      QuickKickCombo: {
+        preset: 'KICK',
+        tags: ['quick', 'light', 'comboVariant'],
+        multipliers: { durations: 0.85, knockback: 1.35 }
+      },
+      Slam: {
+        preset: 'SLAM',
+        tags: ['heavy'],
+        multipliers: { durations: 1.1, knockback: 1.2 }
+      }
+    },
+    abilities: {
+      combo_light: {
+        name: 'Four-Strike Combo',
+        type: 'light',
+        trigger: 'combo',
+        tags: ['combo', 'light'],
+        sequence: ['ComboJab', 'ComboCross', 'ComboHook', 'ComboUpper'],
+        comboWindowMs: 3000,
+        multipliers: { durations: 1 },
+        onHit: abilityKnockback(8)
+      },
+      quick_light: {
+        name: 'Quick Kick',
+        type: 'light',
+        trigger: 'single',
+        tags: ['quick', 'light'],
+        variants: [
+          { id: 'postCombo', attack: 'QuickKickCombo', require: { comboHitsGte: 4, comboActive: true } },
+          { id: 'default', attack: 'QuickKick' }
+        ],
+        multipliers: { durations: 1 },
+        onHit: abilityKnockback(10)
+      },
+      heavy_hold: {
+        name: 'Charged Slam',
+        type: 'heavy',
+        trigger: 'hold-release',
+        tags: ['heavy', 'hold'],
+        attack: 'Slam',
+        charge: {
+          minStage: 1,
+          maxStage: 5,
+          stageDurationMs: 200,
+          stageMultipliers: (stage) => ({
+            durations: 1 + stage * 0.05,
+            knockback: 1 + stage * 0.25
+          })
+        },
+        onHit: abilityKnockback(14)
+      }
+    },
+    slots: {
+      A: { label: 'Primary Attack', light: 'combo_light', heavy: 'heavy_hold' },
+      B: { label: 'Secondary Attack', light: 'quick_light', heavy: 'heavy_hold' }
+    }
   }
 };
 

--- a/docs/js/hitdetect.js
+++ b/docs/js/hitdetect.js
@@ -47,9 +47,17 @@ export function runHitDetect(){
     // Increment counts
     const hc = G.HIT_COUNTS?.npc;
     if (hc){ for (const k of collisions){ hc[k] = (hc[k]||0) + 1; } hc.body = (hc.body||0) + 1; }
-    // Simple knockback
-    const dir = Math.cos(P.facingRad) >= 0 ? 1 : -1;
-    N.pos.x += 8 * dir;
+    const context = P.attack?.context;
+    if (context && typeof context.onHit === 'function'){
+      try {
+        context.onHit(N, collisions);
+      } catch(err){
+        console.warn('[hitdetect] onHit handler error', err);
+      }
+    } else {
+      const dir = Math.cos(P.facingRad) >= 0 ? 1 : -1;
+      N.pos.x += 8 * dir;
+    }
   }
 
   // Optional: overdraw colliders with collision tint


### PR DESCRIPTION
## Summary
- add an ability-centric combat configuration including reusable attacks, ability definitions, and button slot mapping
- refactor combat logic to resolve abilities, build execution context with multipliers, and drive combo/quick/heavy attacks through the new data
- let hit detection defer knockback handling to the active ability context so abilities control on-hit behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e8baee8408326be6c8a504ffa504e)