### PR TITLE
Fix site metadata initialization for config script

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -60,6 +60,93 @@ const resolveConfigUrl = (relativePath) => {
   }
 };
 
+const DEFAULT_CONFIG_SITE_METADATA = {
+  title: 'KHY Stage Game (Modularized)',
+  description: 'Explore the modular combat sandbox powering Song of Khions: Empire Prologue.',
+  siteName: 'SoK Empire Prologue',
+  twitterCard: 'summary',
+  type: 'website',
+};
+
+const normalizeUrl = (value) => {
+  if (!value || typeof value !== 'string') return '';
+  try {
+    const resolved = resolveConfigUrl(value);
+    const base = CONFIG_SITE_ROOT || (typeof window !== 'undefined' && window.location?.href ? window.location.href : undefined);
+    const url = base ? new URL(resolved, base) : new URL(resolved);
+    if (/\/index\.html?$/i.test(url.pathname)) {
+      url.pathname = url.pathname.replace(/\/index\.html?$/i, '/');
+    }
+    url.hash = '';
+    return url.href;
+  } catch (_error) {
+    return value;
+  }
+};
+
+const ensureConfigSiteMetadata = () => {
+  if (typeof window === 'undefined') return;
+
+  window.CONFIG = window.CONFIG || {};
+
+  if (CONFIG_SITE_ROOT && !window.CONFIG.__siteRoot) {
+    window.CONFIG.__siteRoot = CONFIG_SITE_ROOT;
+  }
+  if (typeof window.CONFIG.resolveConfigUrl !== 'function') {
+    window.CONFIG.resolveConfigUrl = resolveConfigUrl;
+  }
+
+  const existing = window.CONFIG.siteMetadata || {};
+  const fallbackUrl = CONFIG_SITE_ROOT || normalizeUrl(typeof window !== 'undefined' && window.location?.href ? window.location.href : '');
+  const metadata = {
+    ...DEFAULT_CONFIG_SITE_METADATA,
+    ...existing,
+  };
+
+  metadata.url = normalizeUrl(metadata.url || metadata.canonicalUrl || fallbackUrl) || fallbackUrl;
+  metadata.canonicalUrl = metadata.url;
+  metadata.image = metadata.image ? normalizeUrl(metadata.image) : resolveConfigUrl('./favicon.svg');
+  if (!metadata.image || typeof metadata.image !== 'string') {
+    metadata.image = resolveConfigUrl('./favicon.svg');
+  }
+
+  window.CONFIG.siteMetadata = metadata;
+
+  if (typeof document === 'undefined') return;
+  const hasQuery = typeof document.querySelector === 'function';
+  const canCreate = typeof document.createElement === 'function';
+  const head = document.head || (typeof document.getElementsByTagName === 'function' ? document.getElementsByTagName('head')[0] : null);
+  if (!head || !canCreate || typeof head.appendChild !== 'function') return;
+
+  const ensureTag = (selector, attributes) => {
+    if (!attributes || !attributes.tagName) return;
+    let element = hasQuery ? document.querySelector(selector) : null;
+    if (!element) {
+      element = document.createElement(attributes.tagName);
+      head.appendChild(element);
+    }
+    Object.entries(attributes).forEach(([key, value]) => {
+      if (key === 'tagName') return;
+      if (value === undefined || value === null || value === '') return;
+      try { element.setAttribute(key, value); } catch (_error) {}
+    });
+    return element;
+  };
+
+  ensureTag('link[rel="canonical"]', { tagName: 'link', rel: 'canonical', href: metadata.canonicalUrl });
+  ensureTag('meta[name="description"]', { tagName: 'meta', name: 'description', content: metadata.description });
+  ensureTag('meta[property="og:type"]', { tagName: 'meta', property: 'og:type', content: metadata.type });
+  ensureTag('meta[property="og:title"]', { tagName: 'meta', property: 'og:title', content: metadata.title });
+  ensureTag('meta[property="og:description"]', { tagName: 'meta', property: 'og:description', content: metadata.description });
+  ensureTag('meta[property="og:site_name"]', { tagName: 'meta', property: 'og:site_name', content: metadata.siteName });
+  ensureTag('meta[property="og:url"]', { tagName: 'meta', property: 'og:url', content: metadata.canonicalUrl });
+  ensureTag('meta[property="og:image"]', { tagName: 'meta', property: 'og:image', content: metadata.image });
+  ensureTag('meta[name="twitter:card"]', { tagName: 'meta', name: 'twitter:card', content: metadata.twitterCard });
+  ensureTag('meta[name="twitter:title"]', { tagName: 'meta', name: 'twitter:title', content: metadata.title });
+  ensureTag('meta[name="twitter:description"]', { tagName: 'meta', name: 'twitter:description', content: metadata.description });
+  ensureTag('meta[name="twitter:image"]', { tagName: 'meta', name: 'twitter:image', content: metadata.image });
+};
+
 if (typeof window !== 'undefined') {
   window.CONFIG = window.CONFIG || {};
   if (CONFIG_SITE_ROOT && !window.CONFIG.__siteRoot) {


### PR DESCRIPTION
## Summary
- add ensureConfigSiteMetadata helper that seeds defaults and injects metadata tags when the DOM is present
- normalize canonical URLs, preserve __siteRoot/resolveConfigUrl, and expose site metadata for other scripts

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ebea5ddc8326980cc04f545fbae6)