### PR TITLE
Add reliable canvas tint helper and update sprite pipeline

### DIFF
--- a/docs/js/sprite_tint_v2.js
+++ b/docs/js/sprite_tint_v2.js
@@ -1,0 +1,167 @@
+const DEFAULT_DEBUG_LABEL = (color) => {
+  const [r = 255, g = 255, b = 255, a = 255] = color || [];
+  const alpha = (a / 255).toFixed(2);
+  return `rgba(${r|0},${g|0},${b|0},${alpha})`;
+};
+
+function rgbaToPaint(rgba) {
+  const [r = 255, g = 255, b = 255, a = 255] = Array.isArray(rgba) ? rgba : [];
+  const alpha = Math.max(0, Math.min(255, a)) / 255;
+  const rr = Math.max(0, Math.min(255, r)) | 0;
+  const gg = Math.max(0, Math.min(255, g)) | 0;
+  const bb = Math.max(0, Math.min(255, b)) | 0;
+  return { css: `rgb(${rr},${gg},${bb})`, alpha };
+}
+
+export function tintSpriteToCanvas(source, dest, blendColor, opts = {}) {
+  if (!source || !dest) return false;
+
+  const w = (source.width || dest.width || 0) | 0;
+  const h = (source.height || dest.height || 0) | 0;
+  if (!w || !h) return false;
+
+  if (dest.width !== w) dest.width = w;
+  if (dest.height !== h) dest.height = h;
+
+  const ctx = dest.getContext && dest.getContext('2d', { willReadFrequently: false });
+  if (!ctx) return false;
+
+  const { css, alpha } = rgbaToPaint(blendColor);
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.globalAlpha = 1;
+  ctx.clearRect(0, 0, w, h);
+
+  ctx.globalAlpha = alpha;
+  ctx.fillStyle = css;
+  ctx.fillRect(0, 0, w, h);
+
+  ctx.globalCompositeOperation = 'destination-in';
+  ctx.globalAlpha = 1;
+  if (typeof ctx.drawImage === 'function') {
+    ctx.drawImage(source, 0, 0);
+  } else {
+    return false;
+  }
+
+  if (opts.debug) {
+    try {
+      const sw = Math.max(8, Math.round(w * 0.06));
+      ctx.globalCompositeOperation = 'source-over';
+      ctx.globalAlpha = 1;
+      ctx.strokeStyle = 'rgba(0,0,0,0.5)';
+      ctx.lineWidth = 1;
+      ctx.fillStyle = css;
+      ctx.fillRect(2, 2, sw, sw);
+      ctx.strokeRect(2, 2, sw, sw);
+      if (opts.label) {
+        ctx.font = `bold ${Math.max(10, Math.round(sw * 0.55))}px sans-serif`;
+        ctx.fillStyle = 'rgba(0,0,0,0.75)';
+        ctx.fillText(opts.label, 4 + sw + 2, 2 + sw - 2);
+      }
+    } catch (err) {
+      // Ignore rendering errors in debug overlay (e.g., fonts unavailable)
+    }
+  }
+
+  return true;
+}
+
+function cloneBlendColor(color) {
+  if (!Array.isArray(color)) return [255, 255, 255, 0];
+  const clone = color.slice(0, 4);
+  if (clone.length < 4) {
+    clone[3] = clone[3] ?? 0;
+  }
+  return clone;
+}
+
+function defaultTintDebug(sprite, color) {
+  const debugFlag = Boolean(sprite && sprite._debugTint);
+  return {
+    debug: debugFlag,
+    label: debugFlag ? DEFAULT_DEBUG_LABEL(color) : undefined
+  };
+}
+
+function ensureCanvas(canvas, width, height) {
+  if (!canvas) {
+    if (typeof document === 'undefined') return null;
+    return ensureCanvas(document.createElement('canvas'), width, height);
+  }
+  const target = canvas;
+  if (target.width !== width) target.width = width;
+  if (target.height !== height) target.height = height;
+  return target;
+}
+
+function copySourceToTarget(source, target) {
+  const ctx = target.getContext && target.getContext('2d');
+  if (!ctx) return;
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.globalAlpha = 1;
+  ctx.clearRect(0, 0, target.width, target.height);
+  ctx.drawImage(source, 0, 0);
+}
+
+export function createExecuteTint({ getDebugOptions } = {}) {
+  const debugResolver = typeof getDebugOptions === 'function' ? getDebugOptions : defaultTintDebug;
+  return function executeTintV2() {
+    const bmp = this && this._bitmap;
+    const src = bmp && (bmp.canvas || bmp._canvas || bmp.image || bmp.baseTexture || bmp);
+    const width = src?.width | 0;
+    const height = src?.height | 0;
+    if (!src || !width || !height) return;
+
+    const color = cloneBlendColor(this._blendColor);
+    const alpha = color[3] == null ? 0 : color[3];
+
+    this._tintCanvas = ensureCanvas(this._tintCanvas, width, height);
+    const out = this._tintCanvas;
+    if (!out) return;
+
+    if (alpha <= 0) {
+      copySourceToTarget(src, out);
+      if (typeof this._applyTintToTarget === 'function') this._applyTintToTarget(out);
+      if (typeof this._setDirty === 'function') this._setDirty();
+      return;
+    }
+
+    const debug = debugResolver(this, color);
+    const ok = tintSpriteToCanvas(src, out, color, debug);
+    if (!ok) {
+      copySourceToTarget(src, out);
+    }
+
+    if (typeof this._applyTintToTarget === 'function') {
+      this._applyTintToTarget(out);
+    } else if (bmp && bmp.context) {
+      const ctx = bmp.context;
+      ctx.clearRect(0, 0, width, height);
+      ctx.drawImage(out, 0, 0);
+    }
+    if (typeof this._setDirty === 'function') this._setDirty();
+  };
+}
+
+export function installExecuteTintPatch(SpriteClass, options) {
+  const SpriteCtor = SpriteClass || (typeof window !== 'undefined' ? window.Sprite : undefined);
+  if (!SpriteCtor || !SpriteCtor.prototype) return false;
+  const proto = SpriteCtor.prototype;
+  const executeTint = createExecuteTint(options);
+  proto._executeTint = executeTint;
+  proto._executeTintV2 = executeTint;
+  return true;
+}
+
+if (typeof window !== 'undefined') {
+  window.tintSpriteToCanvas = window.tintSpriteToCanvas || tintSpriteToCanvas;
+  window.installExecuteTintPatch = window.installExecuteTintPatch || installExecuteTintPatch;
+}
+
+export const __SPRITE_TINT_INTERNALS__ = {
+  rgbaToPaint,
+  cloneBlendColor,
+  ensureCanvas,
+  copySourceToTarget,
+  DEFAULT_DEBUG_LABEL
+};

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -13,6 +13,7 @@
 import { angleZero as angleZeroUtil, basis as basisFn, dist, angle as angleUtil, degToRad } from './math-utils.js?v=1';
 import { pickFighterName as pickFighterNameUtil } from './fighter-utils.js?v=1';
 import { COSMETIC_SLOTS, ensureCosmeticLayers, cosmeticTagFor, resolveFighterBodyColors } from './cosmetics.js?v=1';
