### PR TITLE
Restore camera follow and sync map registry camera start

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -295,7 +295,7 @@ import { initControls } from './controls.js?v=7';
 import { initCombat } from './combat.js?v=19';
 import { updatePoses } from './animator.js?v=4';
 import { renderAll, LIMB_COLORS } from './render.js?v=4';
-import { updateCamera } from './camera.js?v=1';
+import { initCamera, updateCamera } from './camera.js?v=2';
 import { initHitDetect, runHitDetect } from './hitdetect.js?v=1';
 import { initSprites, renderSprites } from './sprites.js?v=8';
 import { initDebugPanel, updateDebugPanel } from './debug-panel.js?v=1';
@@ -306,6 +306,7 @@ import { initTouchControls } from './touch-controls.js?v=1';
 const cv = $$('#game');
 const cx = cv?.getContext('2d');
 window.GAME ||= {};
+initCamera({ canvas: cv });
 
 // Detect touch devices early so we can surface on-screen controls reliably
 const rootElement = document.documentElement;

--- a/docs/js/camera.js
+++ b/docs/js/camera.js
@@ -1,12 +1,164 @@
-// camera.js — simple x-follow camera with smoothing
-export function updateCamera(canvas){
+// camera.js — simple x-follow camera with smoothing integrated with map registry
+const DEFAULT_WORLD_WIDTH = 1600;
+const DEFAULT_VIEWPORT_WIDTH = 720;
+const DEFAULT_SMOOTHING = 0.15;
+
+let attachedRegistry = null;
+let detachRegistryListener = null;
+let lastViewportWidth = DEFAULT_VIEWPORT_WIDTH;
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) return min;
+  if (!Number.isFinite(min) && !Number.isFinite(max)) return value;
+  if (!Number.isFinite(min)) return Math.min(value, max);
+  if (!Number.isFinite(max)) return Math.max(value, min);
+  if (min > max) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function ensureGameCamera() {
+  window.GAME = window.GAME || {};
+  const camera = (window.GAME.CAMERA = window.GAME.CAMERA || {});
+  camera.x = Number.isFinite(camera.x) ? camera.x : 0;
+  camera.y = Number.isFinite(camera.y) ? camera.y : 0;
+  camera.zoom = Number.isFinite(camera.zoom) ? camera.zoom : 1;
+  camera.smoothing = Number.isFinite(camera.smoothing) ? camera.smoothing : DEFAULT_SMOOTHING;
+  camera.worldWidth = Number.isFinite(camera.worldWidth) ? camera.worldWidth : DEFAULT_WORLD_WIDTH;
+  camera.bounds = camera.bounds || { min: 0, max: DEFAULT_WORLD_WIDTH };
+  return camera;
+}
+
+function computeAreaBounds(area) {
+  if (!area) {
+    return { min: 0, max: DEFAULT_WORLD_WIDTH };
+  }
+  let minX = Infinity;
+  let maxX = -Infinity;
+  const consider = (inst) => {
+    const x = inst?.position?.x;
+    if (Number.isFinite(x)) {
+      minX = Math.min(minX, x);
+      maxX = Math.max(maxX, x);
+    }
+  };
+  if (Array.isArray(area.instances)) {
+    for (const inst of area.instances) consider(inst);
+  }
+  if (Array.isArray(area.props)) {
+    for (const prop of area.props) consider(prop);
+  }
+  const startX = area.camera?.startX;
+  if (Number.isFinite(startX)) {
+    minX = Math.min(minX, startX);
+    maxX = Math.max(maxX, startX);
+  }
+  if (!Number.isFinite(minX) || !Number.isFinite(maxX)) {
+    return { min: 0, max: DEFAULT_WORLD_WIDTH };
+  }
+  if (minX === maxX) {
+    maxX = minX + DEFAULT_WORLD_WIDTH;
+  }
+  const minBound = Math.min(0, minX);
+  const maxBound = Math.max(minBound + DEFAULT_WORLD_WIDTH, maxX);
+  return { min: minBound, max: maxBound };
+}
+
+function syncCameraToArea(area) {
+  const camera = ensureGameCamera();
+  const bounds = computeAreaBounds(area);
+  const viewportWidth = lastViewportWidth || DEFAULT_VIEWPORT_WIDTH;
+  const span = Math.max(bounds.max - bounds.min, viewportWidth, 1);
+  const maxTarget = bounds.min + span - viewportWidth;
+  const clampedStart = clamp(area?.camera?.startX, bounds.min, maxTarget);
+
+  camera.bounds = { min: bounds.min, max: bounds.min + span };
+  camera.worldWidth = span;
+  camera.zoom = Number.isFinite(area?.camera?.startZoom)
+    ? area.camera.startZoom
+    : camera.zoom;
+
+  if (Number.isFinite(clampedStart)) {
+    camera.x = clampedStart;
+  } else {
+    camera.x = clamp(camera.x, bounds.min, maxTarget);
+  }
+  camera.targetX = camera.x;
+}
+
+function attachToRegistry(registry) {
+  if (!registry || typeof registry.on !== 'function') {
+    return;
+  }
+  if (registry === attachedRegistry) {
+    return;
+  }
+  if (typeof detachRegistryListener === 'function') {
+    detachRegistryListener();
+    detachRegistryListener = null;
+  }
+  attachedRegistry = registry;
+  detachRegistryListener = registry.on('active-area-changed', (area) => {
+    syncCameraToArea(area);
+  });
+  if (typeof registry.getActiveArea === 'function') {
+    const activeArea = registry.getActiveArea();
+    if (activeArea) {
+      syncCameraToArea(activeArea);
+    }
+  }
+}
+
+export function initCamera({ canvas, mapRegistry } = {}) {
+  const camera = ensureGameCamera();
+  const config = window.CONFIG || {};
+  lastViewportWidth = canvas?.width || config.canvas?.w || lastViewportWidth || DEFAULT_VIEWPORT_WIDTH;
+  camera.bounds = camera.bounds || { min: 0, max: camera.worldWidth || DEFAULT_WORLD_WIDTH };
+
+  const registry = mapRegistry || window.GAME?.mapRegistry || window.__MAP_REGISTRY__;
+  if (registry) {
+    attachToRegistry(registry);
+  }
+
+  const existingCallback = window.GAME.__onMapRegistryReadyForCamera;
+  window.GAME.__onMapRegistryReadyForCamera = (registryInstance) => {
+    attachToRegistry(registryInstance);
+    if (typeof existingCallback === 'function' && existingCallback !== window.GAME.__onMapRegistryReadyForCamera) {
+      try {
+        existingCallback(registryInstance);
+      } catch (_error) {
+        // Ignore downstream errors to keep camera functional
+      }
+    }
+  };
+}
+
+export function updateCamera(canvas) {
   const G = window.GAME || {};
   const C = window.CONFIG || {};
   if (!G.FIGHTERS || !G.CAMERA) return;
-  const P = G.FIGHTERS.player; if (!P) return;
-  const w = canvas?.width || (C.canvas?.w || 720);
-  const worldW = G.CAMERA.worldWidth || 1600;
-  const target = Math.max(0, Math.min(worldW - w, P.pos.x - w*0.5));
-  const k = G.CAMERA.smoothing ?? 0.15;
-  G.CAMERA.x = (G.CAMERA.x||0) + (target - (G.CAMERA.x||0)) * k;
+  const P = G.FIGHTERS.player;
+  if (!P) return;
+
+  const camera = ensureGameCamera();
+  const viewportWidth = canvas?.width || C.canvas?.w || lastViewportWidth || DEFAULT_VIEWPORT_WIDTH;
+  lastViewportWidth = viewportWidth;
+  camera.viewportWidth = viewportWidth;
+
+  const bounds = camera.bounds || { min: 0, max: camera.worldWidth || DEFAULT_WORLD_WIDTH };
+  const minBound = Number.isFinite(bounds.min) ? bounds.min : 0;
+  const maxBound = Number.isFinite(bounds.max) ? bounds.max : minBound + (camera.worldWidth || DEFAULT_WORLD_WIDTH);
+  const maxCameraX = Math.max(minBound, maxBound - viewportWidth);
+
+  const playerX = Number.isFinite(P.hitbox?.x)
+    ? P.hitbox.x
+    : Number.isFinite(P.pos?.x)
+      ? P.pos.x
+      : 0;
+  const desiredX = playerX - viewportWidth * 0.5;
+  const target = clamp(desiredX, minBound, maxCameraX);
+
+  const smoothing = Number.isFinite(camera.smoothing) ? camera.smoothing : DEFAULT_SMOOTHING;
+  const currentX = Number.isFinite(camera.x) ? camera.x : minBound;
+  camera.x = currentX + (target - currentX) * smoothing;
+  camera.targetX = target;
 }

--- a/docs/js/map-bootstrap.js
+++ b/docs/js/map-bootstrap.js
@@ -71,6 +71,7 @@ async function loadStartingArea() {
     window.GAME = window.GAME || {};
     window.GAME.mapRegistry = registry;
     window.GAME.currentAreaId = area.id;
+    window.GAME.__onMapRegistryReadyForCamera?.(registry);
 
     console.info(`[map-bootstrap] Loaded starting area "${area.id}"`);
   } catch (error) {


### PR DESCRIPTION
## Summary
- restore camera follow behaviour with clamped smoothing based on player position
- connect the camera module to map registry events and bootstrap callbacks
- initialize the camera during app startup so map data can drive world bounds

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e6e07d648326b781cab904e42dec)