### PR TITLE
Handle cosmetic rotation overrides in sprite renderer

### DIFF
--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -605,11 +605,22 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
   w *= scaleX;
   h *= scaleY;
 
-  // Rotation (fixed): bone.ang + alignRad + Math.PI
+  const overrideXformSrc = options.styleOverride?.xform || {};
+  const overrideXform = overrideXformSrc[normalizedKey] || overrideXformSrc[styleKey] || null;
+  let extraRotRad = 0;
+  if (overrideXform){
+    if (Number.isFinite(overrideXform.rotRad)){
+      extraRotRad = overrideXform.rotRad;
+    } else if (Number.isFinite(overrideXform.rotDeg)){
+      extraRotRad = degToRad(overrideXform.rotDeg);
+    }
+  }
+
+  // Rotation (fixed): bone.ang + alignRad + extraRotRad + Math.PI
   const alignRad = (options.alignRad != null)
     ? options.alignRad
     : (options.alignDeg != null ? degToRad(options.alignDeg) : (asset.alignRad ?? 0));
-  const theta = bone.ang + alignRad + Math.PI;
+  const theta = bone.ang + alignRad + extraRotRad + Math.PI;
 
   const originalFilter = ctx.filter;
   const filter = applyFilter

--- a/tests/sprite-rotdeg-conversion.test.js
+++ b/tests/sprite-rotdeg-conversion.test.js
@@ -34,4 +34,13 @@ describe('Sprite rotDeg to alignRad conversion (Issue #76)', () => {
     const usesAlignRad = /asset\.alignRad/.test(spritesContent);
     strictEqual(usesAlignRad, true, 'Should use asset.alignRad in rotation calculation');
   });
+
+  it('drawBoneSprite applies styleOverride rotDeg during rotation', () => {
+    const readsOverrideXform = /options\.styleOverride\?\.xform/.test(spritesContent);
+    const convertsOverrideRot = /degToRad\(overrideXform\.rotDeg\)/.test(spritesContent);
+    const addsExtraRotation = /alignRad \+ extraRotRad/.test(spritesContent);
+    ok(readsOverrideXform, 'Should read rotation overrides from styleOverride.xform');
+    ok(convertsOverrideRot, 'Should convert styleOverride rotDeg to radians');
+    ok(addsExtraRotation, 'Should add extra rotation from overrides to theta');
+  });
 });

--- a/tests/v20-orientation.test.js
+++ b/tests/v20-orientation.test.js
@@ -177,14 +177,14 @@ test('sprites.js uses correct rotation formula in drawBoneSprite', async () => {
   // Check that rotation uses bone.ang + alignRad + Math.PI
   assert.match(
     source,
-    /const theta = bone\.ang \+ alignRad \+ Math\.PI;/,
-    'rotation should use: bone.ang + alignRad + Math.PI'
+    /const theta = bone\.ang \+ alignRad(?: \+ extraRotRad)? \+ Math\.PI;/,
+    'rotation should combine alignRad, optional extraRotRad, and Math.PI'
   );
   
   // Check the comment matches
   assert.match(
     source,
-    /rotation:\s*bone\.ang \+ alignRad \+ Math\.PI/,
+    /Rotation \(fixed\):\s*bone\.ang \+ alignRad \+ extraRotRad \+ Math\.PI/,
     'comment should document rotation formula correctly'
   );
 });


### PR DESCRIPTION
## Summary
- apply cosmetic style override rotation when rendering sprites so the editor's rotDeg values affect the preview
- document and assert the new rotation formula across regression tests to prevent future regressions

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69129a05ae2883269854065c96608e06)