### PR TITLE
Correct aim offset orientation when facing right

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -206,6 +206,7 @@ function updateAiming(F, currentPose, fighterId){
   
   let targetAngle;
   let aimSource = 'fallback';
+  let mouseDX = 0;
   
   // Use joystick for aiming if active (mobile), otherwise use mouse (desktop)
   if (G.AIMING?.manualAim && G.JOYSTICK?.active) {
@@ -218,6 +219,7 @@ function updateAiming(F, currentPose, fighterId){
     const dy = G.MOUSE.worldY - (F.pos?.y || 0);
     targetAngle = Math.atan2(dy, dx);
     aimSource = 'mouse';
+    mouseDX = dx;
     
     // Debug log once per second for player
     if (fighterId === 'player' && !F._lastAimLog || (performance.now() - F._lastAimLog) > 1000) {
@@ -230,21 +232,62 @@ function updateAiming(F, currentPose, fighterId){
     targetAngle = F.facingRad || 0;
   }
   
-  // Convert target angle relative to current facing
+  const normAngle = (ang) => {
+    const TAU = Math.PI * 2;
+    let out = ang % TAU;
+    if (out < 0) out += TAU;
+    return out;
+  };
+
+  const applyFacing = (rad) => {
+    const normalized = normAngle(rad);
+    F.facingRad = normalized;
+    const cos = Math.cos(normalized);
+    if (Number.isFinite(cos) && Math.abs(cos) > 1e-6) {
+      F.facingSign = cos >= 0 ? 1 : -1;
+    }
+  };
+
+  const isDashing = !!(F?.stamina?.isDashing || G.STAMINA?.isDashing || G.FIGHTERS?.[fighterId]?.stamina?.isDashing);
+  const initialFacing = (typeof F.facingRad === 'number') ? F.facingRad : ((F.facingSign||1) < 0 ? Math.PI : 0);
+
+  if (!isDashing) {
+    if (aimSource === 'joystick') {
+      const joystickSide = Math.cos(targetAngle) >= 0 ? 0 : Math.PI;
+      const currentSide = Math.cos(initialFacing) >= 0 ? 0 : Math.PI;
+      if (joystickSide !== currentSide) {
+        applyFacing(joystickSide);
+      }
+    } else if (aimSource === 'mouse') {
+      const mouseSide = mouseDX >= 0 ? 0 : Math.PI;
+      const currentSide = Math.cos(initialFacing) >= 0 ? 0 : Math.PI;
+      if (G.MOUSE?.isDown && mouseSide !== currentSide) {
+        applyFacing(mouseSide);
+      }
+    }
+  }
+
   const facingRad = (typeof F.facingRad === 'number') ? F.facingRad : ((F.facingSign||1) < 0 ? Math.PI : 0);
   let relativeAngle = targetAngle - facingRad;
   // Normalize to -PI to PI range
   while (relativeAngle > Math.PI) relativeAngle -= Math.PI * 2;
   while (relativeAngle < -Math.PI) relativeAngle += Math.PI * 2;
-  
+
   // Smooth the aim angle (simple exponential smoothing)
   const dt = F.anim?.dt || 0.016;
   const smoothing = 1 - Math.exp(-(C.aiming.smoothing || 8) * dt);
   const currentAngle = F.aim.currentAngle || 0;
   F.aim.currentAngle = currentAngle + (relativeAngle - currentAngle) * smoothing;
-  
+
   // Calculate offsets based on aim angle
-  const aimDeg = rad2deg(F.aim.currentAngle);
+  const facingCos = Math.cos(facingRad);
+  let aimDeg = rad2deg(F.aim.currentAngle);
+  if (Number.isFinite(facingCos)) {
+    const orientationSign = Math.abs(facingCos) > 1e-4
+      ? (facingCos >= 0 ? -1 : 1)
+      : ((F.facingSign || 1) >= 0 ? -1 : 1);
+    aimDeg *= orientationSign;
+  }
   F.aim.torsoOffset = clamp(aimDeg * 0.5, -(C.aiming.maxTorsoAngle || 45), (C.aiming.maxTorsoAngle || 45));
   F.aim.shoulderOffset = clamp(aimDeg * 0.7, -(C.aiming.maxShoulderAngle || 60), (C.aiming.maxShoulderAngle || 60));
   


### PR DESCRIPTION
## Summary
- add joystick and mouse facing flip checks to the aiming updater
- normalize and apply facing orientation updates so kicks follow the target
- invert aim offset application when facing right so vertical aim matches input direction

## Testing
- npm test *(fails: known baseline issues in tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f08070c9c8326a220f6d090a2be50)