### PR TITLE
Fix left-facing mirror pivot to match reference

### DIFF
--- a/docs/js/render.js
+++ b/docs/js/render.js
@@ -333,8 +333,8 @@ export function renderAll(ctx){
 
   // Apply character flip for debug bones, same as sprites
   if (player.flipLeft) {
-    const centerLocalX = (player.hitbox?.x ?? 0) - camX;
-    ctx.translate(centerLocalX * 2, 0);
+    const centerWorldX = player.hitbox?.x ?? 0;
+    ctx.translate(centerWorldX * 2, 0);
     ctx.scale(-1, 1);
   }
   

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -446,13 +446,12 @@ export function renderSprites(ctx){
   const flipLeft = G.FLIP_STATE?.[entity] || false;
   const centerX = rig.center?.x ?? 0;
   const camX = G.CAMERA?.x || 0;
-  const centerLocalX = centerX - camX;
 
   ctx.save();
   ctx.translate(-camX, 0);
   // Mirror around character center when facing left (matching reference HTML exactly)
   if (flipLeft) {
-    ctx.translate(centerLocalX * 2, 0);
+    ctx.translate(centerX * 2, 0);
     ctx.scale(-1, 1);
   }
 


### PR DESCRIPTION
## Summary
- mirror debug bones around the fighter's world-space center when facing left
- mirror sprite stack around the same pivot to match the reference HTML and prevent off-screen rendering

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910562547ec8326bb951e16d7e5f117)