### PR TITLE
Add cosmetic editor asset browser and override export tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # SoKEmpirePrologue
+
+## Resolving merge conflicts: Keep current vs. keep incoming
+
+When Git highlights a conflict, your editor may offer **Keep Current Changes** or **Keep Incoming Changes** as quick resolutions. They correspond to the two halves of the conflict markers in the file:
+
+* **Current changes** (sometimes shown between `<<<<<<<` and `=======`) are the edits already present on your branch.
+* **Incoming changes** (the lines between `=======` and `>>>>>>>`) are what Git is trying to merge in from the other branch or commit.
+
+Choose the option that matches the content you need after the merge:
+
+1. Select **Keep Current Changes** if your branch’s version is correct and you want to discard the incoming edits.
+2. Select **Keep Incoming Changes** if the other branch’s version is the one you prefer.
+3. Manually merge when both sides contain pieces you need—edit the file to combine them, then remove the conflict markers.
+
+After resolving the conflict, save the file, stage it (`git add`), and continue with the merge (`git merge --continue` or complete the rebase, depending on the operation).
+
+## Launching the game or cosmetic editor locally
+
+The published site is served from the `docs/` directory. Running a static server from that folder gives you the same entry screen that GitHub Pages hosts:
+
+```bash
+python -m http.server 8000 --directory docs
+# or: npx http-server docs -p 4173
+```
+
+Open `http://localhost:8000/` (or your chosen port) and you will be greeted with the selection overlay. Click **Launch Game Demo** to boot the stick-fighter sandbox, or choose **Open Cosmetic Editor** to load the standalone editor without leaving the shared asset/config pipeline.

--- a/docs/assets/asset-manifest.json
+++ b/docs/assets/asset-manifest.json
@@ -1,0 +1,19 @@
+[
+  "./assets/cosmetics/clothes/legs/pants1LR(old).png",
+  "./assets/cosmetics/clothes/legs/pants1LR.png",
+  "./assets/fightersprites/Untitled293_20251027165607.png",
+  "./assets/fightersprites/mao-ao-m/arm-lower.png",
+  "./assets/fightersprites/mao-ao-m/arm-upper.png",
+  "./assets/fightersprites/mao-ao-m/head(old).png",
+  "./assets/fightersprites/mao-ao-m/head.png",
+  "./assets/fightersprites/mao-ao-m/leg-lower.png",
+  "./assets/fightersprites/mao-ao-m/leg-upper.png",
+  "./assets/fightersprites/mao-ao-m/tail.png",
+  "./assets/fightersprites/mao-ao-m/torso.png",
+  "./assets/fightersprites/tletingan/arm-lower.png",
+  "./assets/fightersprites/tletingan/arm-upper.png",
+  "./assets/fightersprites/tletingan/head.png",
+  "./assets/fightersprites/tletingan/leg-lower.png",
+  "./assets/fightersprites/tletingan/leg-upper.png",
+  "./assets/fightersprites/tletingan/torso.png"
+]

