### PR TITLE
Improve combat logging for abilities and stages

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -218,12 +218,6 @@ function updateAiming(F, currentPose, fighterId){
     aimSource = 'mouse';
     mouseDX = dx;
     
-    // Debug log once per second for player
-    if (fighterId === 'player' && (!F._lastAimLog || (performance.now() - F._lastAimLog) > 1000)) {
-      console.log('[aim] source:', aimSource, 'mouseWorld:', {x: G.MOUSE.worldX, y: G.MOUSE.worldY},
-                  'fighterPos:', {x: F.pos?.x, y: F.pos?.y}, 'targetAngle:', radToDegNum(targetAngle).toFixed(1));
-      F._lastAimLog = performance.now();
-    }
   } else {
     // Fallback to facingRad
     targetAngle = F.facingRad || 0;


### PR DESCRIPTION
## Summary
- remove the noisy aim debug logging so the console stays readable
- add structured combat debug messages that name the ability, attack, move, and current stage
- centralize helpers to format combat identifiers for the new logging output

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69103627d6188326ab6026e587378540)