### PR TITLE
Externalize fighter cosmetic overrides to JSON profiles

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -140,6 +140,11 @@ const POSE_ANGLE_SUMMARY = {
 const FIGHTER_TLETINGAN = 'TLETINGAN';
 const FIGHTER_MAOAO_M = 'Mao-ao_M';
 
+const COSMETIC_PROFILE_SOURCES = {
+  [FIGHTER_TLETINGAN]: './config/fighter-offsets/TLETINGAN.json',
+  [FIGHTER_MAOAO_M]: './config/fighter-offsets/Mao-ao_M.json'
+};
+
 const COSMETIC_LIBRARY = {
   basic_headband: {
     slot: 'hat',
@@ -150,22 +155,12 @@ const COSMETIC_LIBRARY = {
     parts: {
       head: {
         image: {
-          url: 'https://i.imgur.com/WsKQ2Eo.png',
-          fighters: {
-            'Mao-ao_M': './assets/fightersprites/mao-ao-m/head.png'
-          }
+          url: 'https://i.imgur.com/WsKQ2Eo.png'
         },
         spriteStyle: {
           base: {
             xform: {
               head: { ax: -0.05, ay: -0.08, scaleX: 1.1, scaleY: 1.05 }
-            }
-          },
-          fighters: {
-            [FIGHTER_TLETINGAN]: {
-              xform: {
-                head: { ax: -0.12, ay: -0.15, scaleX: 1.2, scaleY: 1.1 }
-              }
             }
           }
         },
@@ -175,12 +170,6 @@ const COSMETIC_LIBRARY = {
             tl: { y: -0.1 },
             tr: { y: -0.1 },
             center: { y: -0.05 }
-          },
-          fighters: {
-            [FIGHTER_MAOAO_M]: {
-              units: 'percent',
-              center: { y: -0.02 }
-            }
           }
         }
       }
@@ -201,13 +190,6 @@ const COSMETIC_LIBRARY = {
           base: {
             xform: {
               torso: { ax: -0.5, ay: -0.15, scaleX: 3.8, scaleY: 4.7 }
-            }
-          },
-          fighters: {
-            [FIGHTER_MAOAO_M]: {
-              xform: {
-                torso: { ax: -0.05, scaleX: 1.6, scaleY: 1.8 }
-              }
             }
           }
         },
@@ -469,6 +451,9 @@ window.CONFIG = {
   },
 
   cosmeticLibrary: COSMETIC_LIBRARY,
+  cosmetics: {
+    profileSources: COSMETIC_PROFILE_SOURCES
+  },
 
   fighters: {
     TLETINGAN: {

--- a/docs/config/fighter-offsets/Mao-ao_M.json
+++ b/docs/config/fighter-offsets/Mao-ao_M.json
@@ -1,0 +1,26 @@
+{
+  "cosmetics": {
+    "basic_headband": {
+      "parts": {
+        "head": {
+          "image": { "url": "./assets/fightersprites/mao-ao-m/head.png" },
+          "warp": {
+            "units": "percent",
+            "center": { "y": -0.02 }
+          }
+        }
+      }
+    },
+    "layered_travel_cloak": {
+      "parts": {
+        "torso": {
+          "spriteStyle": {
+            "xform": {
+              "torso": { "ax": -0.05, "scaleX": 1.6, "scaleY": 1.8 }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/config/fighter-offsets/TLETINGAN.json
+++ b/docs/config/fighter-offsets/TLETINGAN.json
@@ -1,0 +1,15 @@
+{
+  "cosmetics": {
+    "basic_headband": {
+      "parts": {
+        "head": {
+          "spriteStyle": {
+            "xform": {
+              "head": { "ax": -0.12, "ay": -0.15, "scaleX": 1.2, "scaleY": 1.1 }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -212,6 +212,7 @@
 
   <!-- In-repo config served same-origin under /docs -->
   <script src="./config/config.js"></script>
+  <script type="module" src="./js/cosmetic-profiles.js?v=1"></script>
   <script type="module" src="./js/app.js?v=19"></script>
 </body>
 </html>

--- a/docs/js/cosmetic-profiles.js
+++ b/docs/js/cosmetic-profiles.js
@@ -1,0 +1,28 @@
+import { registerFighterCosmeticProfile } from './cosmetics.js?v=1';
+
+const ROOT = typeof window !== 'undefined' ? window : globalThis;
+const CONFIG = ROOT?.CONFIG || {};
+const sources = CONFIG.cosmetics?.profileSources || {};
+
+async function loadProfile(fighterName, url){
+  if (!fighterName || !url) return;
+  try {
+    const response = await fetch(url, { cache: 'no-cache' });
+    if (!response.ok){
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const data = await response.json();
+    registerFighterCosmeticProfile(fighterName, data);
+  } catch (err) {
+    console.warn(`[cosmetics] Failed to load profile for ${fighterName} from ${url}`, err);
+  }
+}
+
+const loadEntries = Object.entries(sources)
+  .filter(([fighterName, url]) => typeof fighterName === 'string' && typeof url === 'string' && url.length);
+
+if (typeof fetch !== 'function'){
+  console.warn('[cosmetics] Skipping fighter profile loading: fetch is unavailable in this environment');
+} else if (loadEntries.length){
+  await Promise.all(loadEntries.map(([fighterName, url]) => loadProfile(fighterName, url)));
+}


### PR DESCRIPTION
## Summary
- add per-fighter cosmetic offset JSON profiles and reference them from config
- load fighter cosmetic profiles at startup and merge overrides when resolving layers
- wire the loader into the docs site so cosmetics continue to hydrate before rendering

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910afb7d3bc832681bae15c652a30bc)