### PR TITLE
Restore camera follow from monolith and align sprite rendering

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1117,7 +1117,7 @@ function loop(t){
   if (window.GAME?.combat) window.GAME.combat.tick(dt);
   updatePhysics(dt);
   updatePoses();
-  updateCamera(cv);
+  updateCamera(cv, dt);
   drawStage();
   renderAll(cx);
   renderSprites(cx);

--- a/docs/js/camera.js
+++ b/docs/js/camera.js
@@ -1,12 +1,87 @@
-// camera.js — simple x-follow camera with smoothing
-export function updateCamera(canvas){
+// camera.js — modular camera follow (ported from Ancient Code-Monolith V2)
+// Smoothly tracks the player, clamps to world bounds, and keeps a legacy
+// `window.CAMERA` alias so older helpers continue to function.
+
+const DEFAULT_VIEW_WIDTH = 720;
+const DEFAULT_WORLD_WIDTH = 1600;
+
+function clamp(v, lo, hi){
+  if (lo > hi) return lo;
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function ensureCameraState(){
+  const G = (window.GAME ||= {});
+  const C = window.CONFIG || {};
+  const cam = (G.CAMERA ||= {});
+  if (!Number.isFinite(cam.x)) cam.x = 0;
+  if (!Number.isFinite(cam.targetX)) cam.targetX = cam.x;
+  const cfg = C.camera || {};
+  if (!Number.isFinite(cam.worldWidth)){
+    cam.worldWidth = C.world?.width || cfg.worldWidth || DEFAULT_WORLD_WIDTH;
+  }
+  if (!Number.isFinite(cam.smoothing)){
+    cam.smoothing = cfg.smoothing ?? 0.15;
+  }
+  if (!Number.isFinite(cam.lookAhead)){
+    cam.lookAhead = cfg.lookAhead ?? 0;
+  }
+  if (!Number.isFinite(cam.deadZone)){
+    cam.deadZone = cfg.deadZone ?? 0;
+  }
+  // Maintain backwards-compatible global alias
+  const legacy = (window.CAMERA ||= {});
+  legacy.worldWidth = cam.worldWidth;
+  legacy.smoothing = cam.smoothing;
+  if (!Number.isFinite(legacy.x)) legacy.x = cam.x;
+  if (!Number.isFinite(legacy.targetX)) legacy.targetX = cam.targetX;
+  legacy.lookAhead = cam.lookAhead;
+  legacy.deadZone = cam.deadZone;
+  return cam;
+}
+
+function computeSmoothingFactor(base, dt){
+  // Convert frame-rate dependent factor into time-based easing.
+  // Matches legacy behavior at 60fps when dt ≈ 1/60.
+  const coeff = Number.isFinite(base) ? Math.max(0, base) : 0.15;
+  const delta = Math.max(0, dt || 0);
+  return 1 - Math.exp(-coeff * (delta * 60 || 1));
+}
+
+export function updateCamera(canvas, dt){
   const G = window.GAME || {};
   const C = window.CONFIG || {};
-  if (!G.FIGHTERS || !G.CAMERA) return;
-  const P = G.FIGHTERS.player; if (!P) return;
-  const w = canvas?.width || (C.canvas?.w || 720);
-  const worldW = G.CAMERA.worldWidth || 1600;
-  const target = Math.max(0, Math.min(worldW - w, P.pos.x - w*0.5));
-  const k = G.CAMERA.smoothing ?? 0.15;
-  G.CAMERA.x = (G.CAMERA.x||0) + (target - (G.CAMERA.x||0)) * k;
+  if (!G.FIGHTERS) return;
+  const cam = ensureCameraState();
+  const player = G.FIGHTERS.player;
+  if (!player || !player.pos) return;
+
+  const viewW = canvas?.width || C.canvas?.w || DEFAULT_VIEW_WIDTH;
+  const worldW = Math.max(viewW, cam.worldWidth || DEFAULT_WORLD_WIDTH);
+
+  let target = player.pos.x - viewW * 0.5;
+  if (Number.isFinite(cam.lookAhead) && cam.lookAhead !== 0){
+    const velX = player.vel?.x || 0;
+    target += velX * cam.lookAhead;
+  }
+  target = clamp(target, 0, worldW - viewW);
+
+  if (cam.deadZone > 0){
+    const half = cam.deadZone * 0.5;
+    const camLeft = cam.x + viewW * 0.5 - half;
+    const camRight = cam.x + viewW * 0.5 + half;
+    const playerX = player.pos.x;
+    if (playerX > camLeft && playerX < camRight){
+      target = cam.targetX;
+    }
+  }
+
+  cam.targetX = target;
+  const smoothing = computeSmoothingFactor(cam.smoothing, dt);
+  cam.x += (target - cam.x) * smoothing;
+
+  const legacy = (window.CAMERA ||= {});
+  legacy.x = cam.x;
+  legacy.targetX = target;
+  legacy.worldWidth = worldW;
 }

--- a/docs/js/physics.js
+++ b/docs/js/physics.js
@@ -50,9 +50,16 @@ function ensureCamera(C){
     G.CAMERA = {
       x: 0,
       worldWidth: C.world?.width || defaultWorld,
-      smoothing: 0.15
+      smoothing: 0.15,
+      lookAhead: 0,
+      deadZone: 0
     };
-    return;
+  }
+  if (!Number.isFinite(G.CAMERA.x)){
+    G.CAMERA.x = 0;
+  }
+  if (!Number.isFinite(G.CAMERA.targetX)){
+    G.CAMERA.targetX = G.CAMERA.x;
   }
   if (!Number.isFinite(G.CAMERA.worldWidth)){
     G.CAMERA.worldWidth = C.world?.width || defaultWorld;
@@ -60,6 +67,19 @@ function ensureCamera(C){
   if (!Number.isFinite(G.CAMERA.smoothing)){
     G.CAMERA.smoothing = 0.15;
   }
+  if (!Number.isFinite(G.CAMERA.lookAhead)){
+    G.CAMERA.lookAhead = 0;
+  }
+  if (!Number.isFinite(G.CAMERA.deadZone)){
+    G.CAMERA.deadZone = 0;
+  }
+  const legacy = (window.CAMERA ||= {});
+  legacy.x = G.CAMERA.x;
+  legacy.targetX = G.CAMERA.targetX;
+  legacy.worldWidth = G.CAMERA.worldWidth;
+  legacy.smoothing = G.CAMERA.smoothing;
+  legacy.lookAhead = G.CAMERA.lookAhead;
+  legacy.deadZone = G.CAMERA.deadZone;
 }
 
 function ensureFighterState(fighter, C){

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -445,7 +445,12 @@ export function renderSprites(ctx){
   const entity = (fname === 'player' || fname === 'npc') ? fname : 'player';
   const flipLeft = G.FLIP_STATE?.[entity] || false;
   const centerX = rig.center?.x ?? 0;
-  
+
+  const camX = G.CAMERA?.x || 0;
+
+  ctx.save();
+  ctx.translate(-camX, 0);
+
   ctx.save();
   // Mirror around character center when facing left (matching reference HTML exactly)
   if (flipLeft) {
@@ -454,7 +459,7 @@ export function renderSprites(ctx){
   }
 
   // RENDER.MIRROR flags control per-limb mirroring (e.g., for attack animations)
-  
+
   const { assets, style, offsets, cosmetics } = ensureFighterSprites(C, fname);
 
   const zOf = buildZMap(C);
@@ -583,14 +588,15 @@ export function renderSprites(ctx){
   }
 
   queue.sort((a, b) => a.z - b.z);
-  
+
   for (const entry of queue){
     if (typeof entry?.drawFn === 'function'){
       entry.drawFn();
     }
   }
-  
-  ctx.restore(); // Restore canvas state (undo flip if applied)
+
+  ctx.restore(); // undo flip mirror transform
+  ctx.restore(); // undo camera translation
 }
 
 export function initSprites(){


### PR DESCRIPTION
## Summary
- port the monolith v2 camera follow logic with smoothing, optional look-ahead, and a legacy window.CAMERA alias
- drive the camera with frame delta time and translate sprite rendering by the active camera offset

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910481a76d483269d03ceddfaa87a87)