### PR TITLE
Normalize head tracking limits for wrap-around ranges

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -189,8 +189,8 @@ function normalizeRad(angle){
 
 function getHeadLimitsRad(C, fcfg){
   const limits = fcfg?.limits?.head || C.limits?.head || {};
-  const relMin = degToRad(limits.relMin ?? -75);
-  const relMax = degToRad(limits.relMax ?? 75);
+  const relMin = normalizeRad(degToRad(limits.relMin ?? -75));
+  const relMax = normalizeRad(degToRad(limits.relMax ?? 75));
   const min = Math.min(relMin, relMax);
   const max = Math.max(relMin, relMax);
   return { min, max };

--- a/tests/head-aim-limits.test.js
+++ b/tests/head-aim-limits.test.js
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+test('head limits allow wrap-around ranges after normalization', async () => {
+  const source = await readFile('docs/js/animator.js', 'utf8');
+
+  function extractFunction(name) {
+    const start = source.indexOf(`function ${name}`);
+    assert.notEqual(start, -1, `${name} function should exist`);
+    let depth = 0;
+    let began = false;
+    for (let i = start; i < source.length; i++) {
+      const ch = source[i];
+      if (ch === '{') {
+        depth += 1;
+        began = true;
+      } else if (ch === '}') {
+        depth -= 1;
+        if (began && depth === 0) {
+          return source.slice(start, i + 1);
+        }
+      }
+    }
+    throw new Error(`Could not extract ${name}`);
+  }
+
+  const normalizeSrc = extractFunction('normalizeRad');
+  const getLimitsSrc = extractFunction('getHeadLimitsRad');
+
+  const script = `
+    function degToRad(deg){ return deg * Math.PI / 180; }
+    ${normalizeSrc}
+    ${getLimitsSrc}
+    exports.getHeadLimitsRad = getHeadLimitsRad;
+  `;
+
+  const context = { Math, exports: {} };
+  vm.createContext(context);
+  vm.runInContext(script, context);
+
+  const { getHeadLimitsRad } = context.exports;
+  assert.equal(typeof getHeadLimitsRad, 'function', 'getHeadLimitsRad should be exported for testing');
+
+  const limits = getHeadLimitsRad(
+    { limits: { head: {} } },
+    { limits: { head: { relMin: 75, relMax: 270 } } }
+  );
+
+  assert.ok(limits, 'limits object should be returned');
+  const minDeg = limits.min * 180 / Math.PI;
+  const maxDeg = limits.max * 180 / Math.PI;
+
+  assert.ok(minDeg <= -80 && minDeg >= -100,
+    `Expected min limit near -90°, got ${minDeg.toFixed(3)}°`);
+  assert.ok(maxDeg >= 70 && maxDeg <= 90,
+    `Expected max limit near 75°, got ${maxDeg.toFixed(3)}°`);
+});


### PR DESCRIPTION
## Summary
- normalize head limit angles using normalizeRad so fighters with wrap-around ranges aim correctly
- add a regression test that extracts getHeadLimitsRad from animator.js and verifies wrap-around ranges clamp symmetrically

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69112ccd48b08326865607375d79ed08)