### PR TITLE
Fix config braces and expose presets to ability system

### DIFF
--- a/docs/js/hitdetect.js
+++ b/docs/js/hitdetect.js
@@ -47,9 +47,17 @@ export function runHitDetect(){
     // Increment counts
     const hc = G.HIT_COUNTS?.npc;
     if (hc){ for (const k of collisions){ hc[k] = (hc[k]||0) + 1; } hc.body = (hc.body||0) + 1; }
-    // Simple knockback
-    const dir = Math.cos(P.facingRad) >= 0 ? 1 : -1;
-    N.pos.x += 8 * dir;
+    const context = P.attack?.context;
+    if (context && typeof context.onHit === 'function'){
+      try {
+        context.onHit(N, collisions);
+      } catch(err){
+        console.warn('[hitdetect] onHit handler error', err);
+      }
+    } else {
+      const dir = Math.cos(P.facingRad) >= 0 ? 1 : -1;
+      N.pos.x += 8 * dir;
+    }
   }
 
   // Optional: overdraw colliders with collision tint


### PR DESCRIPTION
## Summary
- close the Mao-ao_M fighter spriteStyle block so config.js parses correctly
- copy the merged preset definitions onto CONFIG.attacks.presets for consumers that look there

## Testing
- npm test *(fails: existing conversion, pose, and shim assertions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e8baee8408326be6c8a504ffa504e)