--- a/docs/config/cosmetics/basic_pants.json
+++ b/docs/config/cosmetics/basic_pants.json
@@ -1,5 +1,8 @@
 {
   "slots": ["legs"],
+  "meta": {
+    "name": "Basic Pants"
+  },
   "hsv": {
     "defaults": { "h": 0, "s": 0, "v": 0 },
     "limits": { "h": [-180, 180], "s": [-1, 1], "v": [-0.5, 0.5] }

--- a/docs/cosmetic-editor.css
+++ b/docs/cosmetic-editor.css
@@ -1,0 +1,385 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #1f2937 0%, #0f172a 55%, #020617 100%);
+  color: #e2e8f0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+main.editor-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 720px) minmax(280px, 420px);
+  gap: 18px;
+  padding: 24px;
+  width: min(1180px, 100%);
+}
+
+@media (max-width: 1100px) {
+  main.editor-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.editor-preview {
+  position: relative;
+  background: linear-gradient(160deg, rgba(30,41,59,0.9), rgba(15,23,42,0.7));
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 18px 45px rgba(15,23,42,0.55);
+}
+
+.editor-preview canvas {
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  border: 1px solid rgba(148,163,184,0.25);
+  background: #020617;
+  cursor: grab;
+}
+
+.editor-preview canvas.is-bucket {
+  cursor: crosshair;
+}
+
+.bucket-hint {
+  position: absolute;
+  inset: 18px;
+  pointer-events: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 12px;
+  font-size: 13px;
+  color: #fbbf24;
+  background: linear-gradient(135deg, rgba(15,23,42,0.0) 0%, rgba(15,23,42,0.65) 35%);
+  border-radius: 12px;
+}
+
+.editor-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.panel {
+  background: rgba(15,23,42,0.75);
+  border-radius: 14px;
+  padding: 16px;
+  border: 1px solid rgba(148,163,184,0.18);
+  box-shadow: inset 0 1px 0 rgba(148,163,184,0.1);
+}
+
+.panel h2 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #cbd5f5;
+}
+
+select, input[type="text"], input[type="number"], button {
+  font-family: inherit;
+  font-size: 14px;
+}
+
+select, input[type="text"], input[type="number"] {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(148,163,184,0.25);
+  background: rgba(15,23,42,0.6);
+  color: inherit;
+  outline: none;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+select:focus, input:focus {
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 2px rgba(56,189,248,0.3);
+}
+
+button {
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(148,163,184,0.3);
+  background: linear-gradient(160deg, rgba(37,99,235,0.45), rgba(59,130,246,0.35));
+  color: #e0f2fe;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(37,99,235,0.35);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.is-active {
+  border-color: rgba(251,191,36,0.85);
+  box-shadow: 0 0 0 2px rgba(251,191,36,0.35);
+  background: linear-gradient(160deg, rgba(251,191,36,0.8), rgba(217,119,6,0.6));
+  color: #0f172a;
+}
+
+.slot-row {
+  display: grid;
+  grid-template-columns: minmax(100px, 1fr) minmax(160px, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 0;
+}
+
+.slot-row__label {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+}
+
+.slot-row[data-active="true"] {
+  background: rgba(30,64,175,0.18);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.bucket-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.bucket-actions button {
+  flex: 1 1 auto;
+}
+
+.bucket-actions button:last-child {
+  flex-basis: 100%;
+}
+
+.bucket-hint[hidden] {
+  display: none;
+}
+
+#editorStatus {
+  min-height: 18px;
+  font-size: 13px;
+  color: #cbd5f5;
+}
+
+#editorStatus[data-tone="warn"] {
+  color: #fbbf24;
+}
+
+#editorStatus[data-tone="error"] {
+  color: #f87171;
+}
+
+.style-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.style-inspector[data-active="false"] {
+  opacity: 0.6;
+}
+
+.style-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+  color: #94a3b8;
+}
+
+.style-field {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(120px, 1fr);
+  gap: 8px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.style-field__hint {
+  grid-column: span 2;
+  font-size: 12px;
+  color: rgba(148,163,184,0.7);
+}
+
+.style-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.style-asset-info {
+  margin-top: 8px;
+  font-size: 12px;
+  color: rgba(148,163,184,0.75);
+  word-break: break-all;
+}
+
+.style-asset-info code {
+  color: #f8fafc;
+}
+
+.panel p {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(203,213,225,0.85);
+}
+
+.panel-intro {
+  margin-bottom: 12px;
+  font-size: 13px;
+  color: rgba(203,213,225,0.75);
+}
+
+.creator-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 10px;
+  font-size: 13px;
+}
+
+.creator-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.creator-field--wide {
+  grid-column: span 2;
+}
+
+.asset-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 6px;
+  border-radius: 12px;
+  border: 1px solid rgba(148,163,184,0.18);
+  background: rgba(15,23,42,0.4);
+  margin: 10px 0;
+}
+
+.asset-list p {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 16px 8px;
+  text-align: center;
+  color: rgba(148,163,184,0.7);
+}
+
+.asset-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: rgba(15,23,42,0.55);
+  font-size: 12px;
+  cursor: pointer;
+  transition: border 0.15s ease, background 0.15s ease;
+}
+
+.asset-item:hover {
+  border-color: rgba(56,189,248,0.35);
+}
+
+.asset-item__name {
+  font-weight: 600;
+  color: #e0f2fe;
+  word-break: break-all;
+}
+
+.asset-item__path {
+  font-size: 11px;
+  color: rgba(148,163,184,0.7);
+  word-break: break-all;
+}
+
+.asset-item--selected {
+  border-color: rgba(249,115,22,0.65);
+  background: linear-gradient(160deg, rgba(249,115,22,0.35), rgba(249,115,22,0.15));
+}
+
+.asset-preview {
+  min-height: 90px;
+  border-radius: 12px;
+  border: 1px dashed rgba(148,163,184,0.35);
+  background: rgba(15,23,42,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
+  padding: 12px;
+}
+
+.asset-preview img {
+  max-width: 100%;
+  max-height: 160px;
+  image-rendering: pixelated;
+}
+
+.creator-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.creator-actions button {
+  flex: 1 1 160px;
+}
+
+.panel-hint {
+  margin-top: 10px;
+  font-size: 12px;
+  color: rgba(148,163,184,0.7);
+}
+
+.override-output {
+  width: 100%;
+  min-height: 180px;
+  border-radius: 12px;
+  border: 1px solid rgba(148,163,184,0.2);
+  background: rgba(15,23,42,0.5);
+  padding: 12px;
+  color: #e2e8f0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  resize: vertical;
+}
+
+.override-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.override-actions button {
+  flex: 1 1 160px;
+}
+

--- a/docs/cosmetic-editor.html
+++ b/docs/cosmetic-editor.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+  <title>Cosmetic Toolkit Preview</title>
+  <link rel="icon" href="./favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="./cosmetic-editor.css">
+</head>
+<body>
+  <main class="editor-layout">
+    <section class="editor-preview">
+      <canvas id="cosmeticCanvas" width="720" height="460" aria-label="Cosmetic preview"></canvas>
+      <div id="bucketHint" class="bucket-hint" hidden>Bucket mode active — click the canvas to fill with your selected colour.</div>
+    </section>
+    <section class="editor-controls">
+      <div class="panel">
+        <h2>Fighter</h2>
+        <select id="fighterSelect" aria-label="Select fighter"></select>
+        <p style="margin-top:8px;">Loads cosmetics from config.js so you can preview a fighter's wardrobe quickly.</p>
+      </div>
+      <div class="panel">
+        <h2>Cosmetic Slots</h2>
+        <div id="cosmeticSlotRows"></div>
+        <p style="margin-top:12px;">Use "Edit" to tweak sprite style overrides live.</p>
+      </div>
+      <div class="panel">
+        <h2>Bucket Tool</h2>
+        <label style="display:flex;flex-direction:column;gap:6px;">
+          <span>Hex colour</span>
+          <input id="bucketColor" type="text" placeholder="#ff3366" value="#ff3366" spellcheck="false" aria-label="Bucket fill hex colour">
+        </label>
+        <div class="bucket-actions" style="margin-top:12px;">
+          <button type="button" id="bucketToggle">🎨 Bucket Mode</button>
+          <button type="button" id="bucketUndo" disabled>↩ Undo</button>
+          <button type="button" id="bucketClear">🧹 Clear Paint</button>
+        </div>
+        <p style="margin-top:10px;">Bucket fill paints directly on the preview layer. Undo is limited to the last 20 fills.</p>
+      </div>
+      <div class="panel style-inspector" id="styleInspector" data-active="false">
+        <div class="style-header">
+          <strong id="styleActiveSlot">No slot selected</strong>
+          <div class="style-actions">
+            <button type="button" id="resetPartOverrides">Reset Part</button>
+            <button type="button" id="resetSlotOverrides">Reset Slot</button>
+          </div>
+        </div>
+        <label style="display:flex;flex-direction:column;gap:6px;">
+          <span>Part</span>
+          <select id="stylePartSelect" aria-label="Select cosmetic part"></select>
+        </label>
+        <div id="styleFields"></div>
+      </div>
+      <div class="panel" id="clothingCreator">
+        <h2>Clothing Creator</h2>
+        <p class="panel-intro">Pick an existing PNG from <code>docs/assets</code> to build or override outfits.</p>
+        <label class="creator-field">
+          <span>Search assets</span>
+          <input id="assetSearch" type="search" placeholder="legs" spellcheck="false" aria-label="Filter available PNG assets">
+        </label>
+        <div id="assetList" class="asset-list" role="listbox" aria-label="Available clothing sprites"></div>
+        <div id="assetPreview" class="asset-preview" aria-live="polite"></div>
+        <div class="creator-grid">
+          <label class="creator-field">
+            <span>New cosmetic ID</span>
+            <input id="creatorId" type="text" placeholder="custom_pants" spellcheck="false" aria-label="New cosmetic identifier">
+          </label>
+          <label class="creator-field">
+            <span>Display name</span>
+            <input id="creatorName" type="text" placeholder="Custom Pants" aria-label="Cosmetic display name">
+          </label>
+          <label class="creator-field">
+            <span>Equip slot</span>
+            <select id="creatorSlot" aria-label="Select slot for new cosmetic"></select>
+          </label>
+          <label class="creator-field creator-field--wide">
+            <span>Part keys (comma-separated)</span>
+            <input id="creatorParts" type="text" placeholder="leg_L_upper, leg_R_upper" spellcheck="false" aria-label="Parts to attach sprite to">
+          </label>
+        </div>
+        <div class="creator-actions">
+          <button type="button" id="creatorAdd">➕ Add Cosmetic To Library</button>
+          <button type="button" id="creatorEquip">🎯 Equip On Selected Fighter</button>
+          <button type="button" id="creatorApplyPart">🖼 Apply To Active Part</button>
+        </div>
+        <p class="panel-hint">The new cosmetic is stored in-memory for this session. Copy the override JSON below to persist it.</p>
+      </div>
+      <div class="panel" id="overridePanel">
+        <h2>Per-Fighter Overrides</h2>
+        <textarea id="overrideOutput" class="override-output" readonly spellcheck="false" aria-label="Generated override JSON"></textarea>
+        <div class="override-actions">
+          <button type="button" id="applyOverrides">✅ Apply To Preview</button>
+          <button type="button" id="copyOverrides">📋 Copy JSON</button>
+          <button type="button" id="downloadOverrides">⬇ Download JSON</button>
+        </div>
+        <p class="panel-hint">Overrides merge with the fighter's profile under <code>docs/config/fighter-offsets</code>. Equip the cosmetic and tweak parts to update the generated snippet.</p>
+      </div>
+      <div class="panel">
+        <h2>Status</h2>
+        <div id="editorStatus" role="status" aria-live="polite"></div>
+      </div>
+    </section>
+  </main>
+
+  <script src="./config/config.js"></script>
+  <script type="module" src="./js/cosmetic-library.js?v=1"></script>
+  <script type="module" src="./js/cosmetic-profiles.js?v=1"></script>
+  <script type="module" src="./js/cosmetic-editor-app.js?v=1"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,6 +23,17 @@
     });
   </script>
 
