### PR TITLE
Add fighter appearance cosmetics with body color tinting

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -419,16 +419,16 @@ window.CONFIG = {
         head:{ origin:{ax:-1, ay:6} }
       },
         sprites: {
-          torso: { url: "https://i.imgur.com/YatjSyo.png" },
-          head:  { url: "https://i.imgur.com/WsKQ2Eo.png" },
-          arm_L_upper: { url: "https://i.imgur.com/CAmWLbf.png" },
-          arm_L_lower: { url: "https://i.imgur.com/gOHujif.png" },
-          arm_R_upper: { url: "https://i.imgur.com/CAmWLbf.png" },
-          arm_R_lower: { url: "https://i.imgur.com/gOHujif.png" },
-          leg_L_upper: { url: "https://i.imgur.com/qgcQTmx.png" },
-          leg_L_lower: { url: "https://i.imgur.com/lZbF7j2.png" },
-          leg_R_upper: { url: "https://i.imgur.com/qgcQTmx.png" },
-          leg_R_lower: { url: "https://i.imgur.com/lZbF7j2.png" }
+          torso: { url: "https://i.imgur.com/YatjSyo.png", bodyColor: 'A' },
+          head:  { url: "https://i.imgur.com/WsKQ2Eo.png", bodyColor: 'B' },
+          arm_L_upper: { url: "https://i.imgur.com/CAmWLbf.png", bodyColor: 'A' },
+          arm_L_lower: { url: "https://i.imgur.com/gOHujif.png", bodyColor: 'A' },
+          arm_R_upper: { url: "https://i.imgur.com/CAmWLbf.png", bodyColor: 'A' },
+          arm_R_lower: { url: "https://i.imgur.com/gOHujif.png", bodyColor: 'A' },
+          leg_L_upper: { url: "https://i.imgur.com/qgcQTmx.png", bodyColor: 'C' },
+          leg_L_lower: { url: "https://i.imgur.com/lZbF7j2.png", bodyColor: 'C' },
+          leg_R_upper: { url: "https://i.imgur.com/qgcQTmx.png", bodyColor: 'C' },
+          leg_R_lower: { url: "https://i.imgur.com/lZbF7j2.png", bodyColor: 'C' }
         },
       spriteStyle: {
           widthFactor: { torso:0.9, armUpper:0.9, armLower:0.9, legUpper:0.9, legLower:0.9, head:0.9 },
@@ -460,16 +460,16 @@ window.CONFIG = {
         head:{ origin:{ax:0, ay:0} }
       },
       sprites: {
-        torso: { url: "./assets/fightersprites/mao-ao-m/torso.png" },
-        head:  { url: "./assets/fightersprites/mao-ao-m/head.png" },
-        arm_L_upper: { url: "./assets/fightersprites/mao-ao-m/arm-upper.png" },
-        arm_L_lower: { url: "./assets/fightersprites/mao-ao-m/arm-lower.png" },
-        arm_R_upper: { url: "./assets/fightersprites/mao-ao-m/arm-upper.png" },
-        arm_R_lower: { url: "./assets/fightersprites/mao-ao-m/arm-lower.png" },
-        leg_L_upper: { url: "./assets/fightersprites/mao-ao-m/leg-upper.png" },
-        leg_L_lower: { url: "./assets/fightersprites/mao-ao-m/leg-lower.png" },
-        leg_R_upper: { url: "./assets/fightersprites/mao-ao-m/leg-upper.png" },
-        leg_R_lower: { url: "./assets/fightersprites/mao-ao-m/leg-lower.png" }
+        torso: { url: "./assets/fightersprites/mao-ao-m/torso.png", bodyColor: 'A' },
+        head:  { url: "./assets/fightersprites/mao-ao-m/head.png", bodyColor: 'B' },
+        arm_L_upper: { url: "./assets/fightersprites/mao-ao-m/arm-upper.png", bodyColor: 'B' },
+        arm_L_lower: { url: "./assets/fightersprites/mao-ao-m/arm-lower.png", bodyColor: 'B' },
+        arm_R_upper: { url: "./assets/fightersprites/mao-ao-m/arm-upper.png", bodyColor: 'B' },
+        arm_R_lower: { url: "./assets/fightersprites/mao-ao-m/arm-lower.png", bodyColor: 'B' },
+        leg_L_upper: { url: "./assets/fightersprites/mao-ao-m/leg-upper.png", bodyColor: 'C' },
+        leg_L_lower: { url: "./assets/fightersprites/mao-ao-m/leg-lower.png", bodyColor: 'C' },
+        leg_R_upper: { url: "./assets/fightersprites/mao-ao-m/leg-upper.png", bodyColor: 'C' },
+        leg_R_lower: { url: "./assets/fightersprites/mao-ao-m/leg-lower.png", bodyColor: 'C' }
       },
       spriteStyle: {
           widthFactor: { torso:1.0, armUpper:1.0, armLower:1.0, legUpper:1.0, legLower:1.0, head:1.0 },
@@ -482,6 +482,28 @@ window.CONFIG = {
             legUpper: { ax:-0.10, ay:0,  scaleX:1.7, scaleY:2.75,  rotDeg:-15 },
             legLower: { ax:-0.0,  ay:0.2,  scaleX:1.7, scaleY:2.1, rotDeg:-4 }
           }
+      },
+      appearance: {
+        slots: {
+          torso: { id: 'maoao_body_paint', colors: ['A'] },
+          head: { id: 'maoao_face_paint', colors: ['B'] }
+        },
+        library: {
+          maoao_body_paint: {
+            meta: { name: 'Tribal Body Paint' },
+            appearance: { inheritSprite: 'torso', bodyColors: ['A'] },
+            parts: {
+              torso: { image: { url: './assets/fightersprites/mao-ao-m/torso.png' } }
+            }
+          },
+          maoao_face_paint: {
+            meta: { name: 'Face Paint' },
+            appearance: { inheritSprite: 'head', bodyColors: ['B'] },
+            parts: {
+              head: { image: { url: './assets/fightersprites/mao-ao-m/head.png' } }
+            }
+          }
+        }
       },
       cosmetics: {}
     }
