### PR TITLE
Add HSV tinting pipeline for cosmetic sprites

### DIFF
--- a/docs/js/cosmetics.js
+++ b/docs/js/cosmetics.js
@@ -159,18 +159,37 @@ export function registerCosmeticLibrary(library = {}){
   return STATE.library;
 }
 
+function coerceNumber(value){
+  if (Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim().length){
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return Number.NaN;
+}
+
 function clamp(value, min, max){
-  if (!Number.isFinite(value)) return min;
-  return Math.min(Math.max(value, min), max);
+  const num = coerceNumber(value);
+  const lo = Number.isFinite(min) ? min : Number.NEGATIVE_INFINITY;
+  const hi = Number.isFinite(max) ? max : Number.POSITIVE_INFINITY;
+  if (!Number.isFinite(num)){
+    if (Number.isFinite(min)) return min;
+    if (Number.isFinite(max)) return max;
+    return 0;
+  }
+  return Math.min(Math.max(num, lo), hi);
 }
 
 function clampHSV(input = {}, cosmetic){
   const defaults = cosmetic?.hsv?.defaults || { h:0, s:0, v:0 };
   const limits = cosmetic?.hsv?.limits || {};
+  const source = Array.isArray(input)
+    ? { h: input[0], s: input[1], v: input[2] }
+    : (input && typeof input === 'object' ? input : {});
   return {
-    h: clamp(input.h ?? defaults.h ?? 0, limits.h?.[0] ?? -180, limits.h?.[1] ?? 180),
-    s: clamp(input.s ?? defaults.s ?? 0, limits.s?.[0] ?? -1, limits.s?.[1] ?? 1),
-    v: clamp(input.v ?? defaults.v ?? 0, limits.v?.[0] ?? -1, limits.v?.[1] ?? 1)
+    h: clamp(source.h ?? defaults.h ?? 0, limits.h?.[0] ?? -180, limits.h?.[1] ?? 180),
+    s: clamp(source.s ?? defaults.s ?? 0, limits.s?.[0] ?? -1, limits.s?.[1] ?? 1),
+    v: clamp(source.v ?? defaults.v ?? 0, limits.v?.[0] ?? -1, limits.v?.[1] ?? 1)
   };
 }
 

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -21,6 +21,194 @@ const GLOB = (window.GAME ||= {});
 const RENDER = (window.RENDER ||= {});
 RENDER.MIRROR = RENDER.MIRROR || {}; // Initialize per-limb mirror flags
 
+const HSV_TINT_CACHE = new WeakMap();
+
+function hsvKey(hsv){
+  if (!hsv) return '0|0|0';
+  const h = Number.isFinite(hsv.h) ? hsv.h : 0;
+  const s = Number.isFinite(hsv.s) ? hsv.s : 0;
+  const v = Number.isFinite(hsv.v) ? hsv.v : 0;
+  return `${h.toFixed(4)}|${s.toFixed(4)}|${v.toFixed(4)}`;
+}
+
+function createTintCanvas(width, height){
+  if (typeof OffscreenCanvas === 'function'){
+    try {
+      const canvas = new OffscreenCanvas(width, height);
+      return canvas;
+    } catch (err) {
+      // Fall back to DOM canvas
+    }
+  }
+  if (typeof document !== 'undefined' && typeof document.createElement === 'function'){
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    return canvas;
+  }
+  return null;
+}
+
+function rgbToHsv(r, g, b){
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+  let h = 0;
+  if (delta){
+    switch(max){
+      case rn:
+        h = ((gn - bn) / delta) % 6;
+        break;
+      case gn:
+        h = (bn - rn) / delta + 2;
+        break;
+      default:
+        h = (rn - gn) / delta + 4;
+        break;
+    }
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+  const s = max === 0 ? 0 : delta / max;
+  const v = max;
+  return { h, s, v };
+}
+
+function hsvToRgb(h, s, v){
+  const c = v * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = v - c;
+  let r = 0, g = 0, b = 0;
+  if (h >= 0 && h < 60){
+    r = c; g = x; b = 0;
+  } else if (h >= 60 && h < 120){
+    r = x; g = c; b = 0;
+  } else if (h >= 120 && h < 180){
+    r = 0; g = c; b = x;
+  } else if (h >= 180 && h < 240){
+    r = 0; g = x; b = c;
+  } else if (h >= 240 && h < 300){
+    r = x; g = 0; b = c;
+  } else {
+    r = c; g = 0; b = x;
+  }
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255)
+  };
+}
+
+function tintImageWithHSV(img, hsv){
+  if (!img || img.__broken) return img;
+  if (!(Number.isFinite(img.naturalWidth) ? img.naturalWidth : img.width)) return img;
+  if (!hsv || (!Number.isFinite(hsv.h) && !Number.isFinite(hsv.s) && !Number.isFinite(hsv.v))){
+    return img;
+  }
+  if (!img.complete || (img.naturalWidth || img.width || 0) === 0 || (img.naturalHeight || img.height || 0) === 0){
+    return img;
+  }
+
+  const width = img.naturalWidth || img.width;
+  const height = img.naturalHeight || img.height;
+  if (!(width > 0 && height > 0)) return img;
+
+  const key = hsvKey(hsv);
+  let cacheForImage = HSV_TINT_CACHE.get(img);
+  if (!cacheForImage){
+    cacheForImage = new Map();
+    HSV_TINT_CACHE.set(img, cacheForImage);
+  }
+  if (cacheForImage.has(key)){
+    return cacheForImage.get(key);
+  }
+
+  const hueShift = Number.isFinite(hsv.h) ? hsv.h : 0;
+  const satFactor = Number.isFinite(hsv.s) ? Math.max(0, 1 + hsv.s) : 1;
+  const valFactor = Number.isFinite(hsv.v) ? Math.max(0, 1 + hsv.v) : 1;
+
+  if (hueShift === 0 && satFactor === 1 && valFactor === 1){
+    cacheForImage.set(key, img);
+    return img;
+  }
+
+  const canvas = createTintCanvas(width, height);
+  if (!canvas) {
+    cacheForImage.set(key, img);
+    return img;
+  }
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    cacheForImage.set(key, img);
+    return img;
+  }
+  ctx.clearRect(0, 0, width, height);
+  try {
+    ctx.drawImage(img, 0, 0, width, height);
+  } catch (err) {
+    cacheForImage.set(key, img);
+    return img;
+  }
+  let imageData;
+  try {
+    imageData = ctx.getImageData(0, 0, width, height);
+  } catch (err) {
+    cacheForImage.set(key, img);
+    return img;
+  }
+  const data = imageData.data;
+  for (let i = 0; i < data.length; i += 4){
+    const alpha = data[i + 3];
+    if (alpha === 0) continue;
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const { h, s, v } = rgbToHsv(r, g, b);
+    let newH = (h + hueShift) % 360;
+    if (newH < 0) newH += 360;
+    let newS = s * satFactor;
+    if (newS < 0) newS = 0;
+    if (newS > 1) newS = 1;
+    let newV = v * valFactor;
+    if (newV < 0) newV = 0;
+    if (newV > 1) newV = 1;
+    const { r: nr, g: ng, b: nb } = hsvToRgb(newH, newS, newV);
+    data[i] = nr;
+    data[i + 1] = ng;
+    data[i + 2] = nb;
+  }
+  ctx.putImageData(imageData, 0, 0);
+  cacheForImage.set(key, canvas);
+  return canvas;
+}
+
+function hasHsvAdjustments(hsv){
+  if (!hsv) return false;
+  return (Number.isFinite(hsv.h) && hsv.h !== 0)
+    || (Number.isFinite(hsv.s) && hsv.s !== 0)
+    || (Number.isFinite(hsv.v) && hsv.v !== 0);
+}
+
+function prepareImageForHSV(img, hsv){
+  if (!hasHsvAdjustments(hsv)){
+    return { image: img, applyFilter: false };
+  }
+  const tinted = tintImageWithHSV(img, hsv);
+  if (tinted && tinted !== img){
+    return { image: tinted, applyFilter: false };
+  }
+  return { image: img, applyFilter: true };
+}
+
+function imageDrawDimensions(img){
+  const width = img?.naturalWidth || img?.videoWidth || img?.width || 0;
+  const height = img?.naturalHeight || img?.videoHeight || img?.height || 0;
+  return { width, height };
+}
+
 // Legacy support: map old hideSprites to new RENDER_DEBUG
 if (typeof RENDER.hideSprites === 'boolean') {
   window.RENDER_DEBUG = window.RENDER_DEBUG || {};
@@ -167,6 +355,10 @@ function legMirrorFlag(side, tagU, tagL){
   return !!RENDER.MIRROR[tagU] || !!RENDER.MIRROR[tagL];
 }
 
+function getMirrorFlag(tag){
+  return !!RENDER.MIRROR[tag];
+}
+
 // Leg drawing uses branch mirroring, standard math
 function drawLegBranch(ctx, rig, side, assets, style, offsets, segment='both'){
   const upKey = side==='L' ? 'leg_L_upper':'leg_R_upper';
@@ -209,6 +401,39 @@ function withBranchMirror(ctx, originX, mirror, drawFn){
   }
   drawFn();
   ctx.restore();
+}
+
+function resolveCosmeticMirror(rig, partKey, bone){
+  const tag = tagOf(partKey);
+  const fallbackOrigin = bone?.x ?? 0;
+  switch (tag){
+    case 'ARM_L_UPPER':
+    case 'ARM_L_LOWER':
+      return {
+        mirror: getMirrorFlag('ARM_L_UPPER') || getMirrorFlag('ARM_L_LOWER'),
+        originX: rig?.arm_L_upper?.x ?? rig?.arm_L_lower?.x ?? fallbackOrigin
+      };
+    case 'ARM_R_UPPER':
+    case 'ARM_R_LOWER':
+      return {
+        mirror: getMirrorFlag('ARM_R_UPPER') || getMirrorFlag('ARM_R_LOWER'),
+        originX: rig?.arm_R_upper?.x ?? rig?.arm_R_lower?.x ?? fallbackOrigin
+      };
+    case 'LEG_L_UPPER':
+    case 'LEG_L_LOWER':
+      return {
+        mirror: getMirrorFlag('LEG_L_UPPER') || getMirrorFlag('LEG_L_LOWER'),
+        originX: rig?.leg_L_upper?.x ?? rig?.leg_L_lower?.x ?? fallbackOrigin
+      };
+    case 'LEG_R_UPPER':
+    case 'LEG_R_LOWER':
+      return {
+        mirror: getMirrorFlag('LEG_R_UPPER') || getMirrorFlag('LEG_R_LOWER'),
+        originX: rig?.leg_R_upper?.x ?? rig?.leg_R_lower?.x ?? fallbackOrigin
+      };
+    default:
+      return { mirror: getMirrorFlag(tag), originX: fallbackOrigin };
+  }
 }
 
 // Sprite rendering for bones, fixed math
@@ -271,12 +496,14 @@ function setTransformFromTriangle(ctx, srcTri, dstTri){
 }
 
 function drawWarpedImage(ctx, img, destPoints, w, h){
+  const { width: srcW, height: srcH } = imageDrawDimensions(img);
+  if (!(srcW > 0 && srcH > 0)) return;
   const srcPoints = {
-    center: [w / 2, h / 2],
+    center: [srcW / 2, srcH / 2],
     tl: [0, 0],
-    tr: [w, 0],
-    br: [w, h],
-    bl: [0, h]
+    tr: [srcW, 0],
+    br: [srcW, srcH],
+    bl: [0, srcH]
   };
   const triangles = [
     ['center', 'tl', 'tr'],
@@ -298,7 +525,7 @@ function drawWarpedImage(ctx, img, destPoints, w, h){
     ctx.closePath();
     ctx.clip();
     if (setTransformFromTriangle(ctx, srcTri, dstTri)){
-      ctx.drawImage(img, 0, 0, img.naturalWidth, img.naturalHeight, 0, 0, w, h);
+      ctx.drawImage(img, 0, 0, srcW, srcH, 0, 0, w, h);
     }
     ctx.restore();
   }
@@ -310,6 +537,9 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
   if (!img || img.__broken) return false;
   if (!img.complete) return false;
   if (!(img.naturalWidth > 0 && img.naturalHeight > 0)) return false;
+
+  const { image: renderImage, applyFilter } = prepareImageForHSV(img, options.hsv);
+  const sourceImage = renderImage || img;
 
   // Normalize styleKey: arm_L_upper -> armUpper, leg_R_lower -> legLower
   // Convert underscore format with optional side marker (L/R) to camelCase used by style configs
@@ -361,8 +591,8 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
   posY += offsetY;
 
   // Sizing
-  const nh = img.naturalHeight || img.height || 1;
-  const nw = img.naturalWidth  || img.width  || 1;
+  const nh = sourceImage.naturalHeight || sourceImage.height || 1;
+  const nw = sourceImage.naturalWidth  || sourceImage.width  || 1;
   const baseH = Math.max(1, bone.len);
   const wfTbl = effectiveStyle.widthFactor || {};
   const wf = (wfTbl[normalizedKey] ?? wfTbl[styleKey] ?? 1);
@@ -381,7 +611,10 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
     : (options.alignDeg != null ? degToRad(options.alignDeg) : (asset.alignRad ?? 0));
   const theta = bone.ang + alignRad + Math.PI;
 
-  const filter = buildFilterString(ctx.filter, options.hsv);
+  const originalFilter = ctx.filter;
+  const filter = applyFilter
+    ? buildFilterString(originalFilter, options.hsv)
+    : (originalFilter && originalFilter !== '' ? originalFilter : 'none');
   const warp = options.warp;
   ctx.save();
   ctx.filter = filter;
@@ -419,11 +652,11 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
       const ry = local.x * sinT + local.y * cosT;
       dest[key] = { x: posX + rx, y: posY + ry };
     }
-    drawWarpedImage(ctx, img, dest, w, h);
+    drawWarpedImage(ctx, sourceImage, dest, w, h);
   } else {
     ctx.translate(posX, posY);
     ctx.rotate(theta);
-    ctx.drawImage(img, -w/2, -h/2, w, h);
+    ctx.drawImage(sourceImage, -w/2, -h/2, w, h);
   }
   ctx.restore();
   return true;
@@ -462,7 +695,7 @@ export function renderSprites(ctx){
   function enqueue(tag, drawFn){ queue.push({ z: zOf(tag), tag, drawFn }); }
 
   // Helper to get mirror flag for a specific part
-  const getMirror = (tag) => !!RENDER.MIRROR[tag];
+  const getMirror = getMirrorFlag;
 
   // Hitbox (if desired)
   // enqueue('HITBOX', ()=> { /* draw hitbox if needed */ });
@@ -570,13 +803,16 @@ export function renderSprites(ctx){
       const baseTag = tagOf(layer.partKey);
       const slotTag = cosmeticTagFor(baseTag, layer.slot);
       const styleKey = layer.styleKey || layer.partKey;
+      const { mirror, originX } = resolveCosmeticMirror(rig, layer.partKey, bone);
       enqueue(slotTag, ()=>{
-        drawBoneSprite(ctx, layer.asset, bone, styleKey, style, offsets, {
-          styleOverride: layer.styleOverride,
-          hsv: layer.hsv,
-          warp: layer.warp,
-          alignRad: layer.alignRad,
-          alignDeg: layer.alignRad == null ? layer.alignDeg : undefined
+        withBranchMirror(ctx, originX, mirror, ()=>{
+          drawBoneSprite(ctx, layer.asset, bone, styleKey, style, offsets, {
+            styleOverride: layer.styleOverride,
+            hsv: layer.hsv,
+            warp: layer.warp,
+            alignRad: layer.alignRad,
+            alignDeg: layer.alignRad == null ? layer.alignDeg : undefined
+          });
         });
       });
     }

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -71,10 +71,43 @@ test('ensureCosmeticLayers resolves equipment with HSV limits applied', () => {
   strictEqual(typeof layers[0].styleOverride, 'object');
 });
 
+test('ensureCosmeticLayers normalizes hsv arrays and string values', () => {
+  clearCosmeticCache();
+  const config = {
+    cosmeticLibrary: {
+      demo_item: {
+        slot: 'hat',
+        hsv: {
+          defaults: { h: 10, s: 0.1, v: -0.1 },
+          limits: { h: [-45, 45], s: [-0.5, 0.5], v: [-0.5, 0.5] }
+        },
+        parts: {
+          head: {
+            image: { url: 'https://example.com/head.png' }
+          }
+        }
+      }
+    },
+    fighters: {
+      hero: {
+        cosmetics: {
+          slots: {
+            hat: { id: 'demo_item', hsv: ['30', '0.4', '-0.2'] }
+          }
+        }
+      }
+    }
+  };
+  const layers = ensureCosmeticLayers(config, 'hero', {});
+  strictEqual(layers.length, 1);
+  deepStrictEqual(layers[0].hsv, { h: 30, s: 0.4, v: -0.2 });
+});
+
 test('sprites.js integrates cosmetic layers and z-order expansion', () => {
   const spritesContent = readFileSync(new URL('../docs/js/sprites.js', import.meta.url), 'utf8');
   strictEqual(/expanded\.push\(cosmeticTagFor\(tag, slot\)\);/.test(spritesContent), true, 'buildZMap should add cosmetic tags');
   strictEqual(/const \{ assets, style, offsets, cosmetics } = ensureFighterSprites/.test(spritesContent), true, 'renderSprites should read cosmetics');
+  strictEqual(/withBranchMirror\(ctx,\s*originX,\s*mirror,\s*\(\)\s*=>\s*\{\s*drawBoneSprite\(ctx, layer\.asset, bone, styleKey/.test(spritesContent), true, 'cosmetic layers should mirror with their limbs');
 });
 
 test('config references cosmetic library sources and fighter slot data', () => {


### PR DESCRIPTION
## Summary
- add a cached HSV tinting pipeline so cosmetics recolor even fully white assets
- draw sprites with tinted canvases when available and fall back to CSS filters if tinting is unavailable
- reuse source dimensions in warped draws to match tinted canvas sizes

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110a783f788326809ad74a400da9e4)