+  <div class="entry-overlay" id="entryOverlay" role="dialog" aria-modal="true" aria-labelledby="entryTitle">
+    <div class="entry-card">
+      <h1 id="entryTitle">SoK Empire Toolkit</h1>
+      <p class="entry-subtitle">Choose which experience you want to open.</p>
+      <div class="entry-actions">
+        <button type="button" id="entryLaunchGame" class="entry-btn entry-btn--primary">Launch Game Demo</button>
+        <a id="entryOpenEditor" class="entry-btn entry-btn--ghost" href="./cosmetic-editor.html">Open Cosmetic Editor</a>
+      </div>
+    </div>
+  </div>
+
   <main class="stack">
     <section class="widget widget--clear">
       <div class="stage" id="gameStage">
@@ -209,6 +220,42 @@
       </div>
     </section>
   </main>
+
+  <script>
+    (() => {
+      const overlay = document.getElementById('entryOverlay');
+      if (!overlay) return;
+
+      const params = new URLSearchParams(window.location.search);
+      const defaultMode = params.get('mode');
+
+      const hideOverlay = () => {
+        overlay.classList.add('entry-overlay--hidden');
+        setTimeout(() => overlay.remove(), 400);
+      };
+
+      if (defaultMode === 'game') {
+        hideOverlay();
+        return;
+      }
+
+      if (defaultMode === 'editor') {
+        window.location.href = './cosmetic-editor.html';
+        return;
+      }
+
+      const launchBtn = document.getElementById('entryLaunchGame');
+
+      launchBtn?.addEventListener('click', () => {
+        hideOverlay();
+      });
+
+      const editorLink = document.getElementById('entryOpenEditor');
+      editorLink?.addEventListener('click', () => {
+        /* no-op */
+      });
+    })();
+  </script>
 
   <!-- In-repo config served same-origin under /docs -->
   <script src="./config/config.js"></script>

