### PR TITLE
Fix tinting of white sprites via HSL adjustments

### DIFF
--- a/tests/sprite-grayscale-tint.test.js
+++ b/tests/sprite-grayscale-tint.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+function setupWindow(){
+  globalThis.window = globalThis.window || {};
+  const win = globalThis.window;
+  win.ASSETS = win.ASSETS || {};
+  win.GAME = win.GAME || {};
+  win.RENDER = win.RENDER || {};
+  win.RENDER_DEBUG = win.RENDER_DEBUG || {};
+  return win;
+}
+
+test('white pixels receive tint when positive lightness adjustments are provided', async (t) => {
+  setupWindow();
+  t.after(() => {
+    delete globalThis.window;
+  });
+  const { __TESTING__ } = await import('../docs/js/sprites.js');
+  const { applyHslAdjustmentsToPixel, normalizeHslInput } = __TESTING__;
+
+  const tint = normalizeHslInput({ h: 18, s: 1, l: 0.9 });
+  const [r, g, b] = applyHslAdjustmentsToPixel(255, 255, 255, tint);
+
+  assert.deepStrictEqual([r, g, b], [255, 219, 204]);
+});
+


### PR DESCRIPTION
## Summary
- prevent lightness adjustments from clamping white pixels back to white by treating large positive deltas as target brightness
- expose internal color helpers for tests and add a regression covering white-sprite tinting

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d276086083269f0971842ca0c6d0)