### PR TITLE
Adjust leg layering and cosmetic rotation control

### DIFF
--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -944,7 +944,8 @@ function buildStyleFields(slot, cosmetic, partKey){
     { key: 'ax', label: 'Offset X (ax)', step: 0.01 },
     { key: 'ay', label: 'Offset Y (ay)', step: 0.01 },
     { key: 'scaleX', label: 'Scale X', step: 0.01 },
-    { key: 'scaleY', label: 'Scale Y', step: 0.01 }
+    { key: 'scaleY', label: 'Scale Y', step: 0.01 },
+    { key: 'rotDeg', label: 'Rotation (deg)', step: 0.1 }
   ];
   for (const field of fields){
     const wrapper = document.createElement('label');

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -332,7 +332,7 @@ function spriteRotationOffset(styleKey){
 
 // Render order: use CONFIG.render.order if available; else fallback
 function buildZMap(C){
-  const def = ['HITBOX','ARM_L_UPPER','ARM_L_LOWER','LEG_L_UPPER','LEG_L_LOWER','TORSO','HEAD','LEG_R_UPPER','LEG_R_LOWER','ARM_R_UPPER','ARM_R_LOWER'];
+  const def = ['HITBOX','ARM_L_UPPER','ARM_L_LOWER','LEG_L_LOWER','LEG_L_UPPER','TORSO','HEAD','LEG_R_LOWER','LEG_R_UPPER','ARM_R_UPPER','ARM_R_LOWER'];
   const baseOrder = (C.render && Array.isArray(C.render.order) && C.render.order.length) ? C.render.order.map(s=>String(s).toUpperCase()) : def;
   const expanded = [];
   for (const tag of baseOrder){


### PR DESCRIPTION
## Summary
- update the default sprite z-order so lower legs render before their matching upper legs
- add a rotation (degrees) input to the cosmetic editor style overrides

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912779980b88326b288510a52636ac8)