### PR TITLE
Add cosmetic overlay pipeline with HSV controls

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -137,6 +137,117 @@ const POSE_ANGLE_SUMMARY = {
   Recoil: { lHip:110, rHip:100 }
 };
 
+const FIGHTER_TLETINGAN = 'TLETINGAN';
+const FIGHTER_MAOAO_M = 'Mao-ao_M';
+
+const COSMETIC_LIBRARY = {
+  basic_headband: {
+    slot: 'hat',
+    hsv: {
+      defaults: { h: 0, s: 0, v: 0 },
+      limits: { h: [-90, 90], s: [-0.5, 0.5], v: [-0.35, 0.35] }
+    },
+    parts: {
+      head: {
+        image: {
+          url: 'https://i.imgur.com/WsKQ2Eo.png',
+          fighters: {
+            'Mao-ao_M': './assets/fightersprites/mao-ao-m/head.png'
+          }
+        },
+        spriteStyle: {
+          base: {
+            xform: {
+              head: { ax: -0.05, ay: -0.08, scaleX: 1.1, scaleY: 1.05 }
+            }
+          },
+          fighters: {
+            [FIGHTER_TLETINGAN]: {
+              xform: {
+                head: { ax: -0.12, ay: -0.15, scaleX: 1.2, scaleY: 1.1 }
+              }
+            }
+          }
+        },
+        warp: {
+          base: {
+            units: 'percent',
+            tl: { y: -0.1 },
+            tr: { y: -0.1 },
+            center: { y: -0.05 }
+          },
+          fighters: {
+            [FIGHTER_MAOAO_M]: {
+              units: 'percent',
+              center: { y: -0.02 }
+            }
+          }
+        }
+      }
+    }
+  },
+  layered_travel_cloak: {
+    slots: ['overwear', 'torso'],
+    hsv: {
+      defaults: { h: 0, s: 0, v: 0 },
+      limits: { h: [-45, 45], s: [-0.4, 0.4], v: [-0.3, 0.5] }
+    },
+    parts: {
+      torso: {
+        image: {
+          url: 'https://i.imgur.com/YatjSyo.png'
+        },
+        spriteStyle: {
+          base: {
+            xform: {
+              torso: { ax: -0.5, ay: -0.15, scaleX: 3.8, scaleY: 4.7 }
+            }
+          },
+          fighters: {
+            [FIGHTER_MAOAO_M]: {
+              xform: {
+                torso: { ax: -0.05, scaleX: 1.6, scaleY: 1.8 }
+              }
+            }
+          }
+        },
+        warp: {
+          base: {
+            units: 'percent',
+            bl: { x: -0.05 },
+            br: { x: 0.05 },
+            center: { y: 0.05 }
+          }
+        }
+      },
+      leg_L_upper: {
+        image: {
+          url: 'https://i.imgur.com/qgcQTmx.png'
+        },
+        spriteStyle: {
+          base: {
+            xform: {
+              legUpper: { ax: -0.12, ay: 0.1, scaleX: 2.2, scaleY: 2.1 }
+            }
+          }
+        }
+      },
+      leg_R_upper: {
+        image: {
+          url: 'https://i.imgur.com/qgcQTmx.png'
+        },
+        spriteStyle: {
+          base: {
+            xform: {
+              legUpper: { ax: -0.12, ay: 0.1, scaleX: 2.2, scaleY: 2.1 }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
 const KICK_MOVE_POSES = {
   Stance: {
     torso: 10,
@@ -357,6 +468,8 @@ window.CONFIG = {
     Walk: deepClone(BASE_POSES.Walk)
   },
 
+  cosmeticLibrary: COSMETIC_LIBRARY,
+
   fighters: {
     TLETINGAN: {
         actor: { scale: 0.9 },
@@ -406,6 +519,12 @@ window.CONFIG = {
             legUpper: { ax:-0.10, ay:0.10,  scaleX:2.0,  scaleY:2.0,  rotDeg:0 },
             legLower: { ax:-0.2,  ay:0.02,  scaleX:2,    scaleY:2.00, rotDeg:-10 }
           }
+      },
+      cosmetics: {
+        slots: {
+          hat: { id: 'basic_headband', hsv: { h: 12, s: 0.1, v: 0.05 } },
+          overwear: { id: 'layered_travel_cloak', hsv: { h: -10, s: -0.15, v: 0.1 } }
+        }
       }
     },
     'Mao-ao_M': {
@@ -443,6 +562,12 @@ window.CONFIG = {
             legUpper: { ax:-0.10, ay:0,  scaleX:1.7, scaleY:2.75,  rotDeg:-15 },
             legLower: { ax:-0.0,  ay:0.2,  scaleX:1.7, scaleY:2.1, rotDeg:-4 }
           }
+      },
+      cosmetics: {
+        slots: {
+          hat: { id: 'basic_headband', hsv: { h: -20, s: 0.2, v: 0 } },
+          torso: { id: 'layered_travel_cloak', hsv: { h: 5, s: -0.1, v: 0.15 } }
+        }
       }
     }
   },

--- a/docs/js/cosmetics.js
+++ b/docs/js/cosmetics.js
@@ -1,0 +1,235 @@
+// cosmetics.js — Cosmetic overlay system for fighters
+// Provides slot definitions, library registration, equipment helpers, and per-fighter layer resolution
+
+import { degToRad } from './math-utils.js?v=1';
+
+const ROOT = (typeof window !== 'undefined' ? window : globalThis);
+const STATE = (ROOT.COSMETIC_SYSTEM ||= {
+  library: {},
+  assetCache: new Map()
+});
+
+export const COSMETIC_SLOTS = [
+  'hat',
+  'hood',
+  'overwear',
+  'torso',
+  'legs',
+  'arms',
+  'upper-face',
+  'lower-face',
+  'hands',
+  'feet',
+  'shoulders',
+  'beard',
+  'hair'
+];
+
+function ensureArray(val){
+  if (!val) return [];
+  return Array.isArray(val) ? val : [val];
+}
+
+function deepMerge(base = {}, extra = {}){
+  const out = Array.isArray(base) ? [...base] : { ...base };
+  for (const [key, value] of Object.entries(extra || {})){
+    if (value && typeof value === 'object' && !Array.isArray(value)){
+      out[key] = deepMerge(base?.[key] || {}, value);
+    } else if (Array.isArray(value)){
+      out[key] = value.slice();
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+function pickPerFighter(def, fighterName){
+  if (def == null) return null;
+  if (typeof def === 'function'){
+    return def(fighterName);
+  }
+  if (typeof def === 'string'){
+    return { url: def };
+  }
+  const base = (def.base ?? def.default ?? (def.url || def.xform || def.widthFactor ? def : {}));
+  const overrides = def.fighters || def.perFighter || {};
+  const fighterOverride = fighterName && overrides[fighterName];
+  if (!fighterOverride){
+    if (base && typeof base === 'object' && !Array.isArray(base)){
+      return deepMerge({}, base);
+    }
+    return base;
+  }
+  return deepMerge(base || {}, fighterOverride);
+}
+
+function loadImage(url){
+  if (!url) return null;
+  const cache = STATE.assetCache;
+  if (cache.has(url)){
+    return cache.get(url);
+  }
+  if (typeof Image === 'undefined'){
+    return null;
+  }
+  const img = new Image();
+  img.crossOrigin = 'anonymous';
+  img.referrerPolicy = 'no-referrer';
+  img.addEventListener('error', ()=>{ img.__broken = true; });
+  img.src = url;
+  cache.set(url, img);
+  return img;
+}
+
+function normalizeCosmetic(id, raw = {}){
+  const slots = ensureArray(raw.slot || raw.slots);
+  const norm = {
+    id,
+    slots: slots.length ? slots : COSMETIC_SLOTS,
+    parts: raw.parts || {},
+    hsv: {
+      defaults: { h:0, s:0, v:0, ...(raw.hsv?.defaults || {}) },
+      limits: {
+        h: raw.hsv?.limits?.h ?? [-180, 180],
+        s: raw.hsv?.limits?.s ?? [-1, 1],
+        v: raw.hsv?.limits?.v ?? [-1, 1]
+      }
+    }
+  };
+  if (raw.meta) norm.meta = { ...raw.meta };
+  return norm;
+}
+
+export function registerCosmeticLibrary(library = {}){
+  for (const [id, cosmetic] of Object.entries(library || {})){
+    STATE.library[id] = normalizeCosmetic(id, cosmetic);
+  }
+  return STATE.library;
+}
+
+function clamp(value, min, max){
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function clampHSV(input = {}, cosmetic){
+  const defaults = cosmetic?.hsv?.defaults || { h:0, s:0, v:0 };
+  const limits = cosmetic?.hsv?.limits || {};
+  return {
+    h: clamp(input.h ?? defaults.h ?? 0, limits.h?.[0] ?? -180, limits.h?.[1] ?? 180),
+    s: clamp(input.s ?? defaults.s ?? 0, limits.s?.[0] ?? -1, limits.s?.[1] ?? 1),
+    v: clamp(input.v ?? defaults.v ?? 0, limits.v?.[0] ?? -1, limits.v?.[1] ?? 1)
+  };
+}
+
+function resolvePartConfig(partConfig = {}, fighterName){
+  const imageCfg = pickPerFighter(partConfig.image || partConfig.images, fighterName);
+  const styleCfg = pickPerFighter(partConfig.spriteStyle, fighterName);
+  const warpCfg = pickPerFighter(partConfig.warp, fighterName);
+  const anchorCfg = pickPerFighter(partConfig.anchor, fighterName);
+  const alignCfg = pickPerFighter(partConfig.align, fighterName);
+  const extra = partConfig.extra || {};
+  const styleKey = partConfig.styleKey || partConfig.style || partConfig.styleName;
+  return {
+    image: imageCfg,
+    spriteStyle: styleCfg,
+    warp: warpCfg,
+    anchor: anchorCfg,
+    align: alignCfg,
+    styleKey,
+    extra: extra
+  };
+}
+
+function ensureAsset(cosmeticId, partKey, imageCfg){
+  if (!imageCfg || !imageCfg.url) return null;
+  const key = `${cosmeticId}::${partKey}::${imageCfg.url}`;
+  let asset = STATE.assets?.get(key);
+  if (!STATE.assets){
+    STATE.assets = new Map();
+  }
+  if (!asset){
+    const img = loadImage(imageCfg.url);
+    asset = { url: imageCfg.url, img, alignRad: imageCfg.alignRad ?? 0 };
+    STATE.assets.set(key, asset);
+  }
+  if (imageCfg.alignRad != null){
+    asset.alignRad = imageCfg.alignRad;
+  }
+  return asset;
+}
+
+export function cosmeticTagFor(baseTag, slot){
+  return `${String(baseTag || '').toUpperCase()}__COS__${String(slot || '').toUpperCase()}`;
+}
+
+function normalizeEquipment(slotEntry){
+  if (!slotEntry) return null;
+  if (typeof slotEntry === 'string'){
+    return { id: slotEntry };
+  }
+  const id = slotEntry.id || slotEntry.cosmeticId || slotEntry.item || slotEntry.name;
+  if (!id) return null;
+  const hsv = slotEntry.hsv || slotEntry.tone || {};
+  const fighterOverrides = slotEntry.fighterOverrides || {};
+  return { id, hsv, fighterOverrides };
+}
+
+export function ensureCosmeticLayers(config = {}, fighterName, baseStyle = {}){
+  const layers = [];
+  const library = registerCosmeticLibrary(config.cosmeticLibrary || config.cosmetics?.library || {});
+  const fighter = config.fighters?.[fighterName] || {};
+  const slotConfig = fighter.cosmetics?.slots || fighter.cosmetics || {};
+  for (const slot of COSMETIC_SLOTS){
+    const equipped = normalizeEquipment(slotConfig[slot]);
+    if (!equipped) continue;
+    const cosmetic = library[equipped.id];
+    if (!cosmetic) continue;
+    const hsv = clampHSV(equipped.hsv, cosmetic);
+    for (const [partKey, partConfig] of Object.entries(cosmetic.parts || {})){
+      const resolved = resolvePartConfig(partConfig, fighterName);
+      if (!resolved?.image?.url) continue;
+      const asset = ensureAsset(cosmetic.id, partKey, resolved.image);
+      if (!asset) continue;
+      let styleOverride = resolved.spriteStyle;
+      if (typeof resolved.anchor === 'string'){
+        styleOverride = {
+          ...(styleOverride || {}),
+          anchor: { ...(styleOverride?.anchor || {}), [partKey]: resolved.anchor }
+        };
+      } else if (resolved.anchor && typeof resolved.anchor === 'object' && !Array.isArray(resolved.anchor)){
+        styleOverride = {
+          ...(styleOverride || {}),
+          anchor: { ...(styleOverride?.anchor || {}), ...resolved.anchor }
+        };
+      }
+      const alignDeg = resolved.align?.deg;
+      const alignRad = resolved.align?.rad ?? (Number.isFinite(alignDeg) ? degToRad(alignDeg) : undefined);
+      layers.push({
+        slot,
+        partKey,
+        cosmeticId: cosmetic.id,
+        asset,
+        hsv,
+        styleOverride,
+        warp: resolved.warp,
+        anchorOverride: resolved.anchor,
+        alignDeg,
+        alignRad,
+        styleKey: resolved.styleKey,
+        extra: resolved.extra || {}
+      });
+    }
+  }
+  return layers;
+}
+
+export function clearCosmeticCache(){
+  if (STATE.assets){
+    STATE.assets.clear();
+  }
+  if (STATE.assetCache){
+    STATE.assetCache.clear();
+  }
+}

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -12,6 +12,7 @@
 
 import { angleZero as angleZeroUtil, basis as basisFn, dist, angle as angleUtil, degToRad } from './math-utils.js?v=1';
 import { pickFighterName as pickFighterNameUtil } from './fighter-utils.js?v=1';
+import { COSMETIC_SLOTS, ensureCosmeticLayers, cosmeticTagFor } from './cosmetics.js?v=1';
 
 const ASSETS = (window.ASSETS ||= {});
 const CACHE = (ASSETS.sprites ||= {});
@@ -144,10 +145,17 @@ function spriteRotationOffset(styleKey){
 // Render order: use CONFIG.render.order if available; else fallback
 function buildZMap(C){
   const def = ['HITBOX','ARM_L_UPPER','ARM_L_LOWER','LEG_L_UPPER','LEG_L_LOWER','TORSO','HEAD','LEG_R_UPPER','LEG_R_LOWER','ARM_R_UPPER','ARM_R_LOWER'];
-  const arr = (C.render && Array.isArray(C.render.order) && C.render.order.length) ? C.render.order.map(s=>String(s).toUpperCase()) : def;
+  const baseOrder = (C.render && Array.isArray(C.render.order) && C.render.order.length) ? C.render.order.map(s=>String(s).toUpperCase()) : def;
+  const expanded = [];
+  for (const tag of baseOrder){
+    expanded.push(tag);
+    for (const slot of COSMETIC_SLOTS){
+      expanded.push(cosmeticTagFor(tag, slot));
+    }
+  }
   const m = new Map();
-  arr.forEach((tag,i)=>m.set(tag, i));
-  return (tag)=> (m.has(tag) ? m.get(tag) : 999);
+  expanded.forEach((tag,i)=>m.set(tag, i));
+  return (tag)=> (m.has(tag) ? m.get(tag) : baseOrder.length + COSMETIC_SLOTS.length + 999);
 }
 
 // === MIRROR API ===
@@ -204,7 +212,100 @@ function withBranchMirror(ctx, originX, mirror, drawFn){
 }
 
 // Sprite rendering for bones, fixed math
+function mergeSpriteStyles(base = {}, overrides = {}){
+  if (!overrides) return base;
+  const out = { ...base };
+  if (overrides.widthFactor){
+    out.widthFactor = { ...(base.widthFactor || {}), ...overrides.widthFactor };
+  }
+  if (overrides.anchor){
+    out.anchor = { ...(base.anchor || {}), ...overrides.anchor };
+  }
+  if (overrides.xformUnits){
+    out.xformUnits = overrides.xformUnits;
+  }
+  if (overrides.xform){
+    out.xform = { ...(base.xform || {}), ...overrides.xform };
+  }
+  return out;
+}
+
+function buildFilterString(baseFilter, hsv){
+  const filters = [];
+  if (baseFilter && baseFilter !== 'none'){
+    filters.push(baseFilter);
+  }
+  if (hsv){
+    if (Number.isFinite(hsv.h)){
+      filters.push(`hue-rotate(${hsv.h}deg)`);
+    }
+    if (Number.isFinite(hsv.s)){
+      const sat = Math.max(0, 1 + hsv.s);
+      filters.push(`saturate(${sat})`);
+    }
+    if (Number.isFinite(hsv.v)){
+      const bright = Math.max(0, 1 + hsv.v);
+      filters.push(`brightness(${bright})`);
+    }
+  }
+  return filters.length ? filters.join(' ') : 'none';
+}
+
+function setTransformFromTriangle(ctx, srcTri, dstTri){
+  const [sx0, sy0] = srcTri[0];
+  const [sx1, sy1] = srcTri[1];
+  const [sx2, sy2] = srcTri[2];
+  const [dx0, dy0] = dstTri[0];
+  const [dx1, dy1] = dstTri[1];
+  const [dx2, dy2] = dstTri[2];
+  const delta = sx0 * (sy1 - sy2) + sx1 * (sy2 - sy0) + sx2 * (sy0 - sy1);
+  if (!delta) return false;
+  const a = dx0 * (sy1 - sy2) + dx1 * (sy2 - sy0) + dx2 * (sy0 - sy1);
+  const b = dy0 * (sy1 - sy2) + dy1 * (sy2 - sy0) + dy2 * (sy0 - sy1);
+  const c = dx0 * (sx2 - sx1) + dx1 * (sx0 - sx2) + dx2 * (sx1 - sx0);
+  const d = dy0 * (sx2 - sx1) + dy1 * (sx0 - sx2) + dy2 * (sx1 - sx0);
+  const e = dx0 * (sx1 * sy2 - sx2 * sy1) + dx1 * (sx2 * sy0 - sx0 * sy2) + dx2 * (sx0 * sy1 - sx1 * sy0);
+  const f = dy0 * (sx1 * sy2 - sx2 * sy1) + dy1 * (sx2 * sy0 - sx0 * sy2) + dy2 * (sx0 * sy1 - sx1 * sy0);
+  ctx.setTransform(a / delta, b / delta, c / delta, d / delta, e / delta, f / delta);
+  return true;
+}
+
+function drawWarpedImage(ctx, img, destPoints, w, h){
+  const srcPoints = {
+    center: [w / 2, h / 2],
+    tl: [0, 0],
+    tr: [w, 0],
+    br: [w, h],
+    bl: [0, h]
+  };
+  const triangles = [
+    ['center', 'tl', 'tr'],
+    ['center', 'tr', 'br'],
+    ['center', 'br', 'bl'],
+    ['center', 'bl', 'tl']
+  ];
+  for (const tri of triangles){
+    const dstTri = tri.map(key => {
+      const pt = destPoints[key];
+      return [pt.x, pt.y];
+    });
+    const srcTri = tri.map(key => srcPoints[key]);
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(dstTri[0][0], dstTri[0][1]);
+    ctx.lineTo(dstTri[1][0], dstTri[1][1]);
+    ctx.lineTo(dstTri[2][0], dstTri[2][1]);
+    ctx.closePath();
+    ctx.clip();
+    if (setTransformFromTriangle(ctx, srcTri, dstTri)){
+      ctx.drawImage(img, 0, 0, img.naturalWidth, img.naturalHeight, 0, 0, w, h);
+    }
+    ctx.restore();
+  }
+}
+
 function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
+  const options = arguments[6] || {};
   const img = asset?.img;
   if (!img || img.__broken) return false;
   if (!img.complete) return false;
@@ -225,9 +326,12 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
   const normalizedKey = normalizeStyleKey(styleKey);
 
   // Get anchor config: anchors at bone midpoint by default
-  const anchorCfg = style.anchor || {};
+  const effectiveStyle = mergeSpriteStyles(style, options.styleOverride);
+  const anchorCfg = effectiveStyle.anchor || {};
   const anchorMode = anchorCfg[styleKey] || 'mid';
-  const resolvedAnchorMode = (anchorCfg[normalizedKey] != null) ? anchorCfg[normalizedKey] : anchorMode;
+  const resolvedAnchorMode = (options.anchorMode != null)
+    ? options.anchorMode
+    : (anchorCfg[normalizedKey] != null ? anchorCfg[normalizedKey] : anchorMode);
 
   // Basis vectors for local orientation
   const bAxis = basisFor(bone.ang);
@@ -241,8 +345,8 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
   }
 
   // Offset config for fine-tuning sprite placement
-  const xform = (style.xform || {})[normalizedKey] || (style.xform || {})[styleKey] || {};
-  const xformUnits = (style.xformUnits || 'px').toLowerCase();
+  const xform = (effectiveStyle.xform || {})[normalizedKey] || (effectiveStyle.xform || {})[styleKey] || {};
+  const xformUnits = (effectiveStyle.xformUnits || 'px').toLowerCase();
 
   let ax = xform.ax ?? 0;
   let ay = xform.ay ?? 0;
@@ -260,7 +364,7 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
   const nh = img.naturalHeight || img.height || 1;
   const nw = img.naturalWidth  || img.width  || 1;
   const baseH = Math.max(1, bone.len);
-  const wfTbl = style.widthFactor || {};
+  const wfTbl = effectiveStyle.widthFactor || {};
   const wf = (wfTbl[normalizedKey] ?? wfTbl[styleKey] ?? 1);
   let w = nw * (baseH / nh) * wf;
   let h = baseH;
@@ -272,12 +376,55 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
   h *= scaleY;
 
   // Rotation (fixed): bone.ang + alignRad + Math.PI
-  const alignRad = asset.alignRad ?? 0;
+  const alignRad = (options.alignRad != null)
+    ? options.alignRad
+    : (options.alignDeg != null ? degToRad(options.alignDeg) : (asset.alignRad ?? 0));
   const theta = bone.ang + alignRad + Math.PI;
+
+  const filter = buildFilterString(ctx.filter, options.hsv);
+  const warp = options.warp;
   ctx.save();
-  ctx.translate(posX, posY);
-  ctx.rotate(theta);
-  ctx.drawImage(img, -w/2, -h/2, w, h);
+  ctx.filter = filter;
+  if (warp && typeof warp === 'object'){
+    const units = (warp.units || 'percent').toLowerCase();
+    const pts = {
+      tl: { x: -w / 2, y: -h / 2 },
+      tr: { x:  w / 2, y: -h / 2 },
+      br: { x:  w / 2, y:  h / 2 },
+      bl: { x: -w / 2, y:  h / 2 },
+      center: { x: 0, y: 0 }
+    };
+    const keys = ['tl','tr','br','bl','center'];
+    const convert = (val, size) => {
+      if (!Number.isFinite(val)) return 0;
+      if (units === 'percent' || units === '%' || units === 'pct'){
+        return val * size;
+      }
+      return val;
+    };
+    for (const key of keys){
+      const spec = warp[key];
+      if (!spec) continue;
+      const dx = convert(spec.x ?? spec.ax ?? 0, w);
+      const dy = convert(spec.y ?? spec.ay ?? 0, h);
+      pts[key].x += dx;
+      pts[key].y += dy;
+    }
+    const cosT = Math.cos(theta);
+    const sinT = Math.sin(theta);
+    const dest = {};
+    for (const key of keys){
+      const local = pts[key];
+      const rx = local.x * cosT - local.y * sinT;
+      const ry = local.x * sinT + local.y * cosT;
+      dest[key] = { x: posX + rx, y: posY + ry };
+    }
+    drawWarpedImage(ctx, img, dest, w, h);
+  } else {
+    ctx.translate(posX, posY);
+    ctx.rotate(theta);
+    ctx.drawImage(img, -w/2, -h/2, w, h);
+  }
   ctx.restore();
   return true;
 }
@@ -308,7 +455,7 @@ export function renderSprites(ctx){
 
   // RENDER.MIRROR flags control per-limb mirroring (e.g., for attack animations)
   
-  const { assets, style, offsets } = ensureFighterSprites(C, fname);
+  const { assets, style, offsets, cosmetics } = ensureFighterSprites(C, fname);
 
   const zOf = buildZMap(C);
   const queue = [];
@@ -416,6 +563,25 @@ export function renderSprites(ctx){
     });
   }
 
+  if (Array.isArray(cosmetics)){
+    for (const layer of cosmetics){
+      const bone = rig[layer.partKey];
+      if (!bone) continue;
+      const baseTag = tagOf(layer.partKey);
+      const slotTag = cosmeticTagFor(baseTag, layer.slot);
+      const styleKey = layer.styleKey || layer.partKey;
+      enqueue(slotTag, ()=>{
+        drawBoneSprite(ctx, layer.asset, bone, styleKey, style, offsets, {
+          styleOverride: layer.styleOverride,
+          hsv: layer.hsv,
+          warp: layer.warp,
+          alignRad: layer.alignRad,
+          alignDeg: layer.alignRad == null ? layer.alignDeg : undefined
+        });
+      });
+    }
+  }
+
   queue.sort((a, b) => a.z - b.z);
   
   for (const entry of queue){
@@ -476,5 +642,7 @@ export function ensureFighterSprites(C, fname){
     }
   }
   
-  return { assets: S, style, offsets };
+  const cosmetics = ensureCosmeticLayers(C, fname, style);
+
+  return { assets: S, style, offsets, cosmetics };
 }

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -1,0 +1,84 @@
+import { strictEqual, deepStrictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
+import { COSMETIC_SLOTS, cosmeticTagFor, ensureCosmeticLayers, clearCosmeticCache } from '../docs/js/cosmetics.js';
+import { readFileSync } from 'node:fs';
+
+const EXPECTED_SLOTS = [
+  'hat',
+  'hood',
+  'overwear',
+  'torso',
+  'legs',
+  'arms',
+  'upper-face',
+  'lower-face',
+  'hands',
+  'feet',
+  'shoulders',
+  'beard',
+  'hair'
+];
+
+test('COSMETIC_SLOTS includes all required slots', () => {
+  deepStrictEqual(COSMETIC_SLOTS, EXPECTED_SLOTS);
+});
+
+test('cosmeticTagFor uppercases base tag and slot', () => {
+  strictEqual(cosmeticTagFor('torso', 'hat'), 'TORSO__COS__HAT');
+});
+
+test('ensureCosmeticLayers resolves equipment with HSV limits applied', () => {
+  clearCosmeticCache();
+  const config = {
+    cosmeticLibrary: {
+      demo_item: {
+        slot: 'hat',
+        hsv: {
+          defaults: { h: 0, s: 0, v: 0 },
+          limits: { h: [-30, 30], s: [-0.25, 0.25], v: [-0.5, 0.5] }
+        },
+        parts: {
+          head: {
+            image: { url: 'https://example.com/head.png' },
+            spriteStyle: {
+              base: { xform: { head: { scaleX: 1.1 } } }
+            },
+            warp: {
+              base: {
+                units: 'percent',
+                tl: { y: -0.1 }
+              }
+            }
+          }
+        }
+      }
+    },
+    fighters: {
+      hero: {
+        cosmetics: {
+          slots: {
+            hat: { id: 'demo_item', hsv: { h: 60, s: 1, v: 1 } }
+          }
+        }
+      }
+    }
+  };
+  const layers = ensureCosmeticLayers(config, 'hero', {});
+  strictEqual(layers.length, 1);
+  strictEqual(layers[0].slot, 'hat');
+  strictEqual(layers[0].partKey, 'head');
+  deepStrictEqual(layers[0].hsv, { h: 30, s: 0.25, v: 0.5 });
+  strictEqual(typeof layers[0].styleOverride, 'object');
+});
+
+test('sprites.js integrates cosmetic layers and z-order expansion', () => {
+  const spritesContent = readFileSync(new URL('../docs/js/sprites.js', import.meta.url), 'utf8');
+  strictEqual(/expanded\.push\(cosmeticTagFor\(tag, slot\)\);/.test(spritesContent), true, 'buildZMap should add cosmetic tags');
+  strictEqual(/const \{ assets, style, offsets, cosmetics } = ensureFighterSprites/.test(spritesContent), true, 'renderSprites should read cosmetics');
+});
+
+test('config registers cosmetic library and fighter slot data', () => {
+  const configContent = readFileSync(new URL('../docs/config/config.js', import.meta.url), 'utf8');
+  strictEqual(/cosmeticLibrary:\s*COSMETIC_LIBRARY/.test(configContent), true, 'config should expose cosmeticLibrary');
+  strictEqual(/cosmetics:\s*\{\s*slots:\s*\{\s*hat:/.test(configContent), true, 'fighters should define cosmetics slots');
+});


### PR DESCRIPTION
## Summary
- introduce a cosmetics system that registers slot definitions, HSV constraints, and per-fighter layer resolution helpers
- update sprite rendering to merge cosmetic layers, expand z-order per slot, and support HSV filters with quad warping
- extend the sample config with cosmetic library entries, fighter equipment slots, and new tests covering the overlay pipeline

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691041832dc48326b2f0ea907745b170)