### PR TITLE
Restore fighter physics system and alt jump input

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -3,6 +3,7 @@ import { degToRad, radToDegNum } from './math-utils.js?v=1';
 import { setMirrorForPart, resetMirror } from './sprites.js?v=1';
 import { pickFighterConfig, pickFighterName } from './fighter-utils.js?v=1';
 import { getFaceLock } from './face-lock.js?v=1';
+import { getPhysicsOffsets, getPhysicsJointAngles } from './physics.js?v=1';
 
 const ANG_KEYS = ['torso','head','lShoulder','lElbow','rShoulder','rElbow','lHip','lKnee','rHip','rKnee'];
 // Convert pose object from degrees to radians using centralized utility
@@ -373,6 +374,16 @@ export function updatePoses(){
   const fighterName = pickFighterName(C);
   const fcfg = pickFighterConfig(C, fighterName);
   for (const id of ['player','npc']){ const F = G.FIGHTERS[id]; if(!F) continue; ensureAnimState(F); F.anim.dt = Math.max(0, now - F.anim.last); F.anim.last = now;
+    if (F.ragdoll){
+      const ragAngles = getPhysicsJointAngles(F) || {};
+      for (const key of ANG_KEYS){
+        if (typeof ragAngles[key] === 'number'){
+          F.jointAngles[key] = ragAngles[key];
+        }
+      }
+      continue;
+    }
+
     let targetDeg = null; const over = getOverride(F);
     if (over){
       // process events / flips for active override (k-based)
@@ -395,6 +406,18 @@ export function updatePoses(){
     
     // Apply aiming offsets to pose
     finalDeg = applyAimingOffsets(finalDeg, F, targetDeg);
+
+    // Blend in physics-driven offsets (lean, crouch) before converting to radians
+    const physOffsets = getPhysicsOffsets(F);
+    const physWeight = C.movement?.physicsWeight ?? 0;
+    if (physOffsets && physWeight > 0){
+      for (const key of ANG_KEYS){
+        const delta = physOffsets[key];
+        if (typeof delta === 'number' && delta !== 0){
+          finalDeg[key] = (finalDeg[key] || 0) + delta * physWeight;
+        }
+      }
+    }
 
     const headDeg = computeHeadTargetDeg(F, finalDeg, fcfg);
     if (typeof headDeg === 'number') {

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -263,6 +263,7 @@ import { initPresets, ensureAltSequenceUsesKickAlt } from './presets.js?v=6';
 import { initFighters } from './fighter.js?v=6';
 import { initControls } from './controls.js?v=7';
 import { initCombat } from './combat.js?v=19';
+import { initPhysics, updatePhysics } from './physics.js?v=1';
 import { updatePoses } from './animator.js?v=4';
 import { renderAll, LIMB_COLORS } from './render.js?v=4';
 import { updateCamera } from './camera.js?v=1';
@@ -1114,6 +1115,7 @@ let frames = 0;
 function loop(t){
   const dt = (t - last) / 1000; last = t;
   if (window.GAME?.combat) window.GAME.combat.tick(dt);
+  updatePhysics(dt);
   updatePoses();
   updateCamera(cv);
   drawStage();
@@ -1213,6 +1215,7 @@ function boot(){
     initFighters(cv, cx);
     initControls();
     initCombat();
+    initPhysics();
     initHitDetect();
     initDebugPanel();
     initTouchControls();

--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -1045,48 +1045,11 @@ function makeCombat(G, C){
     }
   }
 
-  // Movement
-  function updateMovement(dt){
-    const p = P();
-    if (!p) return;
-    
-    const M = C.movement || {};
-    const I = G.input || {};
-    
-    p.vel ||= {x:0, y:0};
-    p.pos ||= {x:0, y:0};
-    
-    const ax = M.accelX || 1200;
-    const max = M.maxSpeedX || 420;
-    const fr = M.friction || 8;
-    
-    // Don't move during attacks
-    if (ATTACK.active){
-      p.vel.x *= Math.max(0, 1 - fr*dt);
-    } else {
-      if (I.left && !I.right){
-        p.vel.x -= ax*dt;
-        p.facingRad = Math.PI;
-        p.facingSign = -1;
-      } else if (I.right && !I.left){
-        p.vel.x += ax*dt;
-        p.facingRad = 0;
-        p.facingSign = 1;
-      } else {
-        p.vel.x *= Math.max(0, 1 - fr*dt);
-      }
-    }
-    
-    p.vel.x = Math.max(-max, Math.min(max, p.vel.x));
-    p.pos.x += p.vel.x * dt;
-  }
-
   function tick(dt){
     handleButtons();
     updateCharge(dt);
     updateTransitions(dt);
     updateCombo(dt);
-    updateMovement(dt);
     processQueue();
   }
 

--- a/docs/js/controls.js
+++ b/docs/js/controls.js
@@ -33,7 +33,10 @@ export function initControls(){
     switch(e.code){
       case 'KeyA': case 'ArrowLeft': I.left = down; break;
       case 'KeyD': case 'ArrowRight': I.right = down; break;
-      case 'KeyW': case 'ArrowUp': case 'Space': I.jump = down; if(down) e.preventDefault(); break;
+      case 'KeyW': case 'ArrowUp': case 'Space': case 'AltLeft': case 'AltRight':
+        I.jump = down;
+        if (down) e.preventDefault();
+        break;
       case 'ShiftLeft': case 'ShiftRight': I.dash = down; break;
       case 'KeyE': case 'KeyJ': setButton('buttonA', down); break;
       case 'KeyF': case 'KeyK': setButton('buttonB', down); break;

--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -13,16 +13,36 @@ export function initFighters(cv, cx){
   if (stanceRad.head == null) stanceRad.head = stanceRad.torso ?? 0;
 
   function makeF(id, x, faceSign){
-    return {
-      id, isPlayer: id==='player',
-      pos:{ x, y: gy-1 }, vel:{ x:0, y:0 },
-      onGround:true, prevOnGround:true, facingRad: 0, facingSign: faceSign,
-      footing: 50, ragdoll:false, stamina:{ current:100, max:100, drainRate:40, regenRate:25, minToDash:10 },
+    const fighter = {
+      id,
+      isPlayer: id==='player',
+      pos:{ x, y: gy-1 },
+      vel:{ x:0, y:0 },
+      onGround:true,
+      prevOnGround:true,
+      landedImpulse:0,
+      facingRad: 0,
+      facingSign: faceSign,
+      footing: 50,
+      ragdoll:false,
+      ragdollTime:0,
+      ragdollVel:{ x:0, y:0 },
+      recovering:false,
+      recoveryTime:0,
+      recoveryDuration:0.8,
+      recoveryStartAngles:{},
+      recoveryStartY: gy-1,
+      recoveryTargetY: gy-1,
+      stamina:{ current:100, max:100, drainRate:40, regenRate:25, minToDash:10, isDashing:false },
       jointAngles: { ...stanceRad },
       walk:{ phase:0, amp:0 },
       attack:{ active:false, preset:null, slot:null },
-      combo:{ active:false, sequenceIndex:0, attackDelay:0 }
+      combo:{ active:false, sequenceIndex:0, attackDelay:0 },
+      input:{ left:false, right:false, jump:false, dash:false },
+      physics:{ offsets:{} }
     };
+    fighter.move = fighter; // touch-controls legacy alias
+    return fighter;
   }
 
   G.FIGHTERS = {

--- a/docs/js/physics.js
+++ b/docs/js/physics.js
@@ -1,0 +1,369 @@
+// physics.js — Universal fighter physics (ported from Ancient Code-Monolith V2)
+// Handles gravity, horizontal acceleration, jump impulses, ragdoll transitions,
+// and produces pose offsets that blend with authored animation.
+
+import { degToRad } from './math-utils.js?v=1';
+
+const TAU = Math.PI * 2;
+
+const JOINT_PHYSICS = {
+  damping: 0.92,
+  normalStiffness: 0.25,
+  ragdollStiffness: 0.05,
+  maxAngularVel: 0.3,
+  joints: {
+    torso: { mass: 2.0, limits: [-0.8, 0.8] },
+    lShoulder: { mass: 0.5, limits: [-1.5, 1.5] },
+    rShoulder: { mass: 0.5, limits: [-1.5, 1.5] },
+    lElbow: { mass: 0.4, limits: [-2.5, 0.2] },
+    rElbow: { mass: 0.4, limits: [-0.2, 2.5] },
+    lHip: { mass: 0.8, limits: [-1.2, 0.8] },
+    rHip: { mass: 0.8, limits: [-1.2, 0.8] },
+    lKnee: { mass: 0.6, limits: [-0.2, 2.0] },
+    rKnee: { mass: 0.6, limits: [-0.2, 2.0] }
+  }
+};
+
+function clamp(v, lo, hi){
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function lerp(a, b, t){
+  return a + (b - a) * t;
+}
+
+function normAngle(rad){
+  let a = rad % TAU;
+  if (a > Math.PI) a -= TAU;
+  if (a < -Math.PI) a += TAU;
+  return a;
+}
+
+function lerpAngle(a, b, t){
+  return a + normAngle(b - a) * t;
+}
+
+function ensureCamera(C){
+  const G = (window.GAME ||= {});
+  const defaultWorld = 1600;
+  if (!G.CAMERA){
+    G.CAMERA = {
+      x: 0,
+      worldWidth: C.world?.width || defaultWorld,
+      smoothing: 0.15
+    };
+    return;
+  }
+  if (!Number.isFinite(G.CAMERA.worldWidth)){
+    G.CAMERA.worldWidth = C.world?.width || defaultWorld;
+  }
+  if (!Number.isFinite(G.CAMERA.smoothing)){
+    G.CAMERA.smoothing = 0.15;
+  }
+}
+
+function ensureFighterState(fighter, C){
+  if (!fighter) return;
+  fighter.vel ||= { x: 0, y: 0 };
+  fighter.pos ||= { x: 0, y: 0 };
+  fighter.ragdollVel ||= { x: fighter.vel.x, y: fighter.vel.y };
+  fighter.recoveryStartAngles ||= {};
+  fighter.physics ||= { offsets: {} };
+  fighter.physics.offsets ||= {};
+  fighter.physics.jointAngles ||= {};
+  fighter.recoveryDuration = fighter.recoveryDuration || 0.8;
+  fighter.recoveryTargetY = fighter.recoveryTargetY ?? fighter.pos.y;
+  fighter.recoveryStartY = fighter.recoveryStartY ?? fighter.pos.y;
+  fighter.stamina ||= { current: 100, max: 100, drainRate: 40, regenRate: 25, minToDash: 10, isDashing: false };
+  fighter.jointAngles ||= {};
+  const joints = Object.keys(JOINT_PHYSICS.joints);
+  for (const key of joints){
+    if (!(key in fighter.jointAngles)) fighter.jointAngles[key] = 0;
+    const velKey = `${key}Vel`;
+    if (!(velKey in fighter.jointAngles)) fighter.jointAngles[velKey] = 0;
+  }
+  if (fighter.isPlayer){
+    const G = window.GAME || {};
+    const sharedInput = (G.input ||= {
+      left:false, right:false, jump:false, dash:false,
+      buttonA:{ down:false, downTime:0, upTime:0 },
+      buttonB:{ down:false, downTime:0, upTime:0 }
+    });
+    fighter.input = sharedInput;
+  } else {
+    fighter.input ||= { left:false, right:false, jump:false, dash:false };
+  }
+  if (!fighter.physics.lastGroundY){
+    const canvasH = C.canvas?.h || 460;
+    const groundRatio = C.groundRatio ?? 0.7;
+    fighter.physics.lastGroundY = Math.round(canvasH * groundRatio);
+  }
+}
+
+function initJointPhysicsState(fighter){
+  const joints = Object.keys(JOINT_PHYSICS.joints);
+  for (const key of joints){
+    const velKey = `${key}Vel`;
+    if (!(velKey in fighter.jointAngles)) fighter.jointAngles[velKey] = 0;
+    if (!(key in fighter.physics.jointAngles)) fighter.physics.jointAngles[key] = fighter.jointAngles[key] || 0;
+  }
+}
+
+function updateJointPhysics(fighter, dt){
+  initJointPhysicsState(fighter);
+  const stiffness = fighter.ragdoll ? JOINT_PHYSICS.ragdollStiffness : JOINT_PHYSICS.normalStiffness;
+  for (const [key, joint] of Object.entries(JOINT_PHYSICS.joints)){
+    const velKey = `${key}Vel`;
+    const angle = fighter.physics.jointAngles[key] ?? fighter.jointAngles[key] ?? 0;
+    let angularVel = fighter.jointAngles[velKey] || 0;
+
+    let targetAngle = 0;
+    if (fighter.ragdoll){
+      if (!(key in fighter.physics.jointTargets)){
+        fighter.physics.jointTargets ||= {};
+        fighter.physics.jointTargets[key] = (Math.random() - 0.5) * 0.5;
+      }
+      targetAngle = fighter.physics.jointTargets[key];
+      if (fighter.ragdollTime < 0.5){
+        angularVel += (Math.random() - 0.5) * 0.3 * dt;
+      }
+    } else if (fighter.recovering){
+      const stancePose = (window.CONFIG?.poses?.Stance) || {};
+      const t = Math.min(1, fighter.recoveryTime / fighter.recoveryDuration);
+      const eased = 1 - Math.pow(1 - t, 3);
+      const start = fighter.recoveryStartAngles[key] || 0;
+      targetAngle = lerp(start, degToRad(stancePose[key] || 0), eased);
+    }
+
+    const angleError = targetAngle - angle;
+    angularVel += angleError * stiffness;
+    angularVel *= JOINT_PHYSICS.damping;
+    angularVel = clamp(angularVel, -JOINT_PHYSICS.maxAngularVel, JOINT_PHYSICS.maxAngularVel);
+
+    let newAngle = angle + angularVel;
+    const [min, max] = joint.limits;
+    newAngle = clamp(newAngle, min, max);
+
+    fighter.physics.jointAngles[key] = newAngle;
+    fighter.jointAngles[velKey] = angularVel;
+  }
+
+  if (fighter.ragdoll){
+    const torsoTilt = fighter.physics.jointAngles.torso || 0;
+    fighter.vel.x += Math.sin(torsoTilt) * 0.15 * dt;
+  }
+}
+
+function enterRagdollState(fighter){
+  if (fighter.ragdoll) return;
+  console.log(`⚠️ ${fighter.id?.toUpperCase() || 'FIGHTER'} RAGDOLL ACTIVATED - Footing: ${fighter.footing?.toFixed?.(1) ?? fighter.footing}`);
+  fighter.ragdoll = true;
+  fighter.ragdollTime = 0;
+  fighter.physics.jointTargets = {};
+  fighter.recovering = false;
+}
+
+function computePhysicsOffsets(fighter){
+  const offsets = {};
+  const vx = fighter.vel?.x || 0;
+  offsets.torso = clamp(vx * 0.04, -25, 25);
+  const crouch = clamp((fighter.landedImpulse || 0) * 0.04, 0, 60);
+  offsets.lKnee = crouch;
+  offsets.rKnee = crouch;
+  offsets.lHip = -crouch * 0.25;
+  offsets.rHip = -crouch * 0.25;
+
+  if (!fighter.onGround && fighter.input?.jump){
+    offsets.torso = (offsets.torso || 0) - 10;
+    offsets.lHip = (offsets.lHip || 0) + 30;
+    offsets.rHip = (offsets.rHip || 0) + 30;
+    offsets.lKnee = (offsets.lKnee || 0) + 30;
+    offsets.rKnee = (offsets.rKnee || 0) + 30;
+  }
+  return offsets;
+}
+
+function updatePlayerFacing(fighter, dt, C){
+  if (!fighter || !fighter.isPlayer) return;
+  const G = window.GAME || {};
+  const face = G.FACE || { active:false, rad:0 };
+  const movement = C.movement || {};
+  let target = fighter.facingRad || 0;
+  if (movement.lockFacingDuringAttack && face.active){
+    target = face.rad ?? target;
+  } else {
+    const input = fighter.input || {};
+    const isDashing = !!fighter.stamina?.isDashing;
+    if (input.left !== input.right && !isDashing){
+      target = input.right ? 0 : Math.PI;
+    }
+  }
+  const smoothing = Number.isFinite(movement.facingSmooth) ? movement.facingSmooth : 10;
+  const s = 1 - Math.exp(-smoothing * dt);
+  const prev = fighter.facingRad || (fighter.facingSign < 0 ? Math.PI : 0);
+  fighter.facingRad = lerpAngle(prev, target, s);
+  fighter.facingSign = Math.cos(fighter.facingRad) >= 0 ? 1 : -1;
+}
+
+function updateFighterPhysics(fighter, dt, C, worldWidth){
+  if (!fighter) return;
+  ensureFighterState(fighter, C);
+
+  const movement = C.movement || {};
+  const parts = C.parts || {};
+  const actorScale = C.actor?.scale ?? 1;
+  const hb = parts.hitbox || { h: 160 };
+  const hbHeight = (hb.h || 160) * actorScale;
+  const canvasH = C.canvas?.h || 460;
+  const groundRatio = C.groundRatio ?? 0.7;
+  const groundSurface = Math.round(canvasH * groundRatio);
+  const groundCenterY = groundSurface - hbHeight / 2;
+  fighter.physics.lastGroundY = groundSurface;
+
+  const wasGrounded = fighter.onGround;
+
+  // Handle buffered jump (pressed this frame)
+  const input = fighter.input || {};
+  const wantsJump = !!input.jump && !fighter.__prevJump && fighter.onGround && !fighter.ragdoll && !fighter.recovering;
+  if (wantsJump){
+    fighter.vel.y = movement.jumpImpulse ?? -650;
+    fighter.onGround = false;
+  }
+  fighter.__prevJump = !!input.jump;
+
+  // Gravity
+  const gravity = movement.gravity ?? 2400;
+  const gravityMult = fighter.ragdoll ? 1.8 : 1.0;
+  fighter.vel.y += gravity * dt * gravityMult;
+
+  // Horizontal input
+  if (!fighter.ragdoll && !fighter.recovering){
+    const dashMult = fighter.stamina?.isDashing ? (movement.dashSpeedMultiplier || 1) : 1;
+    const accelX = (movement.accelX || 0) * dashMult;
+    const maxSpeed = (movement.maxSpeedX || 0) * dashMult;
+    if (input.left) fighter.vel.x -= accelX * dt;
+    if (input.right) fighter.vel.x += accelX * dt;
+    if (maxSpeed > 0){
+      fighter.vel.x = clamp(fighter.vel.x, -maxSpeed, maxSpeed);
+    }
+  }
+
+  // Friction
+  if (fighter.ragdoll){
+    fighter.ragdollVel.x = fighter.ragdollVel.x ?? fighter.vel.x;
+    fighter.vel.x = fighter.ragdollVel.x * 0.96;
+    fighter.ragdollVel.x *= 0.96;
+  } else {
+    const friction = movement.friction ?? 8;
+    fighter.vel.x *= Math.exp(-friction * dt);
+  }
+
+  // Joint physics (for ragdoll blending)
+  updateJointPhysics(fighter, dt);
+
+  // Integrate position
+  fighter.pos.x += fighter.vel.x * dt;
+  fighter.pos.y += fighter.vel.y * dt;
+
+  // Clamp world bounds
+  const margin = 40;
+  const maxX = (worldWidth || 1600) - margin;
+  fighter.pos.x = clamp(fighter.pos.x, margin, maxX);
+
+  // Ground collision
+  const ragdollGround = groundSurface - 20 * actorScale;
+  const targetGround = fighter.ragdoll ? ragdollGround : groundCenterY;
+  if (fighter.pos.y >= targetGround){
+    fighter.pos.y = targetGround;
+    if (fighter.vel.y > 0){
+      if (fighter.ragdoll){
+        fighter.vel.y = -fighter.vel.y * 0.2;
+        for (const key of Object.keys(JOINT_PHYSICS.joints)){
+          const velKey = `${key}Vel`;
+          fighter.jointAngles[velKey] *= 0.5;
+        }
+      } else {
+        fighter.landedImpulse = Math.max(fighter.landedImpulse || 0, fighter.vel.y);
+        const restitution = movement.restitution ?? 0;
+        fighter.vel.y = -fighter.vel.y * restitution;
+      }
+    }
+    fighter.onGround = true;
+  } else {
+    fighter.onGround = false;
+  }
+
+  // Ragdoll transitions and recovery
+  if (fighter.ragdoll){
+    fighter.ragdollTime += dt;
+    if (fighter.onGround && fighter.ragdollTime > 2.5){
+      fighter.ragdoll = false;
+      fighter.ragdollTime = 0;
+      fighter.recovering = true;
+      fighter.recoveryTime = 0;
+      fighter.recoveryStartY = fighter.pos.y;
+      fighter.recoveryTargetY = groundCenterY;
+      fighter.recoveryStartAngles = { ...fighter.physics.jointAngles };
+      fighter.footing = 30;
+    }
+  } else if (fighter.recovering){
+    fighter.recoveryTime += dt;
+    const t = Math.min(1, fighter.recoveryTime / fighter.recoveryDuration);
+    fighter.pos.y = lerp(fighter.recoveryStartY, fighter.recoveryTargetY, t);
+    if (t >= 1){
+      fighter.recovering = false;
+      fighter.recoveryTime = 0;
+    }
+  }
+
+  // Footing recovery
+  if (fighter.onGround && !fighter.ragdoll){
+    const recoveryRate = 20;
+    const maxFooting = window.CONFIG?.knockback?.maxFooting ?? 100;
+    fighter.footing = Math.min(maxFooting, (fighter.footing ?? 0) + recoveryRate * dt);
+  }
+
+  if (!fighter.ragdoll && !fighter.recovering && (fighter.footing ?? 0) <= 10){
+    enterRagdollState(fighter);
+  }
+
+  fighter.landedImpulse = (fighter.landedImpulse || 0) * Math.exp(-10 * dt);
+  fighter.prevOnGround = wasGrounded;
+
+  fighter.physics.offsets = computePhysicsOffsets(fighter);
+  fighter.physics.lastDt = dt;
+}
+
+export function initPhysics(){
+  const C = window.CONFIG || {};
+  ensureCamera(C);
+  const G = window.GAME || {};
+  if (G.FIGHTERS){
+    for (const fighter of Object.values(G.FIGHTERS)){
+      ensureFighterState(fighter, C);
+    }
+  }
+  console.log('[physics] initialized');
+}
+
+export function updatePhysics(dt){
+  const C = window.CONFIG || {};
+  const G = window.GAME || {};
+  const fighters = G.FIGHTERS || {};
+  const worldWidth = G.CAMERA?.worldWidth || C.world?.width || 1600;
+  if (fighters.player){
+    updateFighterPhysics(fighters.player, dt, C, worldWidth);
+    updatePlayerFacing(fighters.player, dt, C);
+  }
+  if (fighters.npc){
+    updateFighterPhysics(fighters.npc, dt, C, worldWidth);
+  }
+}
+
+export function getPhysicsOffsets(fighter){
+  return fighter?.physics?.offsets || null;
+}
+
+export function getPhysicsJointAngles(fighter){
+  return fighter?.physics?.jointAngles || null;
+}

--- a/docs/js/touch-controls.js
+++ b/docs/js/touch-controls.js
@@ -55,6 +55,7 @@ export function initTouchControls(){
   function processJoystickInput(){
     const MOVE = G.FIGHTERS?.player?.move;
     if (!MOVE) return;
+    const sharedInput = G.input;
     
     const deadzone = 0.2;
     const normalized = G.JOYSTICK.distance / 40; // Normalize to 0-1
@@ -72,6 +73,11 @@ export function initTouchControls(){
     } else {
       MOVE.input.left = false;
       MOVE.input.right = false;
+    }
+
+    if (sharedInput){
+      sharedInput.left = MOVE.input.left;
+      sharedInput.right = MOVE.input.right;
     }
     
     // Aiming - update facing direction based on joystick
@@ -125,6 +131,10 @@ export function initTouchControls(){
       MOVE.input.left = false;
       MOVE.input.right = false;
     }
+    if (G.input){
+      G.input.left = false;
+      G.input.right = false;
+    }
     
     updateJoystickVisual();
     processJoystickInput();
@@ -159,6 +169,12 @@ export function initTouchControls(){
         if (action === 'down'){
           const P = G.FIGHTERS?.player;
           if (P) P.input.jump = true;
+          if (G.input) G.input.jump = true;
+        }
+        if (action === 'up'){
+          const P = G.FIGHTERS?.player;
+          if (P) P.input.jump = false;
+          if (G.input) G.input.jump = false;
         }
         break;
       case 'interact':
@@ -198,6 +214,10 @@ export function initTouchControls(){
     btnJump.addEventListener('touchstart', (e) => {
       e.preventDefault();
       handleTouchButton('jump', 'down');
+    }, { passive: false });
+    btnJump.addEventListener('touchend', (e) => {
+      e.preventDefault();
+      handleTouchButton('jump', 'up');
     }, { passive: false });
   }
   


### PR DESCRIPTION
## Summary
- reintroduce joint-based fighter physics and ragdoll-friendly offsets in a new physics module
- integrate the physics update into the game loop and animation blend while extending fighter state for physics data
- allow Alt keys and touch controls to drive jump input alongside existing bindings

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910429879e08326907ab532bb537a4c)