### PR TITLE
Add debug logging for layout descriptor and player position

### DIFF
--- a/docs/js/map-bootstrap.js
+++ b/docs/js/map-bootstrap.js
@@ -48,6 +48,12 @@ async function loadStartingArea() {
     }
 
     const layout = await response.json();
+    console.debug('[map-bootstrap] Loaded raw layout descriptor', {
+      id: layout?.areaId || layout?.id || DEFAULT_AREA_ID,
+      name: layout?.areaName || layout?.name || null,
+      source: layoutUrl.href,
+      layout,
+    });
     const area = convertLayoutToArea(layout, {
       areaId: layout.areaId || layout.id || DEFAULT_AREA_ID,
       areaName: layout.areaName || layout.name || 'Example Street',


### PR DESCRIPTION
## Summary
- log the raw layout descriptor when the starting map loads
- add throttled camera debug logging to report the player's X in layout coordinates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c7d344c88326ab2f31c4f32dbb8a)