### PR TITLE
Restore touch controls parity with V2

### DIFF
--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -1081,6 +1081,18 @@ function makeCombat(G, C){
     p.pos.x += p.vel.x * dt;
   }
 
+  function isPlayerAttacking(){
+    return !!ATTACK.active;
+  }
+
+  function isPlayerCharging(){
+    return !!CHARGE.active;
+  }
+
+  function isPlayerBusy(){
+    return ATTACK.active || CHARGE.active;
+  }
+
   function tick(dt){
     handleButtons();
     updateCharge(dt);
@@ -1090,5 +1102,13 @@ function makeCombat(G, C){
     processQueue();
   }
 
-  return { tick, slotDown, slotUp, updateSlotAssignments };
+  return {
+    tick,
+    slotDown,
+    slotUp,
+    updateSlotAssignments,
+    isPlayerAttacking,
+    isPlayerCharging,
+    isPlayerBusy
+  };
 }

--- a/docs/js/touch-controls.js
+++ b/docs/js/touch-controls.js
@@ -4,209 +4,223 @@
 export function initTouchControls(){
   const G = window.GAME || {};
   if (!G.JOYSTICK || !G.AIMING) return;
-  
+
+  const input = G.input || null;
+  if (!input){
+    console.warn('[touch-controls] GAME.input missing – ensure initControls() runs first');
+    return;
+  }
+
+  const JOY = G.JOYSTICK;
+  JOY.maxDistance = JOY.maxDistance || 50;
+
   const joystickArea = document.getElementById('joystickArea');
   const joystickStick = document.getElementById('joystickStick');
   const btnJump = document.getElementById('btnJump');
   const btnAttackA = document.getElementById('btnAttackA');
   const btnAttackB = document.getElementById('btnAttackB');
   const btnInteract = document.getElementById('btnInteract');
-  
+
   if (!joystickArea || !joystickStick) {
     console.warn('[touch-controls] Joystick elements not found');
     return;
   }
-  
-  // === Joystick Handlers ===
-  
-  function updateJoystickPosition(){
-    let dx = G.JOYSTICK.currentX - G.JOYSTICK.startX;
-    let dy = G.JOYSTICK.currentY - G.JOYSTICK.startY;
-    
-    const maxDistance = 40; // Max stick travel in pixels
-    const distance = Math.sqrt(dx * dx + dy * dy);
-    
-    if (distance > maxDistance){
-      dx = (dx / distance) * maxDistance;
-      dy = (dy / distance) * maxDistance;
+
+  const now = () => performance.now();
+
+  function isPlayerBusy(){
+    if (typeof G.combat?.isPlayerBusy === 'function'){
+      try { return !!G.combat.isPlayerBusy(); }
+      catch(err){ console.warn('[touch-controls] combat.isPlayerBusy threw', err); }
     }
-    
-    G.JOYSTICK.deltaX = dx;
-    G.JOYSTICK.deltaY = dy;
-    G.JOYSTICK.distance = Math.min(distance, maxDistance);
-    G.JOYSTICK.angle = Math.atan2(dy, dx);
-    
-    updateJoystickVisual();
-    processJoystickInput();
+    const player = G.FIGHTERS?.player;
+    return !!player?.attack?.active;
   }
-  
+
+  function clearHorizontalInput(){
+    input.left = false;
+    input.right = false;
+  }
+
   function updateJoystickVisual(){
     if (!joystickStick) return;
-    
-    if (G.JOYSTICK.active){
-      joystickStick.style.transform = `translate(calc(-50% + ${G.JOYSTICK.deltaX}px), calc(-50% + ${G.JOYSTICK.deltaY}px))`;
+    if (JOY.active){
       joystickStick.classList.add('active');
+      joystickStick.style.transform = `translate(calc(-50% + ${JOY.deltaX}px), calc(-50% + ${JOY.deltaY}px))`;
     } else {
-      joystickStick.style.transform = 'translate(-50%, -50%)';
       joystickStick.classList.remove('active');
+      joystickStick.style.transform = 'translate(-50%, -50%)';
     }
   }
-  
-  function processJoystickInput(){
-    const MOVE = G.FIGHTERS?.player?.move;
-    if (!MOVE) return;
-    
-    const deadzone = 0.2;
-    const normalized = G.JOYSTICK.distance / 40; // Normalize to 0-1
-    const angle = G.JOYSTICK.angle;
-    
-    const horizontalStrength = Math.cos(angle) * normalized;
-    
-    // Movement input
-    if (horizontalStrength > deadzone){
-      MOVE.input.right = true;
-      MOVE.input.left = false;
-    } else if (horizontalStrength < -deadzone){
-      MOVE.input.left = true;
-      MOVE.input.right = false;
-    } else {
-      MOVE.input.left = false;
-      MOVE.input.right = false;
-    }
-    
-    // Aiming - update facing direction based on joystick
-    if (normalized > 0.3){ // Require significant input for aiming
+
+  function applyAim(normalized, angle){
+    if (normalized > 0.3){
       G.AIMING.manualAim = true;
       G.AIMING.targetAngle = angle;
-    } else {
+    } else if (!JOY.active || normalized < 0.3){
       G.AIMING.manualAim = false;
     }
   }
-  
-  function handleJoystickStart(e){
-    e.preventDefault();
-    G.JOYSTICK.active = true;
-    
-    const rect = joystickArea.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-    
-    G.JOYSTICK.startX = centerX;
-    G.JOYSTICK.startY = centerY;
-    
-    const touch = e.touches ? e.touches[0] : e;
-    G.JOYSTICK.currentX = touch.clientX;
-    G.JOYSTICK.currentY = touch.clientY;
-    
-    updateJoystickPosition();
-  }
-  
-  function handleJoystickMove(e){
-    if (!G.JOYSTICK.active) return;
-    e.preventDefault();
-    
-    const touch = e.touches ? e.touches[0] : e;
-    G.JOYSTICK.currentX = touch.clientX;
-    G.JOYSTICK.currentY = touch.clientY;
-    
-    updateJoystickPosition();
-  }
-  
-  function handleJoystickEnd(e){
-    e.preventDefault();
-    G.JOYSTICK.active = false;
-    G.JOYSTICK.deltaX = 0;
-    G.JOYSTICK.deltaY = 0;
-    G.JOYSTICK.distance = 0;
-    G.AIMING.manualAim = false;
-    
-    const MOVE = G.FIGHTERS?.player?.move;
-    if (MOVE){
-      MOVE.input.left = false;
-      MOVE.input.right = false;
+
+  function processJoystickInput(){
+    const maxDistance = JOY.maxDistance || 50;
+    const normalized = JOY.active ? Math.min(1, JOY.distance / maxDistance) : 0;
+    const angle = JOY.angle || 0;
+    const horizontalStrength = Math.cos(angle) * normalized;
+    const deadzone = 0.15;
+
+    if (!JOY.active){
+      clearHorizontalInput();
+      applyAim(0, angle);
+      return;
     }
-    
+
+    if (isPlayerBusy()){
+      clearHorizontalInput();
+      applyAim(normalized, angle);
+      return;
+    }
+
+    if (normalized < deadzone){
+      clearHorizontalInput();
+    } else if (horizontalStrength > deadzone){
+      input.right = true;
+      input.left = false;
+    } else if (horizontalStrength < -deadzone){
+      input.left = true;
+      input.right = false;
+    } else {
+      clearHorizontalInput();
+    }
+
+    applyAim(normalized, angle);
+  }
+
+  function updateJoystickPosition(){
+    let dx = JOY.currentX - JOY.startX;
+    let dy = JOY.currentY - JOY.startY;
+
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    const maxDistance = JOY.maxDistance || 50;
+
+    if (distance > maxDistance){
+      const scale = maxDistance / distance;
+      dx *= scale;
+      dy *= scale;
+    }
+
+    JOY.deltaX = dx;
+    JOY.deltaY = dy;
+    JOY.distance = Math.min(distance, maxDistance);
+    JOY.angle = Math.atan2(dy, dx);
+
     updateJoystickVisual();
     processJoystickInput();
   }
-  
-  // Attach joystick event listeners
+
+  function handleJoystickStart(e){
+    e.preventDefault();
+    JOY.active = true;
+
+    const rect = joystickArea.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+
+    JOY.startX = centerX;
+    JOY.startY = centerY;
+
+    const touch = e.touches ? e.touches[0] : e;
+    JOY.currentX = touch.clientX;
+    JOY.currentY = touch.clientY;
+
+    updateJoystickPosition();
+  }
+
+  function handleJoystickMove(e){
+    if (!JOY.active) return;
+    e.preventDefault();
+
+    const touch = e.touches ? e.touches[0] : e;
+    JOY.currentX = touch.clientX;
+    JOY.currentY = touch.clientY;
+
+    updateJoystickPosition();
+  }
+
+  function handleJoystickEnd(e){
+    e && e.preventDefault();
+    JOY.active = false;
+    JOY.deltaX = 0;
+    JOY.deltaY = 0;
+    JOY.distance = 0;
+    JOY.angle = 0;
+
+    clearHorizontalInput();
+    G.AIMING.manualAim = false;
+
+    updateJoystickVisual();
+    processJoystickInput();
+  }
+
   joystickArea.addEventListener('touchstart', handleJoystickStart, { passive: false });
   joystickArea.addEventListener('touchmove', handleJoystickMove, { passive: false });
   joystickArea.addEventListener('touchend', handleJoystickEnd, { passive: false });
   joystickArea.addEventListener('touchcancel', handleJoystickEnd, { passive: false });
-  
-  // Also support mouse for testing on desktop
   joystickArea.addEventListener('mousedown', handleJoystickStart);
   document.addEventListener('mousemove', handleJoystickMove);
   document.addEventListener('mouseup', handleJoystickEnd);
-  
-  // === Touch Button Handlers ===
-  
-  function handleTouchButton(button, action){
-    if (!G.combat) return;
-    
-    switch(button){
-      case 'A':
-        if (action === 'down') G.combat.slotDown('A');
-        else G.combat.slotUp('A');
-        break;
-      case 'B':
-        if (action === 'down') G.combat.slotDown('B');
-        else G.combat.slotUp('B');
-        break;
-      case 'jump':
-        if (action === 'down'){
-          const P = G.FIGHTERS?.player;
-          if (P) P.input.jump = true;
-        }
-        break;
-      case 'interact':
-        if (action === 'down'){
-          // Trigger interact (E key equivalent)
-          const event = new KeyboardEvent('keydown', { code: 'KeyE', key: 'e' });
-          window.dispatchEvent(event);
-        }
-        break;
+
+  function setButtonState(buttonKey, down){
+    const state = input[buttonKey];
+    if (!state) return;
+    const wasDown = !!state.down;
+    if (down){
+      state.down = true;
+      if (!wasDown) state.downTime = now();
+    } else {
+      if (wasDown){
+        state.down = false;
+        state.upTime = now();
+      }
     }
   }
-  
-  // Attach button listeners
-  if (btnAttackA){
-    btnAttackA.addEventListener('touchstart', (e) => {
+
+  function bindHold(btn, onDown, onUp){
+    if (!btn) return;
+    const start = (e)=>{
       e.preventDefault();
-      handleTouchButton('A', 'down');
-    }, { passive: false });
-    btnAttackA.addEventListener('touchend', (e) => {
-      e.preventDefault();
-      handleTouchButton('A', 'up');
-    }, { passive: false });
+      btn.classList.add('active');
+      onDown();
+    };
+    const end = (e)=>{
+      if (e) e.preventDefault();
+      btn.classList.remove('active');
+      onUp();
+    };
+    btn.addEventListener('pointerdown', start);
+    btn.addEventListener('pointerup', end);
+    btn.addEventListener('pointercancel', end);
+    btn.addEventListener('pointerleave', end);
+    btn.addEventListener('touchstart', start, { passive: false });
+    btn.addEventListener('touchend', end, { passive: false });
   }
-  
-  if (btnAttackB){
-    btnAttackB.addEventListener('touchstart', (e) => {
-      e.preventDefault();
-      handleTouchButton('B', 'down');
-    }, { passive: false });
-    btnAttackB.addEventListener('touchend', (e) => {
-      e.preventDefault();
-      handleTouchButton('B', 'up');
-    }, { passive: false });
+
+  function dispatchKey(code, type){
+    const key = code.startsWith('Key') ? code.slice(3).toLowerCase() : code;
+    const evt = new KeyboardEvent(type, { code, key, bubbles: true, cancelable: true });
+    window.dispatchEvent(evt);
   }
-  
+
+  bindHold(btnAttackA, () => setButtonState('buttonA', true), () => setButtonState('buttonA', false));
+  bindHold(btnAttackB, () => setButtonState('buttonB', true), () => setButtonState('buttonB', false));
+
   if (btnJump){
-    btnJump.addEventListener('touchstart', (e) => {
-      e.preventDefault();
-      handleTouchButton('jump', 'down');
-    }, { passive: false });
+    bindHold(btnJump, () => { input.jump = true; }, () => { input.jump = false; });
   }
-  
+
   if (btnInteract){
-    btnInteract.addEventListener('touchstart', (e) => {
-      e.preventDefault();
-      handleTouchButton('interact', 'down');
-    }, { passive: false });
+    bindHold(btnInteract, () => dispatchKey('KeyE', 'keydown'), () => dispatchKey('KeyE', 'keyup'));
   }
-  
+
   console.log('[touch-controls] Initialized');
 }


### PR DESCRIPTION
## Summary
- route virtual joystick movement through `GAME.input` and restore attack/aim gating behaviour from the V2 monolith
- add pointer-friendly button bindings plus keyboard-event mirroring so touch actions feed the modular combat system
- expose combat helpers to report attack/charge status for touch controls to query

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ca992bc88326a6d02b0cdebf9ae0)