@@ -734,6 +756,11 @@ window.CONFIG = {
       hairstyle: 'short',
       beard: 'none',
       adornments: [],
+      bodyColors: {
+        A: { h: 0, s: 0, v: 0 },
+        B: { h: -20, s: 0.15, v: 0.1 },
+        C: { h: 32, s: 0.25, v: -0.05 }
+      },
       cosmetics: {
         slots: {
           hat: { id: 'basic_headband', hsv: { h: -20, s: 0.2, v: 0 } },
@@ -749,6 +776,11 @@ window.CONFIG = {
       hairstyle: 'long',
       beard: 'goatee',
       adornments: ['earring'],
+      bodyColors: {
+        A: { h: -8, s: 0.05, v: 0.08 },
+        B: { h: 24, s: 0.18, v: -0.02 },
+        C: { h: 72, s: 0.28, v: 0.12 }
+      },
       cosmetics: {
         slots: {
           hat: { id: 'basic_headband', hsv: { h: 12, s: 0.1, v: 0.05 } },

--- a/docs/cosmetic-editor.html
+++ b/docs/cosmetic-editor.html
@@ -88,6 +88,20 @@
             <input id="creatorParts" type="text" placeholder="leg_L_upper, leg_R_upper" spellcheck="false" aria-label="Parts to attach sprite to">
           </label>
         </div>
+        <div class="creator-grid">
+          <label class="creator-field">
+            <span>Appearance overlay</span>
+            <input id="creatorAppearance" type="checkbox" aria-label="Treat cosmetic as appearance overlay">
+          </label>
+          <label class="creator-field">
+            <span>Body colors (A,B,C)</span>
+            <input id="creatorBodyColors" type="text" placeholder="A" spellcheck="false" aria-label="Body color letters to inherit">
+          </label>
+          <label class="creator-field creator-field--wide">
+            <span>Inherit sprite key</span>
+            <input id="creatorSpriteKey" type="text" placeholder="torso" spellcheck="false" aria-label="Sprite style key to inherit">
+          </label>
+        </div>
         <div class="creator-actions">
           <button type="button" id="creatorAdd">➕ Add Cosmetic To Library</button>
           <button type="button" id="creatorEquip">🎯 Equip On Selected Fighter</button>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -223,6 +223,16 @@ function initCharacterDropdown() {
       adornments: charData.adornments
     };
 
+    if (charData.bodyColors){
+      try {
+        window.GAME.selectedBodyColors = JSON.parse(JSON.stringify(charData.bodyColors));
+      } catch (_err) {
+        window.GAME.selectedBodyColors = { ...charData.bodyColors };
+      }
+    } else {
+      delete window.GAME.selectedBodyColors;
+    }
+
     if (charData.cosmetics) {
       try {
         window.GAME.selectedCosmetics = JSON.parse(JSON.stringify(charData.cosmetics));

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -12,7 +12,7 @@
 
 import { angleZero as angleZeroUtil, basis as basisFn, dist, angle as angleUtil, degToRad } from './math-utils.js?v=1';
 import { pickFighterName as pickFighterNameUtil } from './fighter-utils.js?v=1';
-import { COSMETIC_SLOTS, ensureCosmeticLayers, cosmeticTagFor } from './cosmetics.js?v=1';
+import { COSMETIC_SLOTS, ensureCosmeticLayers, cosmeticTagFor, resolveFighterBodyColors } from './cosmetics.js?v=1';
 
 const ASSETS = (window.ASSETS ||= {});
 const CACHE = (ASSETS.sprites ||= {});
@@ -699,7 +699,7 @@ export function renderSprites(ctx){
 
   // RENDER.MIRROR flags control per-limb mirroring (e.g., for attack animations)
   
-  const { assets, style, offsets, cosmetics } = ensureFighterSprites(C, fname);
+  const { assets, style, offsets, cosmetics, bodyColors } = ensureFighterSprites(C, fname);
 
   const zOf = buildZMap(C);
   const queue = [];
@@ -708,18 +708,33 @@ export function renderSprites(ctx){
   // Helper to get mirror flag for a specific part
   const getMirror = getMirrorFlag;
 
+  function makeTintOptions(asset){
+    if (!asset || !bodyColors) return undefined;
+    const spec = asset.bodyColor || asset.bodyColors;
+    const letters = Array.isArray(spec) ? spec : (spec != null ? [spec] : []);
+    for (const entry of letters){
+      const key = String(entry || '').trim().toUpperCase();
+      if (!key) continue;
+      const tint = bodyColors[key];
+      if (tint){
+        return { hsv: { ...tint } };
+      }
+    }
+    return undefined;
+  }
+
   // Hitbox (if desired)
   // enqueue('HITBOX', ()=> { /* draw hitbox if needed */ });
 
   // Torso & head
   enqueue('TORSO', ()=>{
     if (assets.torso && rig.torso){
-      drawBoneSprite(ctx, assets.torso, rig.torso, 'torso', style, offsets);
+      drawBoneSprite(ctx, assets.torso, rig.torso, 'torso', style, offsets, makeTintOptions(assets.torso));
     }
   });
   enqueue('HEAD', ()=>{
     if (assets.head && rig.head){
-      drawBoneSprite(ctx, assets.head, rig.head, 'head', style, offsets);
+      drawBoneSprite(ctx, assets.head, rig.head, 'head', style, offsets, makeTintOptions(assets.head));
     }
   });
 
@@ -731,7 +746,7 @@ export function renderSprites(ctx){
     enqueue('ARM_L_UPPER', ()=> {
       const originX = lArmUpper.x;
       withBranchMirror(ctx, originX, lArmMirror, ()=> {
-        drawBoneSprite(ctx, assets.arm_L_upper, lArmUpper, 'arm_L_upper', style, offsets);
+        drawBoneSprite(ctx, assets.arm_L_upper, lArmUpper, 'arm_L_upper', style, offsets, makeTintOptions(assets.arm_L_upper));
       });
     });
   }
@@ -739,7 +754,7 @@ export function renderSprites(ctx){
     enqueue('ARM_L_LOWER', ()=> {
       const originX = lArmUpper?.x ?? lArmLower.x;
       withBranchMirror(ctx, originX, lArmMirror, ()=> {
-        drawBoneSprite(ctx, assets.arm_L_lower, lArmLower, 'arm_L_lower', style, offsets);
+        drawBoneSprite(ctx, assets.arm_L_lower, lArmLower, 'arm_L_lower', style, offsets, makeTintOptions(assets.arm_L_lower));
       });
     });
   }
@@ -752,7 +767,7 @@ export function renderSprites(ctx){
     enqueue('ARM_R_UPPER', ()=> {
       const originX = rArmUpper.x;
       withBranchMirror(ctx, originX, rArmMirror, ()=> {
-        drawBoneSprite(ctx, assets.arm_R_upper, rArmUpper, 'arm_R_upper', style, offsets);
+        drawBoneSprite(ctx, assets.arm_R_upper, rArmUpper, 'arm_R_upper', style, offsets, makeTintOptions(assets.arm_R_upper));
       });
     });
   }
@@ -760,7 +775,7 @@ export function renderSprites(ctx){
     enqueue('ARM_R_LOWER', ()=> {
       const originX = rArmUpper?.x ?? rArmLower.x;
       withBranchMirror(ctx, originX, rArmMirror, ()=> {
-        drawBoneSprite(ctx, assets.arm_R_lower, rArmLower, 'arm_R_lower', style, offsets);
+        drawBoneSprite(ctx, assets.arm_R_lower, rArmLower, 'arm_R_lower', style, offsets, makeTintOptions(assets.arm_R_lower));
       });
     });
   }
@@ -773,7 +788,7 @@ export function renderSprites(ctx){
     enqueue('LEG_L_UPPER', ()=> {
       const originX = lLegUpper.x;
       withBranchMirror(ctx, originX, lLegMirror, ()=> {
-        drawBoneSprite(ctx, assets.leg_L_upper, lLegUpper, 'leg_L_upper', style, offsets);
+        drawBoneSprite(ctx, assets.leg_L_upper, lLegUpper, 'leg_L_upper', style, offsets, makeTintOptions(assets.leg_L_upper));
       });
     });
   }
@@ -781,7 +796,7 @@ export function renderSprites(ctx){
     enqueue('LEG_L_LOWER', ()=> {
       const originX = lLegUpper?.x ?? lLegLower.x;
       withBranchMirror(ctx, originX, lLegMirror, ()=> {
-        drawBoneSprite(ctx, assets.leg_L_lower, lLegLower, 'leg_L_lower', style, offsets);
+        drawBoneSprite(ctx, assets.leg_L_lower, lLegLower, 'leg_L_lower', style, offsets, makeTintOptions(assets.leg_L_lower));
       });
     });
   }
@@ -794,7 +809,7 @@ export function renderSprites(ctx){
     enqueue('LEG_R_UPPER', ()=> {
       const originX = rLegUpper.x;
       withBranchMirror(ctx, originX, rLegMirror, ()=> {
-        drawBoneSprite(ctx, assets.leg_R_upper, rLegUpper, 'leg_R_upper', style, offsets);
+        drawBoneSprite(ctx, assets.leg_R_upper, rLegUpper, 'leg_R_upper', style, offsets, makeTintOptions(assets.leg_R_upper));
       });
     });
   }
@@ -802,7 +817,7 @@ export function renderSprites(ctx){
     enqueue('LEG_R_LOWER', ()=> {
       const originX = rLegUpper?.x ?? rLegLower.x;
       withBranchMirror(ctx, originX, rLegMirror, ()=> {
-        drawBoneSprite(ctx, assets.leg_R_lower, rLegLower, 'leg_R_lower', style, offsets);
+        drawBoneSprite(ctx, assets.leg_R_lower, rLegLower, 'leg_R_lower', style, offsets, makeTintOptions(assets.leg_R_lower));
       });
     });
   }
@@ -890,6 +905,7 @@ export function ensureFighterSprites(C, fname){
   }
   
   const cosmetics = ensureCosmeticLayers(C, fname, style);
+  const bodyColors = resolveFighterBodyColors(C, fname);
 
-  return { assets: S, style, offsets, cosmetics };
+  return { assets: S, style, offsets, cosmetics, bodyColors };
 }

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -138,6 +138,44 @@ test('ensureCosmeticLayers interprets percentage-style saturation and value', ()
   });
 });
 
+test('appearance cosmetics inherit character body colors', () => {
+  clearCosmeticCache();
+  const config = {
+    characters: {
+      hero: {
+        fighter: 'hero',
+        bodyColors: {
+          A: { h: 15, s: 0.3, v: 0.1 }
+        }
+      }
+    },
+    fighters: {
+      hero: {
+        appearance: {
+          slots: {
+            torso: { id: 'hero_markings', colors: ['A'] }
+          },
+          library: {
+            hero_markings: {
+              appearance: { inheritSprite: 'torso', bodyColors: ['A'] },
+              parts: {
+                torso: { image: { url: 'https://example.com/markings.png' } }
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const layers = ensureCosmeticLayers(config, 'hero', {});
+  strictEqual(layers.length, 1);
+  strictEqual(layers[0].slot, 'appearance:torso');
+  deepStrictEqual(layers[0].hsv, { h: 15, s: 0.3, v: 0.1 });
+  deepStrictEqual(layers[0].extra?.appearance?.bodyColors, ['A']);
+  strictEqual(layers[0].styleKey, 'torso');
+});
+
 test('default character pants tint to blue for player and red for enemy', () => {
   clearCosmeticCache();
   const pants = JSON.parse(readFileSync(new URL('../docs/config/cosmetics/basic_pants.json', import.meta.url), 'utf8'));
@@ -182,7 +220,7 @@ test('default character pants tint to blue for player and red for enemy', () => 
 test('sprites.js integrates cosmetic layers and z-order expansion', () => {
   const spritesContent = readFileSync(new URL('../docs/js/sprites.js', import.meta.url), 'utf8');
   strictEqual(/expanded\.push\(cosmeticTagFor\(tag, slot\)\);/.test(spritesContent), true, 'buildZMap should add cosmetic tags');
-  strictEqual(/const \{ assets, style, offsets, cosmetics } = ensureFighterSprites/.test(spritesContent), true, 'renderSprites should read cosmetics');
+  strictEqual(/const \{ assets, style, offsets, cosmetics(?:, bodyColors)? } = ensureFighterSprites/.test(spritesContent), true, 'renderSprites should read cosmetics');
   strictEqual(/withBranchMirror\(ctx,\s*originX,\s*mirror,\s*\(\)\s*=>\s*\{\s*drawBoneSprite\(ctx, layer\.asset, bone, styleKey/.test(spritesContent), true, 'cosmetic layers should mirror with their limbs');
 });
 


### PR DESCRIPTION
## Summary
- add fighter-specific appearance cosmetic registration and map them to character body color HSV data
- tint base fighter sprites using character body color slots and surface configuration for body color mapping
- extend the cosmetic editor UI and workflow to manage appearance slots and creation
- cover the new appearance flow with unit tests

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d68aa8b48326b11c61b977245460)