### PR TITLE
Standardize appearance slot structure

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -753,6 +753,8 @@ window.CONFIG = {
       },
       appearance: {
         slots: {
+          head_hair: {},
+          facial_hair: {},
           eyes: { id: 'mao-ao_circled_eye_L', colors: ['B'] }
         }
       },
@@ -774,8 +776,9 @@ window.CONFIG = {
       },
       appearance: {
         slots: {
-          eyes: { id: 'mao-ao_circled_eyes', colors: ['B'] },
-          hair: { id: 'mao-ao_smooth_stripe', colors: ['B'] }
+          head_hair: { id: 'mao-ao_smooth_stripe', colors: ['B'] },
+          facial_hair: {},
+          eyes: { id: 'mao-ao_circled_eyes', colors: ['B'] }
         }
       },
       cosmetics: {


### PR DESCRIPTION
## Summary
- ensure each character definition declares the head_hair, facial_hair, and eyes appearance slots
- rename the existing hair slot to head_hair to align with the standardized slot naming

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913f45931908326a31e0cfbb13e2324)