### PR TITLE
Fix cosmetic HSV handling and limb mirroring

### DIFF
--- a/docs/js/cosmetics.js
+++ b/docs/js/cosmetics.js
@@ -159,18 +159,37 @@ export function registerCosmeticLibrary(library = {}){
   return STATE.library;
 }
 
+function coerceNumber(value){
+  if (Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim().length){
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return Number.NaN;
+}
+
 function clamp(value, min, max){
-  if (!Number.isFinite(value)) return min;
-  return Math.min(Math.max(value, min), max);
+  const num = coerceNumber(value);
+  const lo = Number.isFinite(min) ? min : Number.NEGATIVE_INFINITY;
+  const hi = Number.isFinite(max) ? max : Number.POSITIVE_INFINITY;
+  if (!Number.isFinite(num)){
+    if (Number.isFinite(min)) return min;
+    if (Number.isFinite(max)) return max;
+    return 0;
+  }
+  return Math.min(Math.max(num, lo), hi);
 }
 
 function clampHSV(input = {}, cosmetic){
   const defaults = cosmetic?.hsv?.defaults || { h:0, s:0, v:0 };
   const limits = cosmetic?.hsv?.limits || {};
+  const source = Array.isArray(input)
+    ? { h: input[0], s: input[1], v: input[2] }
+    : (input && typeof input === 'object' ? input : {});
   return {
-    h: clamp(input.h ?? defaults.h ?? 0, limits.h?.[0] ?? -180, limits.h?.[1] ?? 180),
-    s: clamp(input.s ?? defaults.s ?? 0, limits.s?.[0] ?? -1, limits.s?.[1] ?? 1),
-    v: clamp(input.v ?? defaults.v ?? 0, limits.v?.[0] ?? -1, limits.v?.[1] ?? 1)
+    h: clamp(source.h ?? defaults.h ?? 0, limits.h?.[0] ?? -180, limits.h?.[1] ?? 180),
+    s: clamp(source.s ?? defaults.s ?? 0, limits.s?.[0] ?? -1, limits.s?.[1] ?? 1),
+    v: clamp(source.v ?? defaults.v ?? 0, limits.v?.[0] ?? -1, limits.v?.[1] ?? 1)
   };
 }
 

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -71,10 +71,43 @@ test('ensureCosmeticLayers resolves equipment with HSV limits applied', () => {
   strictEqual(typeof layers[0].styleOverride, 'object');
 });
 
+test('ensureCosmeticLayers normalizes hsv arrays and string values', () => {
+  clearCosmeticCache();
+  const config = {
+    cosmeticLibrary: {
+      demo_item: {
+        slot: 'hat',
+        hsv: {
+          defaults: { h: 10, s: 0.1, v: -0.1 },
+          limits: { h: [-45, 45], s: [-0.5, 0.5], v: [-0.5, 0.5] }
+        },
+        parts: {
+          head: {
+            image: { url: 'https://example.com/head.png' }
+          }
+        }
+      }
+    },
+    fighters: {
+      hero: {
+        cosmetics: {
+          slots: {
+            hat: { id: 'demo_item', hsv: ['30', '0.4', '-0.2'] }
+          }
+        }
+      }
+    }
+  };
+  const layers = ensureCosmeticLayers(config, 'hero', {});
+  strictEqual(layers.length, 1);
+  deepStrictEqual(layers[0].hsv, { h: 30, s: 0.4, v: -0.2 });
+});
+
 test('sprites.js integrates cosmetic layers and z-order expansion', () => {
   const spritesContent = readFileSync(new URL('../docs/js/sprites.js', import.meta.url), 'utf8');
   strictEqual(/expanded\.push\(cosmeticTagFor\(tag, slot\)\);/.test(spritesContent), true, 'buildZMap should add cosmetic tags');
   strictEqual(/const \{ assets, style, offsets, cosmetics } = ensureFighterSprites/.test(spritesContent), true, 'renderSprites should read cosmetics');
+  strictEqual(/withBranchMirror\(ctx,\s*originX,\s*mirror,\s*\(\)\s*=>\s*\{\s*drawBoneSprite\(ctx, layer\.asset, bone, styleKey/.test(spritesContent), true, 'cosmetic layers should mirror with their limbs');
 });
 
 test('config references cosmetic library sources and fighter slot data', () => {


### PR DESCRIPTION
## Summary
- normalize cosmetic HSV inputs so array and string values still tint sprites
- mirror cosmetic layers together with their limbs when branch flips are active
- extend cosmetic tests to cover HSV coercion and the new mirroring hook

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110a783f788326809ad74a400da9e4)