### PR TITLE
Fix head tracking being disabled during walk poses

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -412,7 +412,8 @@ function computeHeadTargetDeg(F, finalPoseDeg, fcfg){
 function updateAiming(F, currentPose, fighterId){
   const C = window.CONFIG || {};
   const G = window.GAME || {};
-  
+  const poseFlags = currentPose || {};
+
   if (!C.aiming?.enabled) {
     F.aim.active = false;
     F.aim.torsoOffset = 0;
@@ -422,8 +423,8 @@ function updateAiming(F, currentPose, fighterId){
     return;
   }
 
-  // Only aim if pose allows it
-  if (!currentPose.allowAiming) {
+  // Only aim if the pose explicitly disables it
+  if (poseFlags.allowAiming === false) {
     F.aim.active = false;
     F.aim.torsoOffset = 0;
     F.aim.shoulderOffset = 0;
@@ -431,7 +432,7 @@ function updateAiming(F, currentPose, fighterId){
     F.aim.headWorldTarget = null;
     return;
   }
-  
+
   F.aim.active = true;
   
   let targetAngle;
@@ -518,8 +519,8 @@ function updateAiming(F, currentPose, fighterId){
   F.aim.shoulderOffset = clamp(aimDeg * 0.7, -(C.aiming.maxShoulderAngle || 60), (C.aiming.maxShoulderAngle || 60));
 
   // Apply leg aiming if pose allows it
-  if (currentPose.aimLegs) {
-    if (currentPose.aimRightLegOnly) {
+  if (poseFlags.aimLegs) {
+    if (poseFlags.aimRightLegOnly) {
       F.aim.hipOffset = clamp(aimDeg * 0.6, -50, 50); // Only right leg aims
     } else {
       F.aim.hipOffset = clamp(aimDeg * 0.4, -40, 40); // Both legs aim
@@ -539,24 +540,25 @@ function updateAiming(F, currentPose, fighterId){
 // Apply aiming offsets to a pose
 function applyAimingOffsets(poseDeg, F, currentPose){
   if (!F.aim.active) return poseDeg;
-  
+
+  const poseFlags = currentPose || {};
   const result = {...poseDeg};
   result.torso = (result.torso || 0) + F.aim.torsoOffset;
   result.lShoulder = (result.lShoulder || 0) + F.aim.shoulderOffset;
   result.rShoulder = (result.rShoulder || 0) + F.aim.shoulderOffset;
-  
+
   // Apply leg aiming if present
   if (F.aim.hipOffset !== 0) {
-    if (currentPose.aimRightLegOnly) {
+    if (poseFlags.aimRightLegOnly) {
       // Only right leg
       result.rHip = (result.rHip || 0) + F.aim.hipOffset;
-    } else if (currentPose.aimLegs) {
+    } else if (poseFlags.aimLegs) {
       // Both legs
       result.lHip = (result.lHip || 0) + F.aim.hipOffset;
       result.rHip = (result.rHip || 0) + F.aim.hipOffset;
     }
   }
-  
+
   return result;
 }
 

--- a/tests/update-aiming-walk.test.js
+++ b/tests/update-aiming-walk.test.js
@@ -1,0 +1,87 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+function extractFunction(source, name) {
+  const start = source.indexOf(`function ${name}`);
+  assert.notEqual(start, -1, `${name} function should exist`);
+  let depth = 0;
+  let began = false;
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') {
+      depth += 1;
+      began = true;
+    } else if (ch === '}') {
+      depth -= 1;
+      if (began && depth === 0) {
+        return source.slice(start, i + 1);
+      }
+    }
+  }
+  throw new Error(`Could not extract ${name}`);
+}
+
+test('updateAiming stays active when allowAiming is unspecified', async () => {
+  const source = await readFile('docs/js/animator.js', 'utf8');
+  const clampSrc = extractFunction(source, 'clamp');
+  const normalizeSrc = extractFunction(source, 'normalizeRad');
+  const convertSrc = extractFunction(source, 'convertAimToHeadRad');
+  const updateAimingSrc = extractFunction(source, 'updateAiming');
+
+  const script = `
+    const degToRad = (deg) => deg * Math.PI / 180;
+    const radToDegNum = (rad) => rad * 180 / Math.PI;
+    ${clampSrc}
+    ${normalizeSrc}
+    ${convertSrc}
+    ${updateAimingSrc}
+    exports.updateAiming = updateAiming;
+  `;
+
+  const context = {
+    Math,
+    exports: {},
+    window: {
+      CONFIG: {
+        aiming: {
+          enabled: true,
+          smoothing: 8,
+          maxTorsoAngle: 45,
+          maxShoulderAngle: 60
+        }
+      },
+      GAME: {
+        AIMING: { manualAim: false },
+        JOYSTICK: { active: false },
+        MOUSE: { worldX: 100, worldY: 0, isDown: false }
+      }
+    },
+    performance: { now: () => 0 }
+  };
+
+  vm.createContext(context);
+  vm.runInContext(script, context);
+
+  const { updateAiming } = context.exports;
+  const fighter = {
+    pos: { x: 0, y: 0 },
+    facingRad: 0,
+    anim: { dt: 0.016 },
+    aim: {
+      active: false,
+      currentAngle: 0,
+      torsoOffset: 0,
+      shoulderOffset: 0,
+      hipOffset: 0,
+      headWorldTarget: null
+    }
+  };
+
+  const pose = {}; // allowAiming is undefined for walk poses
+  updateAiming(fighter, pose, 'player');
+
+  assert.equal(fighter.aim.active, true, 'Aiming should remain active when allowAiming is not specified');
+  assert.equal(typeof fighter.aim.headWorldTarget, 'number', 'Head target should be computed');
+});


### PR DESCRIPTION
## Summary
- allow aiming when a pose does not explicitly disable it so walking head tracking stays active
- guard aiming offset helpers with pose flags before reading pose-specific options
- add a regression test that keeps head tracking active when allowAiming is unspecified

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913e1ba8f0483268686b52e2d9da1fe)