### PR TITLE
Add HUD display for player and spawn coordinates

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -198,6 +198,9 @@
       <div id="aiHud" style="position:absolute; top:8px; left:8px; z-index:50; padding:6px 8px; background:rgba(10,10,14,.7); color:#7dd3fc; font:12px/1.3 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; border:1px solid rgba(125,211,252,.3); border-radius:8px; display:none; pointer-events:none;">
         NPC HUD
       </div>
+      <div id="coordHud" style="position:absolute; top:52px; left:8px; z-index:50; padding:6px 8px; background:rgba(10,10,14,.7); color:#bfdbfe; font:12px/1.3 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; border:1px solid rgba(191,219,254,.35); border-radius:8px; pointer-events:none;">
+        Player: (—, —) | Spawn: (—, —)
+      </div>
       <div id="fpsHud" style="position:absolute; top:8px; right:8px; z-index:50; padding:6px 8px; background:rgba(10,10,14,.7); color:#d1fae5; font:12px/1.3 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; border:1px solid rgba(16,185,129,.35); border-radius:8px; pointer-events:none;">
         FPS: --
       </div>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -384,6 +384,7 @@ const reloadBtn = $$('#btnReloadCfg');
 const fullscreenBtn = $$('#btnFullscreen');
 const stageEl = document.getElementById('gameStage');
 const fpsHud = $$('#fpsHud');
+const coordHud = $$('#coordHud');
 const boneKeyList = $$('#boneKeyList');
 const helpBtn = $$('#btnHelp');
 const helpPanel = $$('#helpPanel');
@@ -1116,6 +1117,15 @@ function updateHUD(){
     if (healthLabel){
       healthLabel.textContent = 'HP: 100';
     }
+  }
+
+  if (coordHud) {
+    const fmt = (value) => (Number.isFinite(value) ? value.toFixed(1) : '—');
+    const pos = P.pos || {};
+    const spawn = window.GAME?.spawnPoints?.player || {};
+    const playerText = `Player: (${fmt(pos.x)}, ${fmt(pos.y)})`;
+    const spawnText = `Spawn: (${fmt(spawn.x)}, ${fmt(spawn.y)})`;
+    coordHud.textContent = `${playerText} | ${spawnText}`;
   }
 }
 

--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -190,6 +190,20 @@ export function initFighters(cv, cx){
     player: makeF('player', playerSpawnX, 1, playerSpawnY),
     npc:    makeF('npc',    npcSpawnX, -1, npcSpawnY)
   };
+  G.spawnPoints = {
+    player: {
+      x: playerSpawnX,
+      y: playerSpawnY,
+      yOffset: playerSpawnYOffset,
+      source: playerSpawn ?? null,
+    },
+    npc: {
+      x: npcSpawnX,
+      y: npcSpawnY,
+      yOffset: resolvedNpcYOffset,
+      source: npcSpawn ?? null,
+    },
+  };
   if (G.editorPreview) {
     G.editorPreview.spawn = {
       player: {


### PR DESCRIPTION
## Summary
- add a HUD widget that shows the player's live position and spawn coordinates
- expose spawn point data from fighter initialization for reuse
- wire the HUD update loop to keep the coordinate display in sync with the game state

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914bdcfd4a083269e213b59ab4dd3d8)