### PR TITLE
Fix fighter dropdown initialization in cosmetic editor

### DIFF
--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -8,7 +8,6 @@ import {
   registerFighterCosmeticProfile,
   getFighterCosmeticProfile
 } from './cosmetics.js?v=1';
-import { COSMETIC_SLOTS, getRegisteredCosmeticLibrary } from './cosmetics.js?v=1';
 
 const CONFIG = window.CONFIG || {};
 const GAME = (window.GAME ||= {});
@@ -917,11 +916,6 @@ function loadFighter(fighterName){
   const profile = getFighterCosmeticProfile(fighterName) || null;
   editorState.loadedProfile = deepClone(profile?.cosmetics || {});
   editorState.slotOverrides = mapProfileToSlotOverrides(slotMap, profile);
-  const fighter = CONFIG.fighters?.[fighterName] || {};
-  const slots = fighter.cosmetics?.slots || fighter.cosmetics || {};
-  setSelectedCosmetics(slots);
-  clearOverlay();
-  editorState.slotOverrides = {};
   editorState.activeSlot = null;
   editorState.activePartKey = null;
   updateSlotSelectsFromState();


### PR DESCRIPTION
## Summary
- remove duplicated cosmetics import that caused cosmetic editor bundle errors
- consolidate loadFighter logic so the fighter dropdown initializes without redeclaration issues

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912426703648326882cbe5a67430f10)