### PR TITLE
feat: add configurable head tracking offsets

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -363,6 +363,10 @@ window.CONFIG = {
     head: { relMin: -75, relMax: 75 }
   },
 
+  headTracking: {
+    offsetDeg: 0
+  },
+
   poses: {
     Stance: deepClone(BASE_POSES.Stance),
     Windup: deepClone(BASE_POSES.Windup),
@@ -396,6 +400,9 @@ window.CONFIG = {
           hip: { absMin:90, absMax:210 },
           knee: { relMin:0, relMax:170 },
           head: { relMin:-75, relMax:75 }
+        },
+        headTracking: {
+          offsetDeg: 0
         },
       offsets: {
         torso: { origin:{ax:0, ay:0}, shoulder:{ax:-8, ay:-5}, hip:{ax:0, ay:0}, neck:{ax:0, ay:0} },
@@ -435,6 +442,9 @@ window.CONFIG = {
       hierarchy: { legsFollowTorsoRotation: false },
       ik: { calvesOnly: true },
       limits: { torso:{ absMin:-45, absMax:90 }, shoulder:{ relMin:-360, relMax:-90 }, elbow:{ relMin:-170, relMax:0 }, hip:{ absMin:90, absMax:210 }, knee:{ relMin:0, relMax:170 }, head:{ relMin:-75, relMax:75 } },
+      headTracking: {
+        offsetDeg: 0
+      },
       offsets: {
         torso: { origin:{ax:0, ay:0}, shoulder:{ax:-8, ay:-5}, hip:{ax:0, ay:0}, neck:{ax:0, ay:0} },
         arm: { upper:{ origin:{ax:0, ay:0}, elbow:{ax:0, ay:0} }, lower:{ origin:{ax:0, ay:0} } },

--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -217,7 +217,12 @@ function computeHeadTargetDeg(F, finalPoseDeg, fcfg){
   const { min, max } = getHeadLimitsRad(C, fcfg);
   const relative = normalizeRad(desiredWorld - torsoRad);
   const clamped = clamp(relative, min, max);
-  const headRad = torsoRad + clamped;
+  const fighterOffsetDeg = fcfg?.headTracking?.offsetDeg;
+  const globalOffsetDeg = C.headTracking?.offsetDeg;
+  const offsetDeg = Number.isFinite(fighterOffsetDeg)
+    ? fighterOffsetDeg
+    : (Number.isFinite(globalOffsetDeg) ? globalOffsetDeg : 0);
+  const headRad = torsoRad + clamped + degToRad(offsetDeg);
   return radToDegNum(headRad);
 }
 


### PR DESCRIPTION
## Summary
- add a global headTracking offset configuration and fighter overrides
- apply the configured offset when computing aimed head rotation

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f80ed63c8326879ee820be0058f0)