### PR TITLE
Ensure CONFIG alias resolves in sandboxed editors

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -1005,6 +1005,10 @@ window.CONFIG = {
   }
 }
 
+const CONFIG = (typeof window !== 'undefined' && window.CONFIG !== undefined)
+  ? window.CONFIG
+  : globalThis.CONFIG;
+
 const toPascalCase = (value = '') => {
   return value
     .replace(/[_-]+/g, ' ')


### PR DESCRIPTION
## Summary
- prefer the sandbox-provided window when aliasing CONFIG inside the config bundle
- fall back to the ambient global object only if the sandbox window does not expose CONFIG

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914bc81d0c48326a8b1acce58309c66)