### PR TITLE
Move Mao-ao appearance slots to character profiles

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -149,7 +149,9 @@ const COSMETIC_LIBRARY_SOURCES = {
   basic_headband: './config/cosmetics/basic_headband.json',
   layered_travel_cloak: './config/cosmetics/layered_travel_cloak.json',
   simple_poncho: './config/cosmetics/simple_poncho.json',
-  basic_pants: './config/cosmetics/basic_pants.json'
+  basic_pants: './config/cosmetics/basic_pants.json',
+  'appearance::Mao-ao_M::maoao_body_paint': './config/cosmetics/appearance/mao-ao/body_paint.json',
+  'appearance::Mao-ao_M::maoao_face_paint': './config/cosmetics/appearance/mao-ao/face_paint.json'
 };
 
 const KICK_MOVE_POSES = {
@@ -483,28 +485,6 @@ window.CONFIG = {
             legLower: { ax:-0.0,  ay:0.2,  scaleX:1.7, scaleY:2.1, rotDeg:-4 }
           }
       },
-      appearance: {
-        slots: {
-          torso: { id: 'maoao_body_paint', colors: ['A'] },
-          head: { id: 'maoao_face_paint', colors: ['B'] }
-        },
-        library: {
-          maoao_body_paint: {
-            meta: { name: 'Tribal Body Paint' },
-            appearance: { inheritSprite: 'torso', bodyColors: ['A'] },
-            parts: {
-              torso: { image: { url: './assets/fightersprites/mao-ao-m/torso.png' } }
-            }
-          },
-          maoao_face_paint: {
-            meta: { name: 'Face Paint' },
-            appearance: { inheritSprite: 'head', bodyColors: ['B'] },
-            parts: {
-              head: { image: { url: './assets/fightersprites/mao-ao-m/head.png' } }
-            }
-          }
-        }
-      },
       cosmetics: {}
     }
   },
@@ -761,6 +741,12 @@ window.CONFIG = {
         B: { h: -20, s: 0.15, v: 0.1 },
         C: { h: 32, s: 0.25, v: -0.05 }
       },
+      appearance: {
+        slots: {
+          torso: { id: 'maoao_body_paint', colors: ['A'] },
+          head: { id: 'maoao_face_paint', colors: ['B'] }
+        }
+      },
       cosmetics: {
         slots: {
           hat: { id: 'basic_headband', hsv: { h: -20, s: 0.2, v: 0 } },
@@ -780,6 +766,12 @@ window.CONFIG = {
         A: { h: -8, s: 0.05, v: 0.08 },
         B: { h: 24, s: 0.18, v: -0.02 },
         C: { h: 72, s: 0.28, v: 0.12 }
+      },
+      appearance: {
+        slots: {
+          torso: { id: 'maoao_body_paint', colors: ['A'] },
+          head: { id: 'maoao_face_paint', colors: ['B'] }
+        }
       },
       cosmetics: {
         slots: {

--- a/docs/config/cosmetics/appearance/mao-ao/body_paint.json
+++ b/docs/config/cosmetics/appearance/mao-ao/body_paint.json
@@ -1,0 +1,16 @@
+{
+  "meta": { "name": "Tribal Body Paint" },
+  "type": "appearance",
+  "appearance": {
+    "inheritSprite": "torso",
+    "bodyColors": ["A"],
+    "originalId": "maoao_body_paint"
+  },
+  "parts": {
+    "torso": {
+      "image": {
+        "url": "./assets/fightersprites/mao-ao-m/torso.png"
+      }
+    }
+  }
+}

--- a/docs/config/cosmetics/appearance/mao-ao/face_paint.json
+++ b/docs/config/cosmetics/appearance/mao-ao/face_paint.json
@@ -1,0 +1,16 @@
+{
+  "meta": { "name": "Face Paint" },
+  "type": "appearance",
+  "appearance": {
+    "inheritSprite": "head",
+    "bodyColors": ["B"],
+    "originalId": "maoao_face_paint"
+  },
+  "parts": {
+    "head": {
+      "image": {
+        "url": "./assets/fightersprites/mao-ao-m/head.png"
+      }
+    }
+  }
+}

--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -7,7 +7,8 @@ import {
   registerCosmeticLibrary,
   registerFighterCosmeticProfile,
   getFighterCosmeticProfile,
-  registerFighterAppearance
+  registerFighterAppearance,
+  resolveCharacterAppearance
 } from './cosmetics.js?v=1';
 
 const CONFIG = window.CONFIG || {};
@@ -1161,7 +1162,12 @@ function loadFighter(fighterName){
   GAME.selectedFighter = fighterName;
   editorState.activeFighter = fighterName;
   const fighter = CONFIG.fighters?.[fighterName] || {};
-  const appearance = registerFighterAppearance(fighterName, fighter.appearance || {});
+  const { appearance: characterAppearance } = resolveCharacterAppearance(CONFIG, fighterName);
+  const appearance = registerFighterAppearance(
+    fighterName,
+    fighter.appearance || {},
+    characterAppearance
+  );
   editorState.appearanceSlotKeys = Object.keys(appearance.slots || {});
   populateCreatorSlotOptions();
   const slots = fighter.cosmetics?.slots || fighter.cosmetics || {};

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -146,11 +146,7 @@ test('appearance cosmetics inherit character body colors', () => {
         fighter: 'hero',
         bodyColors: {
           A: { h: 15, s: 0.3, v: 0.1 }
-        }
-      }
-    },
-    fighters: {
-      hero: {
+        },
         appearance: {
           slots: {
             torso: { id: 'hero_markings', colors: ['A'] }
@@ -165,6 +161,9 @@ test('appearance cosmetics inherit character body colors', () => {
           }
         }
       }
+    },
+    fighters: {
+      hero: {}
     }
   };
 


### PR DESCRIPTION
## Summary
- move Mao-ao appearance slot assignments into the character definitions and load their cosmetic data from JSON files
- teach the cosmetics runtime and editor to merge character-provided appearance slots with fighter defaults
- update the cosmetics tests to exercise character-scoped appearance data

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e59c30448326b3220f5004be1460)