### PR TITLE
Fix ComboPUNCH1 config parsing error

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -592,7 +592,12 @@ window.CONFIG = {
             durMs: 200,
             delayMs: 0,
             priority: 140
-          },
+          }
+        ];
+        base.Strike = strikeBase;
+        return base;
+      })()
+    },
     ComboPUNCH2: {
       name: 'Combo Punch 2',
       tags: ['light', 'combo'],


### PR DESCRIPTION
## Summary
- close the ComboPUNCH1 layer override definition so config.js parses correctly
- ensure the ComboPUNCH1 pose builder returns a value before defining ComboPUNCH2

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691254de3258832688efe0fb2dba2646)