### PR TITLE
Fix head aim orientation

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -1,5 +1,5 @@
 // animator.js — restore basic idle/walk posing; robust speed detection; override TTL required
-import { degToRad, radToDegNum } from './math-utils.js?v=1';
+import { degToRad, radToDegNum, angleFromDelta } from './math-utils.js?v=1';
 import { setMirrorForPart, resetMirror } from './sprites.js?v=1';
 import { pickFighterConfig, pickFighterName } from './fighter-utils.js?v=1';
 import { getFaceLock } from './face-lock.js?v=1';
@@ -344,7 +344,14 @@ function updateAiming(F, currentPose, fighterId){
     F.aim.hipOffset = 0;
   }
 
-  F.aim.headWorldTarget = (F.aim.currentAngle || 0) + facingRad;
+  const worldAimStandard = (F.aim.currentAngle || 0) + facingRad;
+  if (Number.isFinite(worldAimStandard)) {
+    const dirX = Math.cos(worldAimStandard);
+    const dirY = Math.sin(worldAimStandard);
+    F.aim.headWorldTarget = angleFromDelta(dirX, dirY);
+  } else {
+    F.aim.headWorldTarget = null;
+  }
 }
 
 // Apply aiming offsets to a pose


### PR DESCRIPTION
## Summary
- convert the stored head aiming angle into the render coordinate system so the neck tracks the target correctly
- handle invalid aim angles by clearing the head target instead of leaving stale data

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69111ecf332083268d5758c723609d77)