### PR TITLE
Implement layered pose overrides and stagger Combo Punch 2

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -578,10 +578,44 @@ window.CONFIG = {
     ComboPUNCH2: {
       name: 'Combo Punch 2',
       tags: ['light', 'combo'],
-      durations: { toWindup: 480, toStrike: 110, toRecoil: 200, toStance: 120 },
+      durations: { toWindup: 480, toStrike: 700, toRecoil: 220, toStance: 120 },
       knockbackBase: 140,
       cancelWindow: 0.7,
-      poses: deepClone(PUNCH_MOVE_POSES)
+      poses: (() => {
+        const base = deepClone(PUNCH_MOVE_POSES);
+        const strikeBase = deepClone(PUNCH_MOVE_POSES.Strike);
+        const stanceArms = deepClone(PUNCH_MOVE_POSES.Stance);
+        strikeBase.lShoulder = stanceArms.lShoulder;
+        strikeBase.lElbow = stanceArms.lElbow;
+        strikeBase.rShoulder = stanceArms.rShoulder;
+        strikeBase.rElbow = stanceArms.rElbow;
+        strikeBase.layerOverrides = [
+          {
+            id: 'combo2-left',
+            pose: {
+              lShoulder: PUNCH_MOVE_POSES.Strike.lShoulder,
+              lElbow: PUNCH_MOVE_POSES.Strike.lElbow
+            },
+            mask: ['lShoulder', 'lElbow'],
+            durMs: 200,
+            delayMs: 0,
+            priority: 140
+          },
+          {
+            id: 'combo2-right',
+            pose: {
+              rShoulder: PUNCH_MOVE_POSES.Strike.rShoulder,
+              rElbow: PUNCH_MOVE_POSES.Strike.rElbow
+            },
+            mask: ['rShoulder', 'rElbow'],
+            durMs: 200,
+            delayMs: 500,
+            priority: 150
+          }
+        ];
+        base.Strike = strikeBase;
+        return base;
+      })()
     },
     SLAM: {
       name: 'Charged Slam',

--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -31,7 +31,76 @@ function ensureAnimState(F){
   F.walk ||= { phase:0, amp:1, t:0 };
   F.jointAngles ||= {};
   F.aim ||= { targetAngle: 0, currentAngle: 0, torsoOffset: 0, shoulderOffset: 0, hipOffset: 0, active: false, headWorldTarget: null };
-  if (!F.anim){ F.anim = { last: performance.now()/1000, override:null }; }
+  if (!F.anim){ F.anim = { last: performance.now()/1000, override:null, layers: [] }; }
+  else if (!Array.isArray(F.anim.layers)){ F.anim.layers = []; }
+}
+
+function cleanupLayer(F, layer){
+  if (!layer) return;
+  try{
+    if (layer.__flipApplied && layer.pose && Array.isArray(layer.pose.flipParts)){
+      for (const p of layer.pose.flipParts){ setMirrorForPart(p, false); }
+    }
+  }catch(_e){ /* best-effort cleanup */ }
+}
+
+function refreshLegacyOverride(F){
+  if (!F?.anim) return;
+  const layers = Array.isArray(F.anim.layers) ? F.anim.layers : [];
+  if (layers.length === 0){
+    F.anim.override = null;
+    return;
+  }
+  const sorted = [...layers].sort((a,b)=> (a.priority||0) - (b.priority||0));
+  F.anim.override = sorted[sorted.length - 1] || null;
+}
+
+function removeOverrideLayer(F, layerId){
+  if (!F?.anim || !Array.isArray(F.anim.layers)) return;
+  const idx = F.anim.layers.findIndex(l=> l && l.id === layerId);
+  if (idx === -1) return;
+  const [layer] = F.anim.layers.splice(idx, 1);
+  cleanupLayer(F, layer);
+  refreshLegacyOverride(F);
+}
+
+function normalizeLayerMask(mask, pose){
+  if (Array.isArray(mask) && mask.length) return [...mask];
+  if (pose){
+    if (Array.isArray(pose.mask) && pose.mask.length) return [...pose.mask];
+    if (Array.isArray(pose.joints) && pose.joints.length) return [...pose.joints];
+  }
+  return null;
+}
+
+function setOverrideLayer(F, layerId, poseDeg, { durMs=300, mask, priority, suppressWalk, useAsBase } = {}){
+  if (!F) return null;
+  ensureAnimState(F);
+  const now = performance.now()/1000;
+  const dur = (durMs == null) ? 0 : (durMs/1000);
+  const layerMask = normalizeLayerMask(mask, poseDeg);
+  const defaultPriority = (layerId === 'primary') ? 100 : 200;
+  const hasMask = Array.isArray(layerMask) && layerMask.length > 0;
+  const layer = {
+    id: layerId,
+    pose: poseDeg,
+    mask: layerMask,
+    priority: priority ?? defaultPriority,
+    suppressWalk: suppressWalk ?? (layerId === 'primary' && !hasMask),
+    useAsBase: useAsBase ?? (!hasMask && layerId === 'primary'),
+    until: dur > 0 ? now + dur : (dur === 0 ? now : null),
+    __start: now,
+    __dur: dur,
+    __events: primeAnimEventsFromPose(poseDeg),
+    __flipApplied: false,
+    __fullFlipApplied: false,
+    __k: 0
+  };
+  removeOverrideLayer(F, layerId);
+  F.anim.layers.push(layer);
+  F.anim.layers.sort((a,b)=> (a.priority||0) - (b.priority||0));
+  refreshLegacyOverride(F);
+  return layer;
 }
 
 function getFacingRad(F){
@@ -105,18 +174,14 @@ function computeWalkPose(F, C){
   return pose;
 }
 
-function getOverride(F){ return (F.anim && F.anim.override) ? F.anim.override : null; }
+function getOverride(F){
+  if (!F?.anim) return null;
+  refreshLegacyOverride(F);
+  return F.anim.override || null;
+}
 function clearOverride(F){
-  if (!F || !F.anim || !F.anim.override) return;
-  const over = F.anim.override;
-  // cleanup applied per-part flips
-  try{
-    if (over.__flipApplied && over.pose && Array.isArray(over.pose.flipParts)){
-      for (const p of over.pose.flipParts){ setMirrorForPart(p, false); }
-    }
-    // Leave full-facing flips intact so attacks that intentionally flip the character keep the new facing
-  }catch(_e){ /* best-effort cleanup */ }
-  F.anim.override=null;
+  if (!F?.anim) return;
+  removeOverrideLayer(F, 'primary');
 }
 
 function primeAnimEventsFromPose(pose){
@@ -220,6 +285,41 @@ function processAnimEventsForOverride(F, over){
     if (F.attack && typeof F.attack.dirSign === 'number'){
       F.attack.dirSign *= -1;
     }
+  }
+}
+
+function getActiveLayers(F, now){
+  if (!F?.anim || !Array.isArray(F.anim.layers) || F.anim.layers.length === 0) return [];
+  const layers = F.anim.layers;
+  const active = [];
+  for (let i = layers.length - 1; i >= 0; i--){
+    const layer = layers[i];
+    if (!layer) continue;
+    if (layer.until != null && now >= layer.until){
+      cleanupLayer(F, layer);
+      layers.splice(i, 1);
+      continue;
+    }
+    processAnimEventsForOverride(F, layer);
+    active.push(layer);
+  }
+  active.sort((a,b)=> (a.priority||0) - (b.priority||0));
+  refreshLegacyOverride(F);
+  return active;
+}
+
+function applyLayerPose(targetPose, layer){
+  if (!layer?.pose || !targetPose) return;
+  const pose = layer.pose;
+  const mask = Array.isArray(layer.mask) && layer.mask.length ? layer.mask : ANG_KEYS;
+  for (const key of mask){
+    if (key === 'ALL'){
+      for (const k of ANG_KEYS){
+        if (pose[k] != null) targetPose[k] = pose[k];
+      }
+      continue;
+    }
+    if (pose[key] != null) targetPose[key] = pose[key];
   }
 }
 
@@ -438,29 +538,40 @@ export function updatePoses(){
   if (C.debug?.freezeAngles) return;
   const fighterName = pickFighterName(C);
   const fcfg = pickFighterConfig(C, fighterName);
-  for (const id of ['player','npc']){ const F = G.FIGHTERS[id]; if(!F) continue; ensureAnimState(F); F.anim.dt = Math.max(0, now - F.anim.last); F.anim.last = now;
-    let targetDeg = null; const over = getOverride(F);
-    if (over){
-      // process events / flips for active override (k-based)
-      processAnimEventsForOverride(F, over);
-      if (over.until && now < over.until){ targetDeg = over.pose; }
-      else {
-        F.anim.override = null;
-        if (over.until == null) console.log('[anim] cleared timeless override');
+  for (const id of ['player','npc']){
+    const F = G.FIGHTERS[id];
+    if(!F) continue;
+    ensureAnimState(F);
+    F.anim.dt = Math.max(0, now - F.anim.last);
+    F.anim.last = now;
+
+    const walkPose = computeWalkPose(F,C);
+    const basePoseConfig = pickBase(C);
+    let targetDeg = walkPose._active ? { ...walkPose } : { ...basePoseConfig };
+
+    const activeLayers = getActiveLayers(F, now);
+    const walkSuppressed = activeLayers.some(layer => layer.suppressWalk);
+    if (activeLayers.length){
+      if (walkSuppressed){
+        targetDeg = { ...basePoseConfig };
+      }
+      for (const layer of activeLayers){
+        applyLayerPose(targetDeg, layer);
       }
     }
-    if (!targetDeg){ const walkPose = computeWalkPose(F,C); if (walkPose._active) targetDeg = walkPose; }
-    if (!targetDeg) targetDeg = pickBase(C);
-    
+
+    const topLayer = activeLayers.length ? activeLayers[activeLayers.length - 1] : null;
+    const aimingPose = topLayer?.pose || (walkPose._active && !walkSuppressed ? walkPose : basePoseConfig);
+
     // Update aiming system based on current pose
-    updateAiming(F, targetDeg, id);
-    
+    updateAiming(F, aimingPose || targetDeg, id);
+
     // Add basePose to targetDeg (matching reference HTML behavior)
     const basePose = C.basePose || {};
     let finalDeg = addAngles(basePose, targetDeg);
-    
+
     // Apply aiming offsets to pose
-    finalDeg = applyAimingOffsets(finalDeg, F, targetDeg);
+    finalDeg = applyAimingOffsets(finalDeg, F, aimingPose || targetDeg);
 
     const headDeg = computeHeadTargetDeg(F, finalDeg, fcfg);
     if (typeof headDeg === 'number') {
@@ -483,22 +594,45 @@ export function updatePoses(){
   }
 }
 
-export function pushPoseOverride(fighterId, poseDeg, durMs=300){
+export function pushPoseOverride(fighterId, poseDeg, durMs=300, options={}){
+  let opts = (options && typeof options === 'object') ? options : {};
+  let durationArg = durMs;
+  if (durMs && typeof durMs === 'object' && !Array.isArray(durMs)){
+    opts = durMs;
+    durationArg = opts.durMs ?? opts.durationMs ?? opts.dur ?? 300;
+  }
+  const duration = Number.isFinite(durationArg) ? durationArg : (Number.isFinite(opts.durMs) ? opts.durMs : 300);
   const G = window.GAME || {};
   const F = G.FIGHTERS?.[fighterId];
   if(!F) return;
-  ensureAnimState(F);
-  const now = performance.now()/1000;
-  const dur = (durMs == null) ? 0 : (durMs/1000);
-  const over = {
-    pose: poseDeg,
-    until: dur > 0 ? now + dur : (dur === 0 ? now : null),
-    __start: now,
-    __dur: dur,
-    __events: primeAnimEventsFromPose(poseDeg),
-    __flipApplied: false,
-    __fullFlipApplied: false,
-    __k: 0
+  setOverrideLayer(F, 'primary', poseDeg, {
+    durMs: duration,
+    mask: opts.mask,
+    priority: opts.priority,
+    suppressWalk: opts.suppressWalk,
+    useAsBase: opts.useAsBase
+  });
+}
+
+export function pushPoseLayerOverride(fighterId, layerId, poseDeg, options={}){
+  if (!layerId) layerId = 'layer';
+  const opts = options && typeof options === 'object' ? options : {};
+  const delayMs = Number.isFinite(opts.delayMs) ? opts.delayMs : (Number.isFinite(opts.offsetMs) ? opts.offsetMs : 0);
+  const apply = ()=>{
+    const G = window.GAME || {};
+    const F = G.FIGHTERS?.[fighterId];
+    if(!F) return;
+    setOverrideLayer(F, layerId, poseDeg, {
+      durMs: opts.durMs ?? opts.durationMs ?? opts.dur ?? 300,
+      mask: opts.mask,
+      priority: opts.priority,
+      suppressWalk: opts.suppressWalk,
+      useAsBase: opts.useAsBase
+    });
   };
-  F.anim.override = over;
+  if (delayMs > 0){
+    setTimeout(apply, delayMs);
+  } else {
+    apply();
+  }
 }


### PR DESCRIPTION
## Summary
- add a layered override stack to the animator with masked pose application and a new pushPoseLayerOverride helper
- teach combat transitions to queue secondary pose layers and expose the helpers through the debug panel
- update Combo Punch 2 to stage alternating arm strikes using timed layer overrides and longer strike timing

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691201e05c0c8326890688113a652231)