### PR TITLE
Enable aim-relative slam dash with gravity override

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -332,9 +332,17 @@ const SLAM_MOVE_POSES = {
     allowAiming: true,
     aimLegs: false,
     anim_events: [
+      { time: 0.00, velocityY: -680 },
+      { time: 0.00, gravityScale: 0.35, gravityScaleDurationMs: 1200 }
     ]
   },
-  Slam: deepClone(PUNCH_MOVE_POSES.Strike),
+  Slam: {
+    ...deepClone(PUNCH_MOVE_POSES.Strike),
+    anim_events: [
+      { time: 0.00, resetGravityScale: true },
+      { time: 0.00, impulse: 520, aimRelative: true }
+    ]
+  },
   Recoil: deepClone(PUNCH_MOVE_POSES.Recoil)
 };
 


### PR DESCRIPTION
## Summary
- add support for aim-relative impulses and gravity scale events in the animator
- extend player movement with vertical physics that respect temporary gravity overrides
- author the slam heavy attack windup/strike events to float the fighter and dash toward the aim

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116c179cb483268609a7f2501fa95d)