--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -1,0 +1,1020 @@
+import { initFighters } from './fighter.js?v=6';
+import { renderAll } from './render.js?v=4';
+import { initSprites, renderSprites } from './sprites.js?v=8';
+import {
+  COSMETIC_SLOTS,
+  getRegisteredCosmeticLibrary,
+  registerCosmeticLibrary,
+  registerFighterCosmeticProfile,
+  getFighterCosmeticProfile
+} from './cosmetics.js?v=1';
+
+const CONFIG = window.CONFIG || {};
+const GAME = (window.GAME ||= {});
+const editorState = (GAME.editorState ||= {
+  slotOverrides: {},
+  overlayHistory: [],
+  activeSlot: null,
+  activePartKey: null,
+  slotSelection: {},
+  assetManifest: [],
+  filteredAssets: [],
+  selectedAsset: null,
+  assetPinned: false,
+  activeFighter: null,
+  loadedProfile: {}
+});
+
+const canvas = document.getElementById('cosmeticCanvas');
+const ctx = canvas?.getContext('2d');
+
+const fighterSelect = document.getElementById('fighterSelect');
+const slotContainer = document.getElementById('cosmeticSlotRows');
+const styleInspector = document.getElementById('styleInspector');
+const stylePartSelect = document.getElementById('stylePartSelect');
+const styleFields = document.getElementById('styleFields');
+const styleHeader = document.getElementById('styleActiveSlot');
+const styleResetBtn = document.getElementById('resetPartOverrides');
+const styleSlotResetBtn = document.getElementById('resetSlotOverrides');
+const bucketToggle = document.getElementById('bucketToggle');
+const bucketColorInput = document.getElementById('bucketColor');
+const bucketHint = document.getElementById('bucketHint');
+const bucketUndoBtn = document.getElementById('bucketUndo');
+const bucketClearBtn = document.getElementById('bucketClear');
+const statusEl = document.getElementById('editorStatus');
+const assetSearch = document.getElementById('assetSearch');
+const assetList = document.getElementById('assetList');
+const assetPreview = document.getElementById('assetPreview');
+const creatorIdInput = document.getElementById('creatorId');
+const creatorNameInput = document.getElementById('creatorName');
+const creatorSlotSelect = document.getElementById('creatorSlot');
+const creatorPartsInput = document.getElementById('creatorParts');
+const creatorAddBtn = document.getElementById('creatorAdd');
+const creatorEquipBtn = document.getElementById('creatorEquip');
+const creatorApplyBtn = document.getElementById('creatorApplyPart');
+const overrideOutput = document.getElementById('overrideOutput');
+const overrideApplyBtn = document.getElementById('applyOverrides');
+const overrideCopyBtn = document.getElementById('copyOverrides');
+const overrideDownloadBtn = document.getElementById('downloadOverrides');
+
+if (!canvas || !ctx){
+  throw new Error('Cosmetic editor preview canvas is unavailable');
+}
+
+function deepClone(value){
+  if (value == null) return value;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (_err){
+    return value;
+  }
+}
+
+function ensureOverlay(){
+  if (!editorState.overlayCanvas){
+    const overlayCanvas = document.createElement('canvas');
+    overlayCanvas.width = canvas.width;
+    overlayCanvas.height = canvas.height;
+    const overlayCtx = overlayCanvas.getContext('2d');
+    editorState.overlayCanvas = overlayCanvas;
+    editorState.overlayCtx = overlayCtx;
+    editorState.overlayHistory = [];
+    captureOverlaySnapshot();
+  }
+  return editorState.overlayCanvas;
+}
+
+function captureOverlaySnapshot(){
+  const overlayCtx = editorState.overlayCtx;
+  if (!overlayCtx) return;
+  const data = overlayCtx.getImageData(0, 0, canvas.width, canvas.height);
+  const clone = new ImageData(new Uint8ClampedArray(data.data), data.width, data.height);
+  editorState.overlayHistory.push(clone);
+  if (editorState.overlayHistory.length > 20){
+    editorState.overlayHistory.shift();
+  }
+  updateUndoButtonState();
+}
+
+function restoreOverlayFromSnapshot(snapshot){
+  const overlayCtx = editorState.overlayCtx;
+  if (!overlayCtx || !snapshot) return;
+  overlayCtx.putImageData(snapshot, 0, 0);
+}
+
+function undoOverlay(){
+  const history = editorState.overlayHistory;
+  if (!history || history.length <= 1) return;
+  history.pop();
+  const previous = history[history.length - 1];
+  restoreOverlayFromSnapshot(previous);
+  updateUndoButtonState();
+}
+
+function clearOverlay(){
+  ensureOverlay();
+  if (!editorState.overlayCtx) return;
+  editorState.overlayCtx.clearRect(0, 0, canvas.width, canvas.height);
+  editorState.overlayHistory = [];
+  captureOverlaySnapshot();
+}
+
+function updateUndoButtonState(){
+  if (!bucketUndoBtn) return;
+  const hasUndo = (editorState.overlayHistory?.length || 0) > 1;
+  bucketUndoBtn.disabled = !hasUndo;
+}
+
+function showStatus(message, { tone = 'info', timeout = 1800 } = {}){
+  if (!statusEl) return;
+  statusEl.textContent = message || '';
+  statusEl.dataset.tone = tone;
+  if (timeout > 0){
+    window.clearTimeout(editorState._statusTimer);
+    editorState._statusTimer = window.setTimeout(()=>{
+      if (statusEl.dataset.tone === tone){
+        statusEl.textContent = '';
+        delete statusEl.dataset.tone;
+      }
+    }, timeout);
+  }
+}
+
+function populateCreatorSlotOptions(){
+  if (!creatorSlotSelect) return;
+  creatorSlotSelect.innerHTML = '';
+  const frag = document.createDocumentFragment();
+  for (const slot of COSMETIC_SLOTS){
+    const option = document.createElement('option');
+    option.value = slot;
+    option.textContent = slot;
+    frag.appendChild(option);
+  }
+  creatorSlotSelect.appendChild(frag);
+}
+
+function highlightAssetSelection(){
+  if (!assetList) return;
+  const selected = editorState.selectedAsset;
+  const items = assetList.querySelectorAll('.asset-item');
+  items.forEach((item)=>{
+    item.classList.toggle('asset-item--selected', item.dataset.assetPath === selected);
+  });
+}
+
+function setSelectedAsset(path, { pinned = false } = {}){
+  editorState.selectedAsset = path || null;
+  if (pinned){
+    editorState.assetPinned = true;
+  } else if (!path){
+    editorState.assetPinned = false;
+  }
+  if (assetPreview){
+    assetPreview.innerHTML = '';
+    if (path){
+      const img = document.createElement('img');
+      img.src = path;
+      img.alt = 'Selected asset preview';
+      assetPreview.appendChild(img);
+    } else {
+      const span = document.createElement('span');
+      span.textContent = 'Select an asset to preview it here.';
+      assetPreview.appendChild(span);
+    }
+  }
+  highlightAssetSelection();
+}
+
+function renderAssetList(){
+  if (!assetList) return;
+  assetList.innerHTML = '';
+  const assets = editorState.filteredAssets || [];
+  if (!assets.length){
+    const empty = document.createElement('p');
+    empty.textContent = 'No assets match the current search.';
+    assetList.appendChild(empty);
+    return;
+  }
+  const frag = document.createDocumentFragment();
+  for (const path of assets){
+    const item = document.createElement('div');
+    item.className = 'asset-item';
+    item.tabIndex = 0;
+    item.dataset.assetPath = path;
+    item.setAttribute('role', 'option');
+    const name = document.createElement('div');
+    name.className = 'asset-item__name';
+    const last = path.split('/').pop();
+    name.textContent = last || path;
+    const hint = document.createElement('div');
+    hint.className = 'asset-item__path';
+    hint.textContent = path;
+    item.appendChild(name);
+    item.appendChild(hint);
+    frag.appendChild(item);
+  }
+  assetList.appendChild(frag);
+  highlightAssetSelection();
+}
+
+function filterAssetList(query){
+  const manifest = editorState.assetManifest || [];
+  if (!Array.isArray(manifest)){
+    editorState.filteredAssets = [];
+    renderAssetList();
+    return;
+  }
+  const norm = (query || '').trim().toLowerCase();
+  if (!norm){
+    editorState.filteredAssets = manifest.slice();
+    renderAssetList();
+    return;
+  }
+  editorState.filteredAssets = manifest.filter((path)=> path.toLowerCase().includes(norm));
+  renderAssetList();
+}
+
+async function loadAssetManifest(){
+  if (typeof fetch !== 'function'){
+    showStatus('Asset manifest unavailable in this environment.', { tone: 'warn' });
+    return;
+  }
+  try {
+    const response = await fetch('./assets/asset-manifest.json', { cache: 'no-cache' });
+    if (!response.ok){
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const data = await response.json();
+    if (Array.isArray(data)){
+      editorState.assetManifest = data;
+      editorState.filteredAssets = data.slice();
+      renderAssetList();
+      setSelectedAsset(editorState.selectedAsset);
+    }
+  } catch (err){
+    console.warn('[cosmetic-editor] Failed to load asset manifest', err);
+    showStatus('Could not load asset manifest.', { tone: 'warn', timeout: 4000 });
+    renderAssetList();
+  }
+}
+
+function parsePartKeys(raw){
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((part)=> part.trim())
+    .filter((part)=> part.length > 0);
+}
+
+function buildOverridePayload(){
+  const slotSelection = editorState.slotSelection || {};
+  const payload = { cosmetics: {} };
+  for (const [slot, entry] of Object.entries(slotSelection)){
+    const id = entry?.id;
+    if (!id) continue;
+    const overrides = editorState.slotOverrides?.[slot];
+    if (!overrides || Object.keys(overrides).length === 0) continue;
+    payload.cosmetics[id] = deepClone(overrides);
+  }
+  return payload;
+}
+
+function updateOverrideOutputs(){
+  if (!overrideOutput) return;
+  const payload = buildOverridePayload();
+  const cosmetics = payload.cosmetics || {};
+  const hasOverrides = Object.keys(cosmetics).length > 0;
+  overrideOutput.value = hasOverrides
+    ? JSON.stringify(payload, null, 2)
+    : '// No overrides defined for this fighter.';
+  if (overrideApplyBtn) overrideApplyBtn.disabled = !hasOverrides;
+  if (overrideCopyBtn) overrideCopyBtn.disabled = !hasOverrides;
+  if (overrideDownloadBtn) overrideDownloadBtn.disabled = !hasOverrides;
+}
+
+function applyOverridesToProfile(){
+  if (!editorState.activeFighter){
+    showStatus('Load a fighter before applying overrides.', { tone: 'warn' });
+    return;
+  }
+  const payload = buildOverridePayload();
+  registerFighterCosmeticProfile(editorState.activeFighter, payload);
+  editorState.loadedProfile = deepClone(payload.cosmetics || {});
+  showStatus('Applied overrides to fighter preview.', { tone: 'info' });
+  updateOverrideOutputs();
+}
+
+async function copyOverridesToClipboard(){
+  if (!overrideOutput) return;
+  const text = overrideOutput.value || '';
+  if (!text || text.startsWith('// ')){
+    showStatus('No override JSON to copy yet.', { tone: 'warn' });
+    return;
+  }
+  if (!navigator?.clipboard){
+    showStatus('Clipboard API unavailable in this browser.', { tone: 'warn' });
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    showStatus('Override JSON copied to clipboard.', { tone: 'info' });
+  } catch (err){
+    console.warn('[cosmetic-editor] Copy failed', err);
+    showStatus('Unable to copy overrides to clipboard.', { tone: 'error' });
+  }
+}
+
+function downloadOverridesJson(){
+  if (!overrideOutput) return;
+  const text = overrideOutput.value || '';
+  if (!text || text.startsWith('// ')){
+    showStatus('No override JSON to download.', { tone: 'warn' });
+    return;
+  }
+  const blob = new Blob([text], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  const fighter = editorState.activeFighter || 'fighter';
+  link.href = url;
+  link.download = `${fighter}-cosmetics.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.setTimeout(()=> URL.revokeObjectURL(url), 1000);
+  showStatus('Downloaded fighter override JSON.', { tone: 'info' });
+}
+
+function createCustomCosmetic(){
+  const asset = editorState.selectedAsset;
+  if (!asset){
+    showStatus('Select a PNG asset first.', { tone: 'warn' });
+    return;
+  }
+  const id = (creatorIdInput?.value || '').trim();
+  if (!id){
+    showStatus('Enter a cosmetic ID to register.', { tone: 'warn' });
+    creatorIdInput?.focus();
+    return;
+  }
+  const slot = creatorSlotSelect?.value;
+  if (!slot){
+    showStatus('Choose a slot for the new cosmetic.', { tone: 'warn' });
+    return;
+  }
+  const partKeys = parsePartKeys(creatorPartsInput?.value || '');
+  if (!partKeys.length){
+    showStatus('Provide at least one part key (e.g., leg_L_upper).', { tone: 'warn' });
+    creatorPartsInput?.focus();
+    return;
+  }
+  const displayNameRaw = (creatorNameInput?.value || '').trim();
+  const displayName = displayNameRaw || id.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').replace(/\b\w/g, (ch)=> ch.toUpperCase());
+  const parts = {};
+  for (const partKey of partKeys){
+    parts[partKey] = {
+      image: { url: asset }
+    };
+  }
+  const newCosmetic = {
+    slots: [slot],
+    meta: { name: displayName },
+    hsv: {
+      defaults: { h: 0, s: 0, v: 0 },
+      limits: { h: [-180, 180], s: [-1, 1], v: [-1, 1] }
+    },
+    parts
+  };
+  registerCosmeticLibrary({ [id]: newCosmetic });
+  buildSlotRows();
+  updateSlotSelectsFromState();
+  showStatus(`Registered cosmetic "${displayName}" in slot ${slot}.`, { tone: 'info' });
+}
+
+function equipCustomCosmetic(){
+  const slot = creatorSlotSelect?.value;
+  const id = (creatorIdInput?.value || '').trim();
+  if (!slot || !id){
+    showStatus('Enter both cosmetic ID and slot to equip.', { tone: 'warn' });
+    return;
+  }
+  const library = getRegisteredCosmeticLibrary();
+  if (!library[id]){
+    showStatus(`Cosmetic "${id}" is not in the library yet.`, { tone: 'warn' });
+    return;
+  }
+  setSlotSelection(slot, id);
+  updateSlotSelectsFromState();
+  showStyleInspector(slot);
+  showStatus(`Equipped ${library[id].meta?.name || id} to ${slot}.`, { tone: 'info' });
+}
+
+function applyAssetToActivePart(){
+  const asset = editorState.selectedAsset;
+  if (!asset){
+    showStatus('Select an asset before applying it.', { tone: 'warn' });
+    return;
+  }
+  const slot = editorState.activeSlot;
+  const partKey = editorState.activePartKey;
+  if (!slot || !partKey){
+    showStatus('Choose a slot and part in the style inspector first.', { tone: 'warn' });
+    return;
+  }
+  const slotOverride = (editorState.slotOverrides[slot] ||= {});
+  slotOverride.parts ||= {};
+  const partOverride = (slotOverride.parts[partKey] ||= {});
+  partOverride.image = { ...(partOverride.image || {}), url: asset };
+  cleanupEmptyOverrides(slot);
+  showStyleInspector(slot);
+  updateOverrideOutputs();
+  showStatus(`Applied ${asset} to ${slot} → ${partKey}.`, { tone: 'info' });
+}
+
+function getEffectivePartImage(slot, cosmetic, partKey){
+  const slotOverride = editorState.slotOverrides?.[slot];
+  const partOverride = slotOverride?.parts?.[partKey];
+  return partOverride?.image?.url
+    || slotOverride?.image?.url
+    || cosmetic?.parts?.[partKey]?.image?.url
+    || '';
+}
+
+function highlightActivePartAsset(slot, partKey, cosmetic){
+  if (!slot || !partKey) return;
+  if (editorState.assetPinned) return;
+  const current = getEffectivePartImage(slot, cosmetic, partKey);
+  if (current){
+    setSelectedAsset(current);
+  }
+}
+
+function mapProfileToSlotOverrides(slotMap, profile){
+  const overrides = {};
+  const cosmetics = profile?.cosmetics || {};
+  for (const [slot, entry] of Object.entries(slotMap || {})){
+    const id = entry?.id;
+    if (!id) continue;
+    const profileEntry = cosmetics[id];
+    if (!profileEntry) continue;
+    overrides[slot] = deepClone(profileEntry);
+  }
+  return overrides;
+}
+
+function parseHexColor(value){
+  if (!value) return null;
+  const trimmed = value.trim();
+  const hex = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed;
+  if (hex.length !== 3 && hex.length !== 6) return null;
+  const chars = hex.length === 3
+    ? hex.split('').map((ch)=> ch + ch)
+    : [hex.slice(0,2), hex.slice(2,4), hex.slice(4,6)];
+  const nums = chars.map((pair)=> Number.parseInt(pair, 16));
+  if (nums.some((n)=> Number.isNaN(n))) return null;
+  return { r: nums[0], g: nums[1], b: nums[2], a: 255 };
+}
+
+function applyBucketFill(x, y, rgba){
+  ensureOverlay();
+  const overlayCtx = editorState.overlayCtx;
+  if (!overlayCtx || !ctx) return;
+  if (x < 0 || y < 0 || x >= canvas.width || y >= canvas.height) return;
+
+  let baseData;
+  let overlayData;
+  try {
+    baseData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    overlayData = overlayCtx.getImageData(0, 0, canvas.width, canvas.height);
+  } catch (err){
+    console.warn('[cosmetic-editor] Bucket fill failed to access pixel data', err);
+    showStatus('Unable to bucket fill due to browser security (CORS) restrictions.', { tone: 'error', timeout: 4200 });
+    return;
+  }
+  const offset = (y * canvas.width + x) * 4;
+  const target = baseData.data.slice(offset, offset + 4);
+  if (target[3] === 0){
+    showStatus('Clicked transparent pixel – nothing to fill.', { tone: 'warn' });
+    return;
+  }
+
+  captureOverlaySnapshot();
+
+  const stack = [[x, y]];
+  const visited = new Uint8Array(canvas.width * canvas.height);
+  const tolerance = 48;
+  let painted = false;
+
+  function matches(ix){
+    const dr = Math.abs(baseData.data[ix] - target[0]);
+    const dg = Math.abs(baseData.data[ix + 1] - target[1]);
+    const db = Math.abs(baseData.data[ix + 2] - target[2]);
+    const da = Math.abs(baseData.data[ix + 3] - target[3]);
+    return dr <= tolerance && dg <= tolerance && db <= tolerance && da <= 64;
+  }
+
+  while (stack.length){
+    const [px, py] = stack.pop();
+    if (px < 0 || py < 0 || px >= canvas.width || py >= canvas.height) continue;
+    const idx = py * canvas.width + px;
+    if (visited[idx]) continue;
+    visited[idx] = 1;
+    const baseIdx = idx * 4;
+    if (!matches(baseIdx)) continue;
+
+    overlayData.data[baseIdx] = rgba.r;
+    overlayData.data[baseIdx + 1] = rgba.g;
+    overlayData.data[baseIdx + 2] = rgba.b;
+    overlayData.data[baseIdx + 3] = rgba.a;
+    painted = true;
+
+    stack.push([px + 1, py]);
+    stack.push([px - 1, py]);
+    stack.push([px, py + 1]);
+    stack.push([px, py - 1]);
+  }
+
+  if (!painted){
+    editorState.overlayHistory.pop();
+    updateUndoButtonState();
+    showStatus('No similar pixels found to fill.', { tone: 'warn' });
+    return;
+  }
+
+  try {
+    overlayCtx.putImageData(overlayData, 0, 0);
+  } catch (err){
+    console.warn('[cosmetic-editor] Failed to apply bucket fill', err);
+    editorState.overlayHistory.pop();
+    updateUndoButtonState();
+    showStatus('Failed to update paint layer.', { tone: 'error' });
+    return;
+  }
+  updateUndoButtonState();
+}
+
+function normalizeSlotEntry(entry){
+  if (!entry) return null;
+  if (typeof entry === 'string') return { id: entry };
+  if (entry && typeof entry === 'object'){
+    const id = entry.id || entry.cosmeticId || entry.item || entry.name;
+    if (!id) return null;
+    return { ...entry, id };
+  }
+  return null;
+}
+
+function setSelectedCosmetics(slots){
+  const slotMap = {};
+  for (const slot of COSMETIC_SLOTS){
+    const value = normalizeSlotEntry(slots?.[slot]);
+    if (value){
+      slotMap[slot] = deepClone(value);
+    }
+  }
+  GAME.selectedCosmetics = { slots: slotMap };
+  editorState.slotSelection = deepClone(slotMap);
+  return slotMap;
+}
+
+function updateSlotSelectsFromState(){
+  const slots = GAME.selectedCosmetics?.slots || {};
+  for (const [slot, row] of slotRows){
+    const entry = normalizeSlotEntry(slots[slot]);
+    const id = entry?.id || '';
+    row.select.value = id;
+    row.element.dataset.active = editorState.activeSlot === slot ? 'true' : 'false';
+  }
+}
+
+function cleanupEmptyOverrides(slot){
+  const slotOverride = editorState.slotOverrides?.[slot];
+  if (!slotOverride) return;
+  if (slotOverride.parts){
+    for (const [partKey, partOverride] of Object.entries(slotOverride.parts)){
+      if (partOverride?.image && !partOverride.image.url){
+        delete partOverride.image;
+      }
+      const spriteStyle = partOverride?.spriteStyle;
+      const xform = spriteStyle?.xform?.[partKey];
+      if (xform && Object.keys(xform).length === 0){
+        delete spriteStyle.xform[partKey];
+      }
+      if (spriteStyle?.xform && Object.keys(spriteStyle.xform).length === 0){
+        delete spriteStyle.xform;
+      }
+      if (spriteStyle && Object.keys(spriteStyle).length === 0){
+        delete partOverride.spriteStyle;
+      }
+      if (partOverride && Object.keys(partOverride).length === 0){
+        delete slotOverride.parts[partKey];
+      }
+    }
+    if (Object.keys(slotOverride.parts).length === 0){
+      delete slotOverride.parts;
+    }
+  }
+  if (slotOverride.spriteStyle && Object.keys(slotOverride.spriteStyle).length === 0){
+    delete slotOverride.spriteStyle;
+  }
+  if (slotOverride.anchor && Object.keys(slotOverride.anchor).length === 0){
+    delete slotOverride.anchor;
+  }
+  if (slotOverride.warp && Object.keys(slotOverride.warp).length === 0){
+    delete slotOverride.warp;
+  }
+  if (slotOverride.hsv && Object.keys(slotOverride.hsv).length === 0){
+    delete slotOverride.hsv;
+  }
+  if (slotOverride.image && !slotOverride.image.url){
+    delete slotOverride.image;
+  }
+  if (Object.keys(slotOverride).length === 0){
+    delete editorState.slotOverrides[slot];
+  }
+}
+
+function setSlotSelection(slot, cosmeticId){
+  const selection = (GAME.selectedCosmetics ||= { slots: {} });
+  if (!selection.slots) selection.slots = {};
+  editorState.slotSelection ||= {};
+  if (!cosmeticId){
+    selection.slots[slot] = null;
+    delete editorState.slotSelection[slot];
+    delete editorState.slotOverrides[slot];
+  } else {
+    const existing = normalizeSlotEntry(selection.slots[slot]) || {};
+    const next = { ...existing, id: cosmeticId };
+    selection.slots[slot] = next;
+    editorState.slotSelection[slot] = deepClone(next);
+    delete editorState.slotOverrides[slot];
+  }
+  cleanupEmptyOverrides(slot);
+  updateOverrideOutputs();
+  if (editorState.activeSlot === slot){
+    showStyleInspector(slot);
+  }
+}
+
+function resetSlotOverrides(slot){
+  if (!slot) return;
+  delete editorState.slotOverrides[slot];
+  if (editorState.activeSlot === slot){
+    showStyleInspector(slot);
+  }
+  updateOverrideOutputs();
+}
+
+function resetPartOverrides(slot, partKey){
+  if (!slot || !partKey) return;
+  const slotOverride = editorState.slotOverrides?.[slot];
+  if (!slotOverride?.parts) return;
+  delete slotOverride.parts[partKey];
+  cleanupEmptyOverrides(slot);
+  if (editorState.activeSlot === slot){
+    showStyleInspector(slot);
+  }
+  updateOverrideOutputs();
+}
+
+function ensurePartOverride(slot, partKey){
+  const slotOverride = (editorState.slotOverrides[slot] ||= { parts: {} });
+  slotOverride.parts ||= {};
+  const partOverride = (slotOverride.parts[partKey] ||= {});
+  partOverride.spriteStyle ||= {};
+  partOverride.spriteStyle.xform ||= {};
+  partOverride.spriteStyle.xform[partKey] ||= {};
+  return partOverride.spriteStyle.xform[partKey];
+}
+
+function applyStyleValue(slot, partKey, field, rawValue){
+  const xform = ensurePartOverride(slot, partKey);
+  if (rawValue === '' || rawValue == null){
+    delete xform[field];
+  } else {
+    const num = Number(rawValue);
+    if (Number.isFinite(num)){
+      xform[field] = num;
+    } else {
+      delete xform[field];
+    }
+  }
+  cleanupEmptyOverrides(slot);
+  updateOverrideOutputs();
+}
+
+function getBaseSpriteStyle(cosmetic, partKey){
+  const part = cosmetic?.parts?.[partKey];
+  if (!part) return {};
+  const style = part.spriteStyle || {};
+  const base = style.base || {};
+  const xform = base.xform || {};
+  return xform[partKey] || {};
+}
+
+function buildStyleFields(slot, cosmetic, partKey){
+  styleFields.innerHTML = '';
+  if (!slot || !cosmetic || !partKey){
+    const p = document.createElement('p');
+    p.textContent = 'Select a cosmetic part to edit sprite style.';
+    styleFields.appendChild(p);
+    return;
+  }
+  const baseXform = getBaseSpriteStyle(cosmetic, partKey);
+  const current = editorState.slotOverrides?.[slot]?.parts?.[partKey]?.spriteStyle?.xform?.[partKey] || {};
+  const fields = [
+    { key: 'ax', label: 'Offset X (ax)', step: 0.01 },
+    { key: 'ay', label: 'Offset Y (ay)', step: 0.01 },
+    { key: 'scaleX', label: 'Scale X', step: 0.01 },
+    { key: 'scaleY', label: 'Scale Y', step: 0.01 }
+  ];
+  for (const field of fields){
+    const wrapper = document.createElement('label');
+    wrapper.className = 'style-field';
+    const span = document.createElement('span');
+    span.textContent = field.label;
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = String(field.step);
+    input.value = current[field.key] != null ? current[field.key] : '';
+    if (baseXform[field.key] != null){
+      input.placeholder = String(baseXform[field.key]);
+    }
+    input.addEventListener('input', (event)=>{
+      applyStyleValue(slot, partKey, field.key, event.target.value);
+    });
+    wrapper.appendChild(span);
+    wrapper.appendChild(input);
+    if (baseXform[field.key] != null){
+      const hint = document.createElement('span');
+      hint.className = 'style-field__hint';
+      hint.textContent = `Base: ${baseXform[field.key]}`;
+      wrapper.appendChild(hint);
+    }
+    styleFields.appendChild(wrapper);
+  }
+  const currentImageUrl = getEffectivePartImage(slot, cosmetic, partKey);
+  if (currentImageUrl){
+    const info = document.createElement('p');
+    info.className = 'style-asset-info';
+    info.innerHTML = `Current image: <code>${currentImageUrl}</code>`;
+    styleFields.appendChild(info);
+  }
+}
+
+function showStyleInspector(slot){
+  editorState.activeSlot = slot;
+  updateSlotSelectsFromState();
+  if (!slot){
+    styleInspector.dataset.active = 'false';
+    styleFields.innerHTML = '<p>Select a cosmetic slot to edit sprite style overrides.</p>';
+    stylePartSelect.innerHTML = '';
+    styleHeader.textContent = 'No slot selected';
+    return;
+  }
+  const library = getRegisteredCosmeticLibrary();
+  const row = slotRows.get(slot);
+  const cosmeticId = row?.select?.value || '';
+  styleHeader.textContent = `Slot: ${slot}`;
+  if (!cosmeticId){
+    styleInspector.dataset.active = 'true';
+    stylePartSelect.innerHTML = '';
+    styleFields.innerHTML = '<p>Select a cosmetic for this slot to enable style editing.</p>';
+    return;
+  }
+  const cosmetic = library[cosmeticId];
+  if (!cosmetic){
+    styleInspector.dataset.active = 'true';
+    stylePartSelect.innerHTML = '';
+    styleFields.innerHTML = `<p>Cosmetic \"${cosmeticId}\" is not available in the library.</p>`;
+    return;
+  }
+  const parts = Object.keys(cosmetic.parts || {});
+  styleInspector.dataset.active = 'true';
+  stylePartSelect.innerHTML = '';
+  if (!parts.length){
+    styleFields.innerHTML = '<p>This cosmetic has no editable sprite parts.</p>';
+    return;
+  }
+  for (const partKey of parts){
+    const option = document.createElement('option');
+    option.value = partKey;
+    option.textContent = partKey;
+    stylePartSelect.appendChild(option);
+  }
+  const preferred = editorState.activePartKey && parts.includes(editorState.activePartKey)
+    ? editorState.activePartKey
+    : parts[0];
+  stylePartSelect.value = preferred;
+  editorState.activePartKey = preferred;
+  buildStyleFields(slot, cosmetic, preferred);
+  highlightActivePartAsset(slot, preferred, cosmetic);
+}
+
+function handlePartChange(){
+  const slot = editorState.activeSlot;
+  const library = getRegisteredCosmeticLibrary();
+  const row = slotRows.get(slot);
+  if (!slot || !row) return;
+  const cosmeticId = row.select.value;
+  const cosmetic = library[cosmeticId];
+  const partKey = stylePartSelect.value;
+  editorState.activePartKey = partKey;
+  buildStyleFields(slot, cosmetic, partKey);
+  highlightActivePartAsset(slot, partKey, cosmetic);
+}
+
+const slotRows = new Map();
+
+function buildSlotRows(){
+  const library = getRegisteredCosmeticLibrary();
+  slotContainer.innerHTML = '';
+  slotRows.clear();
+  for (const slot of COSMETIC_SLOTS){
+    const row = document.createElement('div');
+    row.className = 'slot-row';
+    row.dataset.slot = slot;
+    const label = document.createElement('span');
+    label.className = 'slot-row__label';
+    label.textContent = slot;
+    const select = document.createElement('select');
+    const noneOption = document.createElement('option');
+    noneOption.value = '';
+    noneOption.textContent = 'None';
+    select.appendChild(noneOption);
+    const options = Object.entries(library)
+      .filter(([_, cosmetic]) => Array.isArray(cosmetic?.slots) ? cosmetic.slots.includes(slot) : true)
+      .sort(([a], [b]) => a.localeCompare(b));
+    for (const [id, cosmetic] of options){
+      const option = document.createElement('option');
+      option.value = id;
+      option.textContent = cosmetic?.meta?.name || id;
+      select.appendChild(option);
+    }
+    select.addEventListener('change', (event)=>{
+      setSlotSelection(slot, event.target.value);
+    });
+    const editButton = document.createElement('button');
+    editButton.type = 'button';
+    editButton.className = 'slot-row__edit';
+    editButton.textContent = 'Edit';
+    editButton.addEventListener('click', ()=>{
+      showStyleInspector(slot);
+    });
+    row.appendChild(label);
+    row.appendChild(select);
+    row.appendChild(editButton);
+    slotContainer.appendChild(row);
+    slotRows.set(slot, { element: row, select, editButton });
+  }
+}
+
+function populateFighterSelect(){
+  fighterSelect.innerHTML = '';
+  const fighters = CONFIG.fighters || {};
+  const keys = Object.keys(fighters);
+  if (!keys.length){
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = 'No fighters found';
+    fighterSelect.appendChild(opt);
+    fighterSelect.disabled = true;
+    return;
+  }
+  for (const key of keys){
+    const opt = document.createElement('option');
+    opt.value = key;
+    opt.textContent = key;
+    fighterSelect.appendChild(opt);
+  }
+  fighterSelect.addEventListener('change', (event)=>{
+    loadFighter(event.target.value);
+  });
+  fighterSelect.value = keys[0];
+  loadFighter(keys[0]);
+}
+
+function loadFighter(fighterName){
+  if (!fighterName) return;
+  GAME.selectedFighter = fighterName;
+  editorState.activeFighter = fighterName;
+  const fighter = CONFIG.fighters?.[fighterName] || {};
+  const slots = fighter.cosmetics?.slots || fighter.cosmetics || {};
+  const slotMap = setSelectedCosmetics(slots);
+  clearOverlay();
+  editorState.assetPinned = false;
+  setSelectedAsset(null);
+  const profile = getFighterCosmeticProfile(fighterName) || null;
+  editorState.loadedProfile = deepClone(profile?.cosmetics || {});
+  editorState.slotOverrides = mapProfileToSlotOverrides(slotMap, profile);
+  editorState.activeSlot = null;
+  editorState.activePartKey = null;
+  updateSlotSelectsFromState();
+  showStyleInspector(null);
+  updateOverrideOutputs();
+  showStatus(`Loaded fighter ${fighterName}`, { tone: 'info' });
+}
+
+function updateBucketMode(isActive){
+  editorState.bucketActive = isActive;
+  bucketToggle.classList.toggle('is-active', !!isActive);
+  canvas.classList.toggle('is-bucket', !!isActive);
+  if (bucketHint){
+    bucketHint.hidden = !isActive;
+  }
+}
+
+function handleCanvasClick(event){
+  if (!editorState.bucketActive) return;
+  const color = parseHexColor(bucketColorInput.value);
+  if (!color){
+    showStatus('Enter a valid hex color (e.g., #ff9933).', { tone: 'warn' });
+    return;
+  }
+  const rect = canvas.getBoundingClientRect();
+  const scaleX = canvas.width / rect.width;
+  const scaleY = canvas.height / rect.height;
+  const x = Math.floor((event.clientX - rect.left) * scaleX);
+  const y = Math.floor((event.clientY - rect.top) * scaleY);
+  applyBucketFill(x, y, color);
+}
+
+function draw(){
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  renderAll(ctx);
+  renderSprites(ctx);
+  const overlayCanvas = ensureOverlay();
+  if (overlayCanvas){
+    ctx.drawImage(overlayCanvas, 0, 0);
+  }
+  requestAnimationFrame(draw);
+}
+
+function attachEventListeners(){
+  canvas.addEventListener('click', handleCanvasClick);
+  bucketToggle.addEventListener('click', ()=>{
+    updateBucketMode(!editorState.bucketActive);
+  });
+  bucketUndoBtn.addEventListener('click', ()=>{
+    undoOverlay();
+  });
+  bucketClearBtn.addEventListener('click', ()=>{
+    clearOverlay();
+  });
+  stylePartSelect.addEventListener('change', handlePartChange);
+  styleResetBtn.addEventListener('click', ()=>{
+    if (editorState.activeSlot && editorState.activePartKey){
+      resetPartOverrides(editorState.activeSlot, editorState.activePartKey);
+    }
+  });
+  styleSlotResetBtn.addEventListener('click', ()=>{
+    if (editorState.activeSlot){
+      resetSlotOverrides(editorState.activeSlot);
+    }
+  });
+  assetSearch?.addEventListener('input', (event)=>{
+    filterAssetList(event.target.value);
+  });
+  assetList?.addEventListener('click', (event)=>{
+    const target = event.target.closest('.asset-item');
+    if (!target) return;
+    const path = target.dataset.assetPath;
+    if (path){
+      setSelectedAsset(path, { pinned: true });
+    }
+  });
+  assetList?.addEventListener('keydown', (event)=>{
+    if (event.key !== 'Enter' && event.key !== ' '){
+      return;
+    }
+    const target = event.target.closest('.asset-item');
+    if (!target) return;
+    event.preventDefault();
+    const path = target.dataset.assetPath;
+    if (path){
+      setSelectedAsset(path, { pinned: true });
+    }
+  });
+  creatorAddBtn?.addEventListener('click', createCustomCosmetic);
+  creatorEquipBtn?.addEventListener('click', equipCustomCosmetic);
+  creatorApplyBtn?.addEventListener('click', applyAssetToActivePart);
+  overrideApplyBtn?.addEventListener('click', applyOverridesToProfile);
+  overrideCopyBtn?.addEventListener('click', ()=>{ copyOverridesToClipboard(); });
+  overrideDownloadBtn?.addEventListener('click', downloadOverridesJson);
+}
+
+(async function bootstrap(){
+  ensureOverlay();
+  setSelectedAsset(null);
+  await initSprites();
+  initFighters(canvas, ctx);
+  GAME.CAMERA = GAME.CAMERA || { x: 0, worldWidth: canvas.width };
+  populateCreatorSlotOptions();
+  await loadAssetManifest();
+  buildSlotRows();
+  populateFighterSelect();
+  attachEventListeners();
+  updateSlotSelectsFromState();
+  updateBucketMode(false);
+  requestAnimationFrame(draw);
+})();
+

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -28,6 +28,87 @@ body{
   min-height:100vh;
 }
 
+.entry-overlay{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:24px;
+  background:radial-gradient(circle at center, rgba(9,12,20,0.88) 0%, rgba(5,7,13,0.96) 65%);
+  backdrop-filter:blur(4px);
+  z-index:999;
+  transition:opacity 0.35s ease;
+}
+
+.entry-overlay--hidden{
+  opacity:0;
+  pointer-events:none;
+}
+
+.entry-card{
+  width:min(440px, calc(100% - 32px));
+  padding:32px clamp(20px, 5vw, 36px);
+  border-radius:20px;
+  background:linear-gradient(165deg, rgba(15,23,42,0.95), rgba(9,9,11,0.92));
+  border:1px solid rgba(148,163,184,0.35);
+  box-shadow:0 28px 80px rgba(0,0,0,0.55);
+  text-align:center;
+}
+
+.entry-card h1{
+  margin:0 0 10px;
+  font-size:clamp(22px, 4vw, 30px);
+  letter-spacing:0.3px;
+}
+
+.entry-subtitle{
+  margin:0 0 26px;
+  color:var(--muted);
+  font-size:14px;
+}
+
+.entry-actions{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  margin-bottom:18px;
+}
+
+.entry-btn{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:12px 16px;
+  border-radius:12px;
+  font-weight:600;
+  font-size:15px;
+  letter-spacing:0.2px;
+  cursor:pointer;
+  text-decoration:none;
+  transition:transform 0.12s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  border:1px solid transparent;
+}
+
+.entry-btn--primary{
+  background:linear-gradient(135deg,#2563eb,#60a5fa);
+  color:white;
+  border-color:rgba(59,130,246,0.65);
+  box-shadow:0 14px 40px rgba(37,99,235,0.35);
+}
+
+.entry-btn--primary:hover{background:linear-gradient(135deg,#1d4ed8,#3b82f6);}
+
+.entry-btn--ghost{
+  background:rgba(15,23,42,0.35);
+  color:var(--fg);
+  border-color:rgba(148,163,184,0.35);
+}
+
+.entry-btn--ghost:hover{background:rgba(15,23,42,0.55);}
+
+.entry-btn:active{transform:translateY(1px);}
+
 main.stack{
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
## Summary
- add an asset-backed clothing creator panel with search, preview, and on-the-fly cosmetic registration
- expose fighter override JSON generation, copy, download, and in-memory application from the editor
- remove the landing overlay persistence checkbox and label basic pants for clarity while sharing a prebuilt asset manifest
- document how to launch the entry overlay locally so the game and cosmetic editor are both accessible from one server

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f5963874832684ea34c1b5c9763c)