### PR TITLE
Fix combo punch overrides to use single-hand strikes

### DIFF
--- a/ancient code-monolith of truth.html
+++ b/ancient code-monolith of truth.html
@@ -772,7 +772,7 @@
     </section>
   </main>
 
-<script src="https://cdn.jsdelivr.net/gh/Oolnokk/SoKEmpirePrologue@1b50d8fbb33d17147eef3473e562a7258ed65ce5/config/config.js"></script>
+<script src="./docs/config/config.js"></script>
 <!-- === Safe-boot guards + optional-module shims === -->
 <script>
   window.CONFIG = window.CONFIG || {};

--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -585,7 +585,6 @@ window.CONFIG = {
           {
             id: 'combo1-right',
             pose: {
-              pose: {
               rShoulder: PUNCH_MOVE_POSES.Strike.rShoulder,
               rElbow: PUNCH_MOVE_POSES.Strike.rElbow
             },
@@ -594,7 +593,11 @@ window.CONFIG = {
             delayMs: 0,
             priority: 140
           }
-        ],
+        ];
+        base.Strike = strikeBase;
+        return base;
+      })()
+    },
     ComboPUNCH2: {
       name: 'Combo Punch 2',
       tags: ['light', 'combo'],
@@ -629,7 +632,7 @@ window.CONFIG = {
             },
             mask: ['rShoulder', 'rElbow'],
             durMs: 100,
-            delayMs: 800,
+            delayMs: 500,
             priority: 150
           }
         ];


### PR DESCRIPTION
## Summary
- ensure the legacy demo page loads the repo's config bundle instead of the CDN build so local tweaks apply
- flatten combo punch override poses and return the rebuilt strike pose for ComboPUNCH1
- shorten the follow-up delay for ComboPUNCH2 so the second hand fires within the strike window

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124b117f6883268ebabf2dac3efdbe)