### PR TITLE
Handle config asset loading for GitHub Pages deployments

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -1,5 +1,75 @@
 // khyunchained CONFIG with sprite anchor mapping (torso/start) & optional debug
 
+const __CONFIG_SCRIPT_CONTEXT__ = (() => {
+  if (typeof document !== 'undefined') {
+    const current = document.currentScript;
+    if (current?.src) {
+      try {
+        const scriptUrl = new URL(current.src, window.location?.href || current.src);
+        return {
+          scriptUrl,
+          siteRoot: new URL('../', scriptUrl).href,
+        };
+      } catch (error) {
+        console.warn?.('[config] Unable to derive site root from currentScript', error);
+      }
+    }
+
+    const scripts = typeof document.getElementsByTagName === 'function'
+      ? document.getElementsByTagName('script')
+      : [];
+    for (let index = scripts.length - 1; index >= 0; index -= 1) {
+      const candidate = scripts[index];
+      const src = candidate?.src;
+      if (!src) continue;
+      if (!/\/config\/config\.js(?:[?#].*)?$/i.test(src)) continue;
+      try {
+        const scriptUrl = new URL(src, window.location?.href || src);
+        return {
+          scriptUrl,
+          siteRoot: new URL('../', scriptUrl).href,
+        };
+      } catch (error) {
+        console.warn?.('[config] Unable to derive site root from script tag', error);
+      }
+    }
+  }
+
+  if (typeof window !== 'undefined' && window.location) {
+    try {
+      const siteRoot = new URL('.', window.location.href).href;
+      return { scriptUrl: null, siteRoot };
+    } catch (error) {
+      console.warn?.('[config] Unable to derive site root from window.location', error);
+    }
+  }
+
+  return { scriptUrl: null, siteRoot: '' };
+})();
+
+const CONFIG_SITE_ROOT = __CONFIG_SCRIPT_CONTEXT__.siteRoot;
+
+const resolveConfigUrl = (relativePath) => {
+  if (!relativePath || typeof relativePath !== 'string') return relativePath;
+  try {
+    const base = CONFIG_SITE_ROOT || (typeof window !== 'undefined' && window.location ? window.location.href : undefined);
+    if (!base) return relativePath;
+    return new URL(relativePath, base).href;
+  } catch (_error) {
+    return relativePath;
+  }
+};
+
+if (typeof window !== 'undefined') {
+  window.CONFIG = window.CONFIG || {};
+  if (CONFIG_SITE_ROOT && !window.CONFIG.__siteRoot) {
+    window.CONFIG.__siteRoot = CONFIG_SITE_ROOT;
+  }
+  if (typeof window.CONFIG.resolveConfigUrl !== 'function') {
+    window.CONFIG.resolveConfigUrl = resolveConfigUrl;
+  }
+}
+
 const abilityKnockback = (base, { clamp } = {}) => {
   return (context, opponent) => {
     if (!opponent?.pos) return;

--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -33,6 +33,29 @@ const editorState = (GAME.editorState ||= {
   currentPaletteSource: { slot: null, partKey: null, cosmeticId: null }
 });
 
+function resolveStaticUrl(path){
+  if (!path || typeof path !== 'string') return path;
+  const resolver = typeof CONFIG.resolveConfigUrl === 'function' ? CONFIG.resolveConfigUrl : null;
+  if (resolver){
+    try {
+      return resolver(path);
+    } catch (error){
+      // fall through to location-based resolution
+    }
+  }
+  if (typeof URL === 'function'){
+    try {
+      const base = CONFIG.__siteRoot || window.location?.href;
+      if (base){
+        return new URL(path, base).href;
+      }
+    } catch (_err){
+      // ignore resolution failures
+    }
+  }
+  return path;
+}
+
 const canvas = document.getElementById('cosmeticCanvas');
 const ctx = canvas?.getContext('2d');
 
@@ -260,7 +283,8 @@ async function loadAssetManifest(){
     return;
   }
   try {
-    const response = await fetch('./assets/asset-manifest.json', { cache: 'no-cache' });
+    const manifestUrl = resolveStaticUrl('./assets/asset-manifest.json');
+    const response = await fetch(manifestUrl, { cache: 'no-cache' });
     if (!response.ok){
       throw new Error(`HTTP ${response.status}`);
     }

--- a/docs/js/cosmetic-library.js
+++ b/docs/js/cosmetic-library.js
@@ -4,17 +4,41 @@ const ROOT = typeof window !== 'undefined' ? window : globalThis;
 const CONFIG = ROOT?.CONFIG || {};
 const sources = CONFIG.cosmetics?.librarySources || {};
 
+function resolveLibraryUrl(url) {
+  if (!url || typeof url !== 'string') return url;
+  const resolver = CONFIG?.resolveConfigUrl;
+  if (typeof resolver === 'function') {
+    try {
+      return resolver(url);
+    } catch (error) {
+      // fall through to location-based resolution
+    }
+  }
+  if (typeof URL === 'function') {
+    try {
+      const base = CONFIG?.__siteRoot || ROOT?.location?.href;
+      if (base) {
+        return new URL(url, base).href;
+      }
+    } catch (_error) {
+      // ignore resolution failures
+    }
+  }
+  return url;
+}
+
 async function loadCosmetic(id, url){
   if (!id || !url) return;
+  const resolvedUrl = resolveLibraryUrl(url);
   try {
-    const response = await fetch(url, { cache: 'no-cache' });
+    const response = await fetch(resolvedUrl, { cache: 'no-cache' });
     if (!response.ok){
       throw new Error(`HTTP ${response.status}`);
     }
     const data = await response.json();
     registerCosmeticLibrary({ [id]: data });
   } catch (err) {
-    console.warn(`[cosmetics] Failed to load cosmetic ${id} from ${url}`, err);
+    console.warn(`[cosmetics] Failed to load cosmetic ${id} from ${resolvedUrl}`, err);
   }
 }
 


### PR DESCRIPTION
## Summary
- derive the site root from the published config script and expose a shared resolve helper on `window.CONFIG`
- resolve cosmetic library, profile, palette, and editor asset fetches against the derived base path before issuing requests

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e0062b7c832697499f173b8b5d58)