### PR TITLE
Fix aiming inversion by correcting orientation sign

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -284,8 +284,8 @@ function updateAiming(F, currentPose, fighterId){
   let aimDeg = rad2deg(F.aim.currentAngle);
   if (Number.isFinite(facingCos)) {
     const orientationSign = Math.abs(facingCos) > 1e-4
-      ? (facingCos >= 0 ? -1 : 1)
-      : ((F.facingSign || 1) >= 0 ? -1 : 1);
+      ? (facingCos >= 0 ? 1 : -1)
+      : ((F.facingSign || 1) >= 0 ? 1 : -1);
     aimDeg *= orientationSign;
   }
   F.aim.torsoOffset = clamp(aimDeg * 0.5, -(C.aiming.maxTorsoAngle || 45), (C.aiming.maxTorsoAngle || 45));


### PR DESCRIPTION
## Summary
- correct the aiming orientation sign so vertical aiming is no longer inverted when facing either direction

## Testing
- `npm test` *(fails: existing suite failures unrelated to this change, e.g. baseline conversion and pose fixtures)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f19a560c483269f2075abada38867)