### PR TITLE
Fix mobile controls and fullscreen behavior

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -40,10 +40,10 @@ const KICK_MOVE_POSES = {
     lElbow: -120,
     rShoulder: -80,
     rElbow: -100,
-    lHip: 110,
-    lKnee: 30,
-    rHip: 170,
-    rKnee: 40,
+    lHip:130,
+    lKnee:90,
+    rHip:100,
+    rKnee:90,
     rootMoveVel: { x: 0, y: 0 },
     impulseMag: 0,
     impulseDirDeg: 0,
@@ -60,10 +60,10 @@ const KICK_MOVE_POSES = {
     lElbow: 0,
     rShoulder: 90,
     rElbow: 0,
-    lHip: 87,
-    lKnee: 0,
-    rHip: 0,
-    rKnee: 0,
+    lHip:180,
+    lKnee:0,
+    rHip:110,
+    rKnee:20,
     rootMoveVel: { x: 0, y: 0 },
     impulseMag: 120,
     impulseDirDeg: 0,
@@ -86,10 +86,10 @@ const KICK_MOVE_POSES = {
     lElbow: -120,
     rShoulder: -90,
     rElbow: -120,
-    lHip: 110,
-    lKnee: 40,
-    rHip: 30,
-    rKnee: 50,
+    lHip:110,
+    lKnee:60,
+    rHip:100,
+    rKnee:60,
     rootMoveVel: { x: 0, y: 0 },
     impulseMag: 0,
     impulseDirDeg: 0,
@@ -217,6 +217,10 @@ window.CONFIG = {
   groundRatio: 0.70,
   canvas: { w: 720, h: 460, scale: 1 },
   groundY: 380,
+  // Debug options are surfaced in the debug panel; freezeAngles lets animators hold joints for edits
+  debug: {
+    freezeAngles: false
+  },
   basePose: {
     torso: 0,
     lShoulder: -90,
@@ -248,7 +252,8 @@ window.CONFIG = {
         aimLegs: false
     },
     Windup: {
-        torso: -35, lShoulder: -360, lElbow: 0, rShoulder: -360, rElbow: 0, lHip: 40, lKnee: 90, rHip: -90, rKnee: 90,
+        torso: -35, lShoulder: -360, lElbow: 0, rShoulder: -360, rElbow: 0,
+        lHip: 130, lKnee: 90, rHip: 100, rKnee: 90,
       rootMoveVel: { x: 0, y: 0 }, impulseMag: 0, impulseDirDeg: 0,
       allowAiming: true, aimLegs: false,
       anim_events: [
@@ -257,7 +262,8 @@ window.CONFIG = {
       ]
     },
     Strike: {
-        torso: 45, lShoulder: -45, lElbow: 0, rShoulder: -45, rElbow: 0, lHip: 180, lKnee: 0, rHip: 90, rKnee: 0,
+        torso: 45, lShoulder: -45, lElbow: 0, rShoulder: -45, rElbow: 0,
+        lHip: 180, lKnee: 0, rHip: 110, rKnee: 20,
       rootMoveVel: { x: 0, y: 0, flip: false }, impulseMag: 0, impulseDirDeg: 0,
       allowAiming: true, aimLegs: false,
       anim_events: [
@@ -266,7 +272,8 @@ window.CONFIG = {
       ]
     },
     Recoil: { durMs: 200, phase: 'recoil',
-        torso: -15, lShoulder: -45, lElbow: 0, rShoulder: -45, rElbow: 0, lHip: 0, lKnee: 70, rHip: 110, rKnee: 0,
+        torso: -15, lShoulder: -45, lElbow: 0, rShoulder: -45, rElbow: 0,
+        lHip: 110, lKnee: 70, rHip: 100, rKnee: 40,
       rootMoveVel: { x: 0, y: 0 }, impulseMag: 0, impulseDirDeg: 0,
       allowAiming: false, aimLegs: false,
       anim_events: [

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,23 +45,6 @@
         <!-- Door Interaction Prompt -->
         <div class="interact-prompt" id="interactPrompt">Press E to Enter</div>
 
-        <!-- Touch Controls (mobile) -->
-        <div class="controls-overlay">
-          <!-- Virtual Joystick -->
-          <div class="joystick-area" id="joystickArea">
-            <div class="joystick-base"></div>
-            <div class="joystick-stick" id="joystickStick"></div>
-          </div>
-
-          <!-- Action Buttons -->
-          <div class="action-buttons">
-            <button class="action-btn" id="btnJump">↑</button>
-            <button class="action-btn" id="btnAttackB">B</button>
-            <button class="action-btn" id="btnAttackA">A</button>
-            <button class="action-btn" id="btnInteract">E</button>
-          </div>
-        </div>
-
         <!-- Transition Overlay + area name -->
         <div class="transition-overlay" id="transitionOverlay"></div>
         <div class="area-name" id="areaName"></div>

--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -1,5 +1,5 @@
 // animator.js — restore basic idle/walk posing; robust speed detection; override TTL required
-import { degToRad } from './math-utils.js?v=1';
+import { degToRad, radToDegNum } from './math-utils.js?v=1';
 import { setMirrorForPart, resetMirror } from './sprites.js?v=1';
 
 const ANG_KEYS = ['torso','lShoulder','lElbow','rShoulder','rElbow','lHip','lKnee','rHip','rKnee'];
@@ -177,9 +177,6 @@ function processAnimEventsForOverride(F, over){
 // Helper to clamp values
 function clamp(val, min, max){ return Math.min(max, Math.max(min, val)); }
 
-// Helper to convert radians to degrees
-function rad2deg(r){ return r * 180 / Math.PI; }
-
 // Update aiming offsets based on current pose
 function updateAiming(F, currentPose, fighterId){
   const C = window.CONFIG || {};
@@ -222,9 +219,9 @@ function updateAiming(F, currentPose, fighterId){
     mouseDX = dx;
     
     // Debug log once per second for player
-    if (fighterId === 'player' && !F._lastAimLog || (performance.now() - F._lastAimLog) > 1000) {
-      console.log('[aim] source:', aimSource, 'mouseWorld:', {x: G.MOUSE.worldX, y: G.MOUSE.worldY}, 
-                  'fighterPos:', {x: F.pos?.x, y: F.pos?.y}, 'targetAngle:', (targetAngle * 180 / Math.PI).toFixed(1));
+    if (fighterId === 'player' && (!F._lastAimLog || (performance.now() - F._lastAimLog) > 1000)) {
+      console.log('[aim] source:', aimSource, 'mouseWorld:', {x: G.MOUSE.worldX, y: G.MOUSE.worldY},
+                  'fighterPos:', {x: F.pos?.x, y: F.pos?.y}, 'targetAngle:', radToDegNum(targetAngle).toFixed(1));
       F._lastAimLog = performance.now();
     }
   } else {
@@ -281,7 +278,7 @@ function updateAiming(F, currentPose, fighterId){
 
   // Calculate offsets based on aim angle
   const facingCos = Math.cos(facingRad);
-  let aimDeg = rad2deg(F.aim.currentAngle);
+  let aimDeg = radToDegNum(F.aim.currentAngle);
   if (Number.isFinite(facingCos)) {
     const orientationSign = Math.abs(facingCos) > 1e-4
       ? (facingCos >= 0 ? 1 : -1)

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -60,6 +60,32 @@ const cv = $$('#game');
 const cx = cv?.getContext('2d');
 window.GAME ||= {};
 
+// Detect touch devices early so we can surface on-screen controls reliably
+const rootElement = document.documentElement;
+function detectTouchSupport(){
+  const nav = navigator || {};
+  const coarsePointer = typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches;
+  const hasTouch = ('ontouchstart' in window) || (nav.maxTouchPoints > 0) || (nav.msMaxTouchPoints > 0) || coarsePointer;
+  rootElement.classList.toggle('is-touch', !!hasTouch);
+}
+detectTouchSupport();
+if (typeof window.matchMedia === 'function'){
+  const coarseQuery = window.matchMedia('(pointer: coarse)');
+  const applyFromQuery = (ev) => {
+    if (ev.matches) {
+      rootElement.classList.add('is-touch');
+    } else if (!('ontouchstart' in window) && (navigator.maxTouchPoints || 0) === 0) {
+      rootElement.classList.remove('is-touch');
+    }
+  };
+  if (typeof coarseQuery.addEventListener === 'function') {
+    coarseQuery.addEventListener('change', applyFromQuery);
+  } else if (typeof coarseQuery.addListener === 'function') {
+    coarseQuery.addListener(applyFromQuery);
+  }
+}
+window.addEventListener('touchstart', () => rootElement.classList.add('is-touch'), { once: true, passive: true });
+
 // Mouse tracking state
 window.GAME.MOUSE = {
   isDown: false,
@@ -104,6 +130,8 @@ const footingFill = $$('#footingFill');
 const healthFill = $$('#healthFill');
 const statusInfo = $$('#statusInfo');
 const reloadBtn = $$('#btnReloadCfg');
+const fullscreenBtn = $$('#btnFullscreen');
+const stageEl = document.getElementById('gameStage');
 const fpsHud = $$('#fpsHud');
 const boneKeyList = $$('#boneKeyList');
 
@@ -121,6 +149,40 @@ if (reloadBtn){
       console.error(e);
     }
   });
+}
+
+if (fullscreenBtn && stageEl){
+  const doc = document;
+  const requestFs = stageEl.requestFullscreen || stageEl.webkitRequestFullscreen || stageEl.msRequestFullscreen;
+  const exitFs = doc.exitFullscreen || doc.webkitExitFullscreen || doc.msExitFullscreen;
+
+  const updateFullscreenUi = () => {
+    const isFull = doc.fullscreenElement === stageEl || doc.webkitFullscreenElement === stageEl;
+    fullscreenBtn.textContent = isFull ? '⤡ Exit' : '⤢ Full';
+    fullscreenBtn.setAttribute('aria-pressed', isFull ? 'true' : 'false');
+  };
+
+  fullscreenBtn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    if (!requestFs || !exitFs){
+      console.warn('[fullscreen] Browser does not support fullscreen API');
+      return;
+    }
+    try {
+      const isFull = doc.fullscreenElement === stageEl || doc.webkitFullscreenElement === stageEl;
+      if (!isFull){
+        await requestFs.call(stageEl);
+      } else {
+        await exitFs.call(doc);
+      }
+    } catch (err){
+      console.error('[fullscreen] toggle failed', err);
+    }
+  });
+
+  doc.addEventListener('fullscreenchange', updateFullscreenUi);
+  doc.addEventListener('webkitfullscreenchange', updateFullscreenUi);
+  updateFullscreenUi();
 }
 
 if (boneKeyList) {

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -226,12 +226,13 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
 
   // Get anchor config: anchors at bone midpoint by default
   const anchorCfg = style.anchor || {};
-  const anchorMode = anchorCfg[normalizedKey] || anchorCfg[styleKey] || 'mid';
+  const anchorMode = anchorCfg[styleKey] || 'mid';
+  const resolvedAnchorMode = (anchorCfg[normalizedKey] != null) ? anchorCfg[normalizedKey] : anchorMode;
 
   // Basis vectors for local orientation
   const bAxis = basisFor(bone.ang);
   let posX, posY;
-  if (anchorMode === 'start') {
+  if (resolvedAnchorMode === 'start') {
     posX = bone.x;
     posY = bone.y;
   } else {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -22,6 +22,12 @@
 .area-name{position:absolute;top:60px;left:12px;font-weight:600;color:#93c5fd}
 
 .controls-overlay{position:absolute;inset:0;pointer-events:none}
+.controls-overlay .top-ui,
+.controls-overlay .help-panel,
+.controls-overlay .joystick-area,
+.controls-overlay .action-buttons,
+.controls-overlay button,
+.controls-overlay .interact-btn{pointer-events:auto}
 .top-ui{position:absolute;top:8px;right:8px;display:flex;gap:6px;pointer-events:auto}
 .ui-btn{padding:6px 8px;border-radius:10px;border:1px solid #374151;background:#0b1220;color:#e5e7eb}
 .help-panel{position:absolute;top:40px;right:8px;min-width:220px;background:#0b1220;border:1px solid #1f2937;border-radius:12px;padding:10px;display:none}
@@ -108,11 +114,16 @@
 
 /* Show touch controls on touch devices or when screen is small */
 @media (hover:none),(max-width:768px){
-  .joystick-area,
+  .joystick-area{
+    display:block;
+  }
   .action-buttons{
     display:grid;
   }
 }
+
+.is-touch .joystick-area{display:block}
+.is-touch .action-buttons{display:grid}
 
 @media (hover:none){ .help-panel{font-size:14px} }
 


### PR DESCRIPTION
## Summary
- correct the aiming log guard and switch animator logging/conversions to the shared radToDeg helpers
- add explicit hip angle corrections and debug.freezeAngles defaults to config while cleaning duplicate mobile control markup and enabling touch overlays through CSS and runtime detection
- implement a working fullscreen toggle tied to the stage plus restore anchor defaults in sprites.js so tests enforce the midpoint behavior

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc39bbee883268a0aa9d828ad8af0)