### PR TITLE
Stop resetting joystick aim on release

### DIFF
--- a/docs/js/touch-controls.js
+++ b/docs/js/touch-controls.js
@@ -71,7 +71,6 @@ export function initTouchControls(){
 
     if (!JOY.active){
       clearHorizontalInput();
-      applyAim(0, angle);
       return;
     }
 
@@ -153,7 +152,6 @@ export function initTouchControls(){
     JOY.deltaX = 0;
     JOY.deltaY = 0;
     JOY.distance = 0;
-    JOY.angle = 0;
 
     clearHorizontalInput();
     G.AIMING.manualAim = false;


### PR DESCRIPTION
## Summary
- prevent touch joystick release from overwriting the stored aim angle
- avoid forcing applyAim when the joystick is inactive so the last angle persists

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110a0d1bf08326a38d860ae406cdf8)