### PR TITLE
Add legacy browser detection for docs demo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -385,6 +385,6 @@
   <script type="module" src="./js/map-bootstrap.js?v=1"></script>
   <script type="module" src="./js/cosmetic-library.js?v=1"></script>
   <script type="module" src="./js/cosmetic-profiles.js?v=1"></script>
-  <script type="module" src="./js/app.js?v=19"></script>
+  <script src="./js/bootstrap.js?v=1"></script>
 </body>
 </html>

--- a/docs/js/bootstrap.js
+++ b/docs/js/bootstrap.js
@@ -1,0 +1,44 @@
+(function () {
+  function supportsModernSyntax() {
+    try {
+      // Optional chaining and nullish coalescing
+      // eslint-disable-next-line no-new-func
+      new Function('var obj={foo:{bar:1}}; return obj?.foo?.bar ?? 0;');
+      // Logical assignment
+      // eslint-disable-next-line no-new-func
+      new Function('var state={}; state.config ||= {}; return state.config;');
+    } catch (error) {
+      return false;
+    }
+    return true;
+  }
+
+  function showLegacyBrowserNotice() {
+    var message = document.createElement('div');
+    message.className = 'legacy-browser-notice';
+    message.innerHTML = '<strong>Your browser is out of date.</strong> This demo uses modern JavaScript features that are unavailable in your current browser. Please update to a newer version of Chrome, Firefox, Safari, or Edge to continue.';
+
+    var attach = function () {
+      document.body.insertBefore(message, document.body.firstChild || null);
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', attach);
+    } else {
+      attach();
+    }
+  }
+
+  function loadAppModule() {
+    var script = document.createElement('script');
+    script.type = 'module';
+    script.src = './js/app.js?v=19';
+    document.head.appendChild(script);
+  }
+
+  if (supportsModernSyntax()) {
+    loadAppModule();
+  } else {
+    showLegacyBrowserNotice();
+  }
+})();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -805,6 +805,23 @@ canvas#game{
   text-transform: uppercase;
 }
 
+.legacy-browser-notice {
+  background: #fee2e2;
+  color: #7f1d1d;
+  border: 1px solid #fecaca;
+  padding: 12px 16px;
+  margin: 16px;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.legacy-browser-notice strong {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
 @media (max-width: 960px){
   :root{--control-scale:clamp(0.58,4vw,0.75);--stage-bottom-offset:clamp(12px,3vw,20px);}
 }

--- a/tests/legacy-shim.test.js
+++ b/tests/legacy-shim.test.js
@@ -9,7 +9,7 @@ async function readJs(filename) {
   return readFile(path.join(rootDir, filename), 'utf8');
 }
 
-const moduleLoaderPattern = /<script\s+type="module"\s+src="\.\/js\/app\.js\?v=\d+"><\/script>/i;
+const bootstrapLoaderPattern = /<script\s+src="\.\/js\/bootstrap\.js\?v=\d+"><\/script>/i;
 
 async function readIndex() {
   return readFile(path.resolve('docs/index.html'), 'utf8');
@@ -44,11 +44,20 @@ test('combat module does not define a clearPoseOverride bandaid', async () => {
   );
 });
 
-test('index.html references the versioned app module directly', async () => {
+test('index.html loads the versioned bootstrap loader', async () => {
   const html = await readIndex();
   assert.match(
     html,
-    moduleLoaderPattern,
-    'docs/index.html must load ./js/app.js via a versioned module script tag',
+    bootstrapLoaderPattern,
+    'docs/index.html must load ./js/bootstrap.js via a versioned script tag',
+  );
+});
+
+test('bootstrap loader triggers the versioned app module', async () => {
+  const loader = await readJs('bootstrap.js');
+  assert.match(
+    loader,
+    /script\.src\s*=\s*'\.\/js\/app\.js\?v=\d+'/,
+    'docs/js/bootstrap.js must load ./js/app.js via a versioned module script tag',
   );
 });


### PR DESCRIPTION
## Summary
- add a bootstrap script that verifies support for modern JS syntax before loading the docs app and surfaces a helpful message when it is missing
- switch the docs landing page to load the new bootstrap helper and style the legacy-browser notice so the fallback reads clearly

## Testing
- not run (browser-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a881b1f08326830987bbfdc4f50b)