### PR TITLE
Restore character dropdown state across reloads

### DIFF
--- a/tests/character-dropdown.test.js
+++ b/tests/character-dropdown.test.js
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('Character dropdown resilience', () => {
+  const appJsPath = join(__dirname, '..', 'docs', 'js', 'app.js');
+  const appJsSrc = readFileSync(appJsPath, 'utf-8');
+
+  it('computes the previous selection before rebuilding options', () => {
+    assert.ok(
+      /const previousSelection\s*=/.test(appJsSrc),
+      'initCharacterDropdown should compute a previousSelection before clearing the dropdown'
+    );
+
+    assert.ok(
+      appJsSrc.includes('characterSelect.value ||') && appJsSrc.includes('window.GAME?.selectedCharacter'),
+      'previousSelection should consider the existing DOM value and window.GAME.selectedCharacter state'
+    );
+  });
+
+  it('re-applies the previous selection when it remains available', () => {
+    assert.ok(
+      /const hasPreviousSelection\s*=/.test(appJsSrc),
+      'initCharacterDropdown should detect whether the previous selection is still present in the config'
+    );
+
+    assert.ok(
+      appJsSrc.includes('Object.prototype.hasOwnProperty.call(characters, previousSelection)'),
+      'previous selection check should guard against stale config entries'
+    );
+
+    assert.ok(
+      appJsSrc.includes("onCharacterChange({ target: { value: nextSelection } });"),
+      'initCharacterDropdown should invoke onCharacterChange with the restored selection to sync runtime state'
+    );
+  });
+
+  it('clears runtime state when the selection is removed', () => {
+    assert.ok(
+      appJsSrc.includes('if (!selectedChar || !map[selectedChar]) {'),
+      'change handler should guard against cleared or missing characters'
+    );
+
+    assert.ok(
+      appJsSrc.includes('window.GAME.selectedCharacter = null;'),
+      'clearing the selection should reset window.GAME.selectedCharacter'
+    );
+
+    assert.ok(
+      appJsSrc.includes('setAbilitySelection(defaults, { syncDropdowns: true })'),
+      'clearing the selection should restore ability dropdowns from defaults'
+    );
+  });
+});

--- a/tests/fighter-dropdown.test.js
+++ b/tests/fighter-dropdown.test.js
@@ -38,15 +38,32 @@ describe('Fighter dropdown selection fix', () => {
     // Find the fighterSelect.addEventListener('change', ...) section
     const changeHandlerRegex = /fighterSelect\.addEventListener\s*\(\s*['"]change['"]\s*,[\s\S]*?\}\s*\);/;
     const changeHandlerMatch = appJsSrc.match(changeHandlerRegex);
-    
+
     assert.ok(changeHandlerMatch, 'Fighter dropdown should have a change event listener');
-    
+
     const handlerCode = changeHandlerMatch[0];
-    
+
     // Verify that the handler still sets currentSelectedFighter (local variable)
     assert.ok(
       handlerCode.includes('currentSelectedFighter'),
       'Change handler should still set currentSelectedFighter for local tracking'
+    );
+  });
+
+  it('fighter dropdown restores previous selection when reinitialised', () => {
+    assert.ok(
+      /const previousSelection\s*=/.test(appJsSrc),
+      'initFighterDropdown should compute a previous selection before rebuilding options'
+    );
+
+    assert.ok(
+      appJsSrc.includes('window.GAME.selectedFighter = previousSelection'),
+      'initFighterDropdown should push the restored selection into window.GAME to keep the runtime in sync'
+    );
+
+    assert.ok(
+      appJsSrc.includes("fighterSelect.dataset.initialized = 'true'"),
+      'initFighterDropdown should guard the change listener to avoid duplicate registrations when reinitialised'
     );
   });
 });


### PR DESCRIPTION
## Summary
- reuse the previous character selection when rebuilding the dropdown and fall back to defaults when it disappears
- clear linked fighter, weapon, cosmetic, and ability state when the character choice is cleared
- add regression tests that verify the character dropdown restoration and reset behaviours

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150623110c83269ae3fa3f43a41c47)