### PR TITLE
Revert merges applied after 3 AM EST

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -494,7 +494,7 @@ window.CONFIG = {
         torso: { origin:{ax:0, ay:0}, shoulder:{ax:-8, ay:-5}, hip:{ax:0, ay:0}, neck:{ax:0, ay:0} },
         arm: { upper:{ origin:{ax:0, ay:0}, elbow:{ax:0, ay:0} }, lower:{ origin:{ax:0, ay:0} } },
         leg: { upper:{ origin:{ax:0, ay:0}, knee:{ax:0, ay:0}  }, lower:{ origin:{ax:0, ay:0} } },
-        head:{ origin:{ax:-1, ay:6}, eyes:{ax:0, ay:0.2} }
+        head:{ origin:{ax:-1, ay:6} }
       },
         sprites: {
           torso: { url: "https://i.imgur.com/YatjSyo.png" },
@@ -537,7 +537,7 @@ window.CONFIG = {
         torso: { origin:{ax:0, ay:0}, shoulder:{ax:-8, ay:-5}, hip:{ax:0, ay:0}, neck:{ax:0, ay:0} },
         arm: { upper:{ origin:{ax:0, ay:0}, elbow:{ax:0, ay:0} }, lower:{ origin:{ax:0, ay:0} } },
         leg: { upper:{ origin:{ax:0, ay:0}, knee:{ax:0, ay:0}  }, lower:{ origin:{ax:0, ay:0} } },
-        head:{ origin:{ax:0, ay:0}, eyes:{ax:0, ay:0.2} }
+        head:{ origin:{ax:0, ay:0} }
       },
       sprites: {
         torso: { url: "./assets/fightersprites/mao-ao-m/torso.png" },

--- a/docs/js/debug-panel.js
+++ b/docs/js/debug-panel.js
@@ -76,7 +76,7 @@ function updateTransformsDisplay(fighter, bones) {
   html += '</div>';
 
   const boneOrder = [
-    'torso', 'head', 'eyes',
+    'torso', 'head',
     'arm_L_upper', 'arm_L_lower',
     'arm_R_upper', 'arm_R_lower',
     'leg_L_upper', 'leg_L_lower',
@@ -339,32 +339,10 @@ function copyPoseConfigToClipboard() {
     bones: {}
   };
 
-  const fighters = C.fighters || {};
-  const fighterKeys = Object.keys(fighters);
-  const selectedName = (window.GAME?.selectedFighter && fighters[window.GAME.selectedFighter])
-    ? window.GAME.selectedFighter
-    : (fighterKeys[0] || null);
-  if (selectedName) {
-    const fighterCfg = fighters[selectedName];
-    exportData.config.fighter = {
-      name: selectedName,
-      eyes: fighterCfg?.eyes || null
-    };
-  }
-
-  if (player.gaze?.world != null) {
-    exportData.eyes = {
-      worldDeg: Math.round(radToDegNum(player.gaze.world)),
-      source: player.gaze.source || 'pose',
-      restOffsetDeg: Math.round(radToDegNum(player.gaze.restOffsetRad || 0)),
-      aimOffsetDeg: Math.round(radToDegNum(player.gaze.aimOffsetRad || 0))
-    };
-  }
-
   // Add bone world transforms
   const bones = G.ANCHORS_OBJ?.player;
   if (bones) {
-    const boneKeys = ['torso', 'head', 'eyes', 'arm_L_upper', 'arm_L_lower', 'arm_R_upper', 'arm_R_lower',
+    const boneKeys = ['torso', 'head', 'arm_L_upper', 'arm_L_lower', 'arm_R_upper', 'arm_R_lower',
                      'leg_L_upper', 'leg_L_lower', 'leg_R_upper', 'leg_R_lower'];
     
     for (const key of boneKeys) {

--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -35,7 +35,6 @@ export function initFighters(cv, cx){
       recoveryTargetY: gy-1,
       stamina:{ current:100, max:100, drainRate:40, regenRate:25, minToDash:10, isDashing:false },
       jointAngles: { ...stanceRad },
-      gaze: { world: stanceRad.head ?? stanceRad.torso ?? 0, restOffsetRad: 0, aimOffsetRad: 0, source: 'pose', anchorRatio: 0.6 },
       walk:{ phase:0, amp:0 },
       attack:{ active:false, preset:null, slot:null },
       combo:{ active:false, sequenceIndex:0, attackDelay:0 },

--- a/docs/js/physics.js
+++ b/docs/js/physics.js
@@ -3,7 +3,6 @@
 // and produces pose offsets that blend with authored animation.
 
 import { degToRad } from './math-utils.js?v=1';
-import { pickFighterConfig, pickFighterName } from './fighter-utils.js?v=1';
 
 const TAU = Math.PI * 2;
 
@@ -206,29 +205,13 @@ function updatePlayerFacing(fighter, dt, C){
   fighter.facingSign = Math.cos(fighter.facingRad) >= 0 ? 1 : -1;
 }
 
-function resolveFighterScale(C, fcfg){
-  const base = C.actor?.scale ?? 1;
-  const fighterScale = fcfg?.actor?.scale ?? 1;
-  return base * fighterScale;
-}
-
-function resolveFighterParts(C, fcfg){
-  const baseParts = C.parts || {};
-  const fighterParts = fcfg?.parts || {};
-  return {
-    ...baseParts,
-    ...fighterParts,
-    hitbox: fighterParts.hitbox || baseParts.hitbox || { w: 120, h: 160, r: 60 }
-  };
-}
-
-function updateFighterPhysics(fighter, dt, C, worldWidth, fcfg){
+function updateFighterPhysics(fighter, dt, C, worldWidth){
   if (!fighter) return;
   ensureFighterState(fighter, C);
 
   const movement = C.movement || {};
-  const parts = resolveFighterParts(C, fcfg);
-  const actorScale = resolveFighterScale(C, fcfg);
+  const parts = C.parts || {};
+  const actorScale = C.actor?.scale ?? 1;
   const hb = parts.hitbox || { h: 160 };
   const hbHeight = (hb.h || 160) * actorScale;
   const canvasH = C.canvas?.h || 460;
@@ -368,14 +351,12 @@ export function updatePhysics(dt){
   const G = window.GAME || {};
   const fighters = G.FIGHTERS || {};
   const worldWidth = G.CAMERA?.worldWidth || C.world?.width || 1600;
-  const fighterName = pickFighterName(C);
-  const fighterConfig = pickFighterConfig(C, fighterName);
   if (fighters.player){
-    updateFighterPhysics(fighters.player, dt, C, worldWidth, fighterConfig);
+    updateFighterPhysics(fighters.player, dt, C, worldWidth);
     updatePlayerFacing(fighters.player, dt, C);
   }
   if (fighters.npc){
-    updateFighterPhysics(fighters.npc, dt, C, worldWidth, fighterConfig);
+    updateFighterPhysics(fighters.npc, dt, C, worldWidth);
   }
 }
 

--- a/docs/js/render.js
+++ b/docs/js/render.js
@@ -30,7 +30,6 @@ if (typeof window !== 'undefined') {
     showBone: {          // Per-bone visibility (all default to true)
       torso: true,
       head: true,
-      eyes: true,
       arm_L_upper: true,
       arm_L_lower: true,
       arm_R_upper: true,
@@ -164,66 +163,9 @@ function computeAnchorsForFighter(F, C, fighterName) {
   return { B, L, hitbox, flipLeft };
 }
 
-function pointFromBoneEnd(bone){
-  if (!bone) return null;
-  const { endX, endY } = bone;
-  if (Number.isFinite(endX) && Number.isFinite(endY)) {
-    return { x: endX, y: endY };
-  }
-  if (Number.isFinite(bone.x) && Number.isFinite(bone.y)) {
-    return { x: bone.x, y: bone.y };
-  }
-  return null;
-}
-
-function mirrorPointX(pt, pivotX){
-  if (!pt || !Number.isFinite(pivotX)) return pt;
-  pt.x = 2 * pivotX - pt.x;
-  return pt;
-}
-
-function updateColliderPositions(G, fighter){
-  if (!G || !fighter) return;
-  const B = fighter.B || {};
-  const hb = fighter.hitbox || {};
-  const pivotX = Number.isFinite(hb.x) ? hb.x : Number.isFinite(B.center?.x) ? B.center.x : null;
-  const pivotY = Number.isFinite(hb.y) ? hb.y : Number.isFinite(B.center?.y) ? B.center.y : null;
-  if (!Number.isFinite(pivotX) || !Number.isFinite(pivotY)) return;
-
-  const next = {
-    hitCenter: { x: pivotX, y: pivotY },
-    handL: pointFromBoneEnd(B.arm_L_lower) || pointFromBoneEnd(B.arm_L_upper),
-    handR: pointFromBoneEnd(B.arm_R_lower) || pointFromBoneEnd(B.arm_R_upper),
-    footL: pointFromBoneEnd(B.leg_L_lower) || pointFromBoneEnd(B.leg_L_upper),
-    footR: pointFromBoneEnd(B.leg_R_lower) || pointFromBoneEnd(B.leg_R_upper),
-  };
-
-  if (fighter.flipLeft) {
-    for (const key of ['handL','handR','footL','footR']) {
-      mirrorPointX(next[key], pivotX);
-    }
-  }
-
-  const mirrorFlags = (window.RENDER && window.RENDER.MIRROR) || {};
-  if (mirrorFlags.ARM_R_UPPER || mirrorFlags.ARM_R_LOWER) {
-    mirrorPointX(next.handR, pivotX);
-  }
-  if (mirrorFlags.LEG_R_UPPER || mirrorFlags.LEG_R_LOWER) {
-    mirrorPointX(next.footR, pivotX);
-  }
-
-  const colliders = (G.COLLIDERS_POS ||= {});
-  colliders.hitCenter = next.hitCenter;
-  colliders.handL = next.handL || null;
-  colliders.handR = next.handR || null;
-  colliders.footL = next.footL || null;
-  colliders.footR = next.footR || null;
-}
-
 export const LIMB_COLORS = {
   torso: '#fbbf24',
   head: '#d1d5db',
-  eyes: '#a855f7',
   arm_L_upper: '#60a5fa',
   arm_L_lower: '#3b82f6',
   arm_R_upper: '#f87171',
@@ -274,7 +216,7 @@ function drawStick(ctx, B) {
   
   ctx.lineCap = 'round';
   ctx.lineWidth = 4;
-  const order = ['torso','head','eyes','arm_L_upper','arm_L_lower','arm_R_upper','arm_R_lower','leg_L_upper','leg_L_lower','leg_R_upper','leg_R_lower'];
+  const order = ['torso','head','arm_L_upper','arm_L_lower','arm_R_upper','arm_R_lower','leg_L_upper','leg_L_lower','leg_R_upper','leg_R_lower'];
   for (const key of order) {
     drawSegment(ctx, key, B);
   }
@@ -354,15 +296,14 @@ export function renderAll(ctx){
   const fName=(G.selectedFighter && C.fighters?.[G.selectedFighter])? G.selectedFighter : (C.fighters?.TLETINGAN? 'TLETINGAN' : Object.keys(C.fighters||{})[0] || 'default'); 
   const player=computeAnchorsForFighter(G.FIGHTERS.player,C,fName); 
   const npc=computeAnchorsForFighter(G.FIGHTERS.npc,C,fName); 
-  (G.ANCHORS_OBJ ||= {});
-  G.ANCHORS_OBJ.player=player.B;
+  (G.ANCHORS_OBJ ||= {}); 
+  G.ANCHORS_OBJ.player=player.B; 
   G.ANCHORS_OBJ.npc=npc.B;
   // Store flip state so sprites.js can flip sprite images when facing left
   (G.FLIP_STATE ||= {});
   G.FLIP_STATE.player = player.flipLeft;
   G.FLIP_STATE.npc = npc.flipLeft;
-  updateColliderPositions(G, player);
-
+  
   // Fallback background so the viewport is never visually blank
   try{
     ctx.fillStyle = '#eaeaea';
@@ -384,14 +325,14 @@ export function renderAll(ctx){
     }
   }catch(_e){ /* ignore */ }
   
-  const camX=G.CAMERA?.x||0;
-  ctx.save();
+  const camX=G.CAMERA?.x||0; 
+  ctx.save(); 
   ctx.translate(-camX,0);
-
+  
   // Apply character flip for debug bones, same as sprites
   if (player.flipLeft) {
-    const centerWorldX = player.hitbox?.x ?? 0;
-    ctx.translate(centerWorldX * 2, 0);
+    const centerX = player.hitbox?.x ?? 0;
+    ctx.translate(centerX * 2, 0);
     ctx.scale(-1, 1);
   }
   

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -445,10 +445,8 @@ export function renderSprites(ctx){
   const entity = (fname === 'player' || fname === 'npc') ? fname : 'player';
   const flipLeft = G.FLIP_STATE?.[entity] || false;
   const centerX = rig.center?.x ?? 0;
-  const camX = G.CAMERA?.x || 0;
-
+  
   ctx.save();
-  ctx.translate(-camX, 0);
   // Mirror around character center when facing left (matching reference HTML exactly)
   if (flipLeft) {
     ctx.translate(centerX * 2, 0);
@@ -487,7 +485,7 @@ export function renderSprites(ctx){
   const lArmMirror = getMirror('ARM_L_UPPER') || getMirror('ARM_L_LOWER');
   if (lArmUpper) {
     enqueue('ARM_L_UPPER', ()=> {
-      const originX = lArmUpper.x ?? 0;
+      const originX = lArmUpper.x;
       withBranchMirror(ctx, originX, lArmMirror, ()=> {
         drawBoneSprite(ctx, assets.arm_L_upper, lArmUpper, 'arm_L_upper', style, offsets);
       });
@@ -495,7 +493,7 @@ export function renderSprites(ctx){
   }
   if (lArmLower) {
     enqueue('ARM_L_LOWER', ()=> {
-      const originX = (lArmUpper?.x ?? lArmLower.x) ?? 0;
+      const originX = lArmUpper?.x ?? lArmLower.x;
       withBranchMirror(ctx, originX, lArmMirror, ()=> {
         drawBoneSprite(ctx, assets.arm_L_lower, lArmLower, 'arm_L_lower', style, offsets);
       });
@@ -508,7 +506,7 @@ export function renderSprites(ctx){
   const rArmMirror = getMirror('ARM_R_UPPER') || getMirror('ARM_R_LOWER');
   if (rArmUpper) {
     enqueue('ARM_R_UPPER', ()=> {
-      const originX = rArmUpper.x ?? 0;
+      const originX = rArmUpper.x;
       withBranchMirror(ctx, originX, rArmMirror, ()=> {
         drawBoneSprite(ctx, assets.arm_R_upper, rArmUpper, 'arm_R_upper', style, offsets);
       });
@@ -516,7 +514,7 @@ export function renderSprites(ctx){
   }
   if (rArmLower) {
     enqueue('ARM_R_LOWER', ()=> {
-      const originX = (rArmUpper?.x ?? rArmLower.x) ?? 0;
+      const originX = rArmUpper?.x ?? rArmLower.x;
       withBranchMirror(ctx, originX, rArmMirror, ()=> {
         drawBoneSprite(ctx, assets.arm_R_lower, rArmLower, 'arm_R_lower', style, offsets);
       });
@@ -529,7 +527,7 @@ export function renderSprites(ctx){
   const lLegMirror = getMirror('LEG_L_UPPER') || getMirror('LEG_L_LOWER');
   if (lLegUpper) {
     enqueue('LEG_L_UPPER', ()=> {
-      const originX = lLegUpper.x ?? 0;
+      const originX = lLegUpper.x;
       withBranchMirror(ctx, originX, lLegMirror, ()=> {
         drawBoneSprite(ctx, assets.leg_L_upper, lLegUpper, 'leg_L_upper', style, offsets);
       });
@@ -537,7 +535,7 @@ export function renderSprites(ctx){
   }
   if (lLegLower) {
     enqueue('LEG_L_LOWER', ()=> {
-      const originX = (lLegUpper?.x ?? lLegLower.x) ?? 0;
+      const originX = lLegUpper?.x ?? lLegLower.x;
       withBranchMirror(ctx, originX, lLegMirror, ()=> {
         drawBoneSprite(ctx, assets.leg_L_lower, lLegLower, 'leg_L_lower', style, offsets);
       });
@@ -550,7 +548,7 @@ export function renderSprites(ctx){
   const rLegMirror = getMirror('LEG_R_UPPER') || getMirror('LEG_R_LOWER');
   if (rLegUpper) {
     enqueue('LEG_R_UPPER', ()=> {
-      const originX = rLegUpper.x ?? 0;
+      const originX = rLegUpper.x;
       withBranchMirror(ctx, originX, rLegMirror, ()=> {
         drawBoneSprite(ctx, assets.leg_R_upper, rLegUpper, 'leg_R_upper', style, offsets);
       });
@@ -558,7 +556,7 @@ export function renderSprites(ctx){
   }
   if (rLegLower) {
     enqueue('LEG_R_LOWER', ()=> {
-      const originX = (rLegUpper?.x ?? rLegLower.x) ?? 0;
+      const originX = rLegUpper?.x ?? rLegLower.x;
       withBranchMirror(ctx, originX, rLegMirror, ()=> {
         drawBoneSprite(ctx, assets.leg_R_lower, rLegLower, 'leg_R_lower', style, offsets);
       });

--- a/tests/debug-panel.test.js
+++ b/tests/debug-panel.test.js
@@ -70,7 +70,7 @@ describe('debug-panel.js module', () => {
   });
 
   it('includes bone order for display', () => {
-    const expectedBones = ['torso', 'head', 'eyes', 'arm_L_upper', 'arm_L_lower', 'arm_R_upper', 'arm_R_lower',
+    const expectedBones = ['torso', 'head', 'arm_L_upper', 'arm_L_lower', 'arm_R_upper', 'arm_R_lower',
                           'leg_L_upper', 'leg_L_lower', 'leg_R_upper', 'leg_R_lower'];
     for (const bone of expectedBones) {
       assert.ok(debugPanelSrc.includes(`'${bone}'`) || debugPanelSrc.includes(`"${bone}"`), 


### PR DESCRIPTION
## Summary
- revert the series of morning merge commits to restore the pre-3 AM EST state
- remove the head gaze configuration and collider mirroring updates introduced by those merges
- roll back physics scale overrides and sprite mirroring adjustments tied to the reverted work

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105fa20dbc83269191fa688536c805)