+import { tintSpriteToCanvas } from './sprite_tint_v2.js?v=1';
 
 const ASSETS = (window.ASSETS ||= {});
 const CACHE = (ASSETS.sprites ||= {});
@@ -257,31 +258,21 @@ function tintImageWithHsl(img, adjustments){
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
-  const ctx = canvas.getContext('2d');
-  if (!ctx){
+
+  const [r, g, b] = applyHslAdjustmentsToPixel(255, 255, 255, adjustments);
+  const blendColor = [r, g, b, 255];
+
+  const debugFlag = Boolean(typeof window !== 'undefined' && window.RENDER_DEBUG?.tintSwatches);
+  const debugOptions = debugFlag
+    ? { debug: true, label: `rgba(${r|0},${g|0},${b|0},1.00)` }
+    : { debug: false };
+
+  const ok = tintSpriteToCanvas(img, canvas, blendColor, debugOptions);
+  if (!ok){
     imageCache.set(key, null);
     return null;
   }
-  ctx.drawImage(img, 0, 0, width, height);
 
-  let imageData;
-  try {
-    imageData = ctx.getImageData(0, 0, width, height);
-  } catch (err){
-    imageCache.set(key, null);
-    return null;
-  }
-
-  const data = imageData.data;
-  for (let i = 0; i < data.length; i += 4){
-    const alpha = data[i + 3];
-    if (!alpha) continue;
-    const [nr, ng, nb] = applyHslAdjustmentsToPixel(data[i], data[i + 1], data[i + 2], adjustments);
-    data[i] = nr;
-    data[i + 1] = ng;
-    data[i + 2] = nb;
-  }
-  ctx.putImageData(imageData, 0, 0);
   imageCache.set(key, canvas);
   return canvas;
 }
@@ -1060,5 +1051,6 @@ export const __TESTING__ = {
   applyHslAdjustmentsToPixel,
   normalizeHslInput,
   rgbToHslNormalized,
-  hslToRgbNormalized
+  hslToRgbNormalized,
+  tintImageWithHsl
 };

--- a/tests/sprite-tint-helper.test.js
+++ b/tests/sprite-tint-helper.test.js
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+function createStubContext(ops){
+  const ctx = {
+    globalCompositeOperation: 'source-over',
+    globalAlpha: 0,
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    font: '',
+    clearRect: (...args) => ops.push(['clearRect', ...args]),
+    fillRect: (...args) => ops.push(['fillRect', ctx.fillStyle, ...args]),
+    strokeRect: (...args) => ops.push(['strokeRect', ctx.strokeStyle, ...args]),
+    drawImage: (...args) => ops.push(['drawImage', ...args]),
+    fillText: (...args) => ops.push(['fillText', ...args])
+  };
+  return ctx;
+}
+
+test('tintSpriteToCanvas performs fill-then-mask tinting', async () => {
+  const ops = [];
+  const ctx = createStubContext(ops);
+  const dest = {
+    width: 0,
+    height: 0,
+    getContext(type){
+      assert.strictEqual(type, '2d');
+      return ctx;
+    }
+  };
+  const source = { width: 12, height: 8 };
+  const { tintSpriteToCanvas } = await import('../docs/js/sprite_tint_v2.js');
+
+  const result = tintSpriteToCanvas(source, dest, [16, 32, 64, 255], { debug: true, label: 'dbg' });
+
+  assert.strictEqual(result, true);
+  assert.strictEqual(dest.width, 12);
+  assert.strictEqual(dest.height, 8);
+  assert.strictEqual(ops[1][1], 'rgb(16,32,64)');
+  assert.strictEqual(ctx.globalCompositeOperation, 'source-over');
+  assert.deepStrictEqual(ops.slice(0, 3).map(([name]) => name), ['clearRect', 'fillRect', 'drawImage']);
+  const debugCalls = ops.filter(([name]) => name === 'strokeRect' || name === 'fillText');
+  assert.ok(debugCalls.length >= 1);
+});
+
+test('tintSpriteToCanvas returns false when context is unavailable', async () => {
+  const { tintSpriteToCanvas } = await import('../docs/js/sprite_tint_v2.js');
+  const source = { width: 10, height: 10 };
+  const dest = { width: 0, height: 0, getContext: () => null };
+  assert.strictEqual(tintSpriteToCanvas(source, dest, [255, 0, 0, 255]), false);
+});


### PR DESCRIPTION
## Summary
- add a reusable canvas tint helper that draws fill-then-mask output with optional debug swatches
- switch sprites.js HSL tinting to the new helper and expose the API for tests
- cover the helper with a node test that verifies the fill/mask and failure fallback paths

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f485d1888326ae141df36b138df0)