### PR TITLE
Preserve fighter dropdown selection across reinitialisation

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -606,6 +606,11 @@ function initFighterDropdown() {
 
   const C = window.CONFIG || {};
   const fighters = C.fighters || {};
+  const previousSelection =
+    fighterSelect.value ||
+    currentSelectedFighter ||
+    window.GAME?.selectedFighter ||
+    null;
 
   // Clear existing options
   fighterSelect.innerHTML = '';
@@ -624,17 +629,37 @@ function initFighterDropdown() {
     fighterSelect.appendChild(option);
   });
 
-  // Handle selection change
-  fighterSelect.addEventListener('change', (e) => {
-    const selectedFighter = e.target.value;
-    currentSelectedFighter = selectedFighter;
-    window.GAME.selectedFighter = selectedFighter;
-    if (selectedFighter) {
-      showFighterSettings(selectedFighter);
-    } else {
+  const hasPreviousSelection =
+    previousSelection && Object.prototype.hasOwnProperty.call(fighters, previousSelection);
+
+  if (hasPreviousSelection) {
+    fighterSelect.value = previousSelection;
+    currentSelectedFighter = previousSelection;
+    window.GAME ||= {};
+    window.GAME.selectedFighter = previousSelection;
+    showFighterSettings(previousSelection);
+  } else {
+    fighterSelect.value = '';
+    if (!previousSelection) {
       hideFighterSettings();
     }
-  });
+  }
+
+  // Handle selection change
+  if (!fighterSelect.dataset.initialized) {
+    fighterSelect.addEventListener('change', (e) => {
+      const selectedFighter = e.target.value;
+      currentSelectedFighter = selectedFighter;
+      window.GAME ||= {};
+      window.GAME.selectedFighter = selectedFighter;
+      if (selectedFighter) {
+        showFighterSettings(selectedFighter);
+      } else {
+        hideFighterSettings();
+      }
+    });
+    fighterSelect.dataset.initialized = 'true';
+  }
 
   console.log('[initFighterDropdown] Fighter dropdown initialized with', Object.keys(fighters).length, 'fighters');
 }

--- a/tests/fighter-dropdown.test.js
+++ b/tests/fighter-dropdown.test.js
@@ -38,15 +38,32 @@ describe('Fighter dropdown selection fix', () => {
     // Find the fighterSelect.addEventListener('change', ...) section
     const changeHandlerRegex = /fighterSelect\.addEventListener\s*\(\s*['"]change['"]\s*,[\s\S]*?\}\s*\);/;
     const changeHandlerMatch = appJsSrc.match(changeHandlerRegex);
-    
+
     assert.ok(changeHandlerMatch, 'Fighter dropdown should have a change event listener');
-    
+
     const handlerCode = changeHandlerMatch[0];
-    
+
     // Verify that the handler still sets currentSelectedFighter (local variable)
     assert.ok(
       handlerCode.includes('currentSelectedFighter'),
       'Change handler should still set currentSelectedFighter for local tracking'
+    );
+  });
+
+  it('fighter dropdown restores previous selection when reinitialised', () => {
+    assert.ok(
+      /const previousSelection\s*=/.test(appJsSrc),
+      'initFighterDropdown should compute a previous selection before rebuilding options'
+    );
+
+    assert.ok(
+      appJsSrc.includes('window.GAME.selectedFighter = previousSelection'),
+      'initFighterDropdown should push the restored selection into window.GAME to keep the runtime in sync'
+    );
+
+    assert.ok(
+      appJsSrc.includes("fighterSelect.dataset.initialized = 'true'"),
+      'initFighterDropdown should guard the change listener to avoid duplicate registrations when reinitialised'
     );
   });
 });


### PR DESCRIPTION
## Summary
- preserve the fighter dropdown selection when the control is rebuilt and avoid duplicate change handlers
- sync the restored selection into `window.GAME` and hide the settings panel when no fighter is chosen
- extend the fighter dropdown test to cover selection restoration safeguards

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150623110c83269ae3fa3f43a41c47)