### PR TITLE
Fix missing fighters block closure in config

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -511,6 +511,7 @@ window.CONFIG = {
       },
       cosmetics: {}
     },
+  },
 
   movement: {
     authoredWeight:0.6, physicsWeight:0.4,


### PR DESCRIPTION
## Summary
- close the fighters section in docs/config/config.js so the file parses correctly

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ae8e5be48326bfe8cf4539385917)