### PR TITLE
Fix stage aspect ratio to keep player centered

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -170,9 +170,14 @@ main.stack{
 }
 
 .stage{
+  --stage-aspect-width:720;
+  --stage-aspect-height:460;
+  --stage-max-height:min(90vh,720px);
   position:relative;
-  width:100%;
-  height:clamp(320px,60vh,720px);
+  width:min(100%,calc(var(--stage-max-height)*var(--stage-aspect-width)/var(--stage-aspect-height)));
+  aspect-ratio:var(--stage-aspect-width)/var(--stage-aspect-height);
+  max-height:var(--stage-max-height);
+  margin-inline:auto;
   border-radius:var(--card-br);
   overflow:hidden;
   background:#080b12;


### PR DESCRIPTION
## Summary
- enforce a fixed 720×460 aspect ratio for the stage container so the canvas no longer stretches with layout changes
- cap the rendered height to 90vh/720px and center the stage horizontally to maintain consistent framing

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691536a3be4c83268bb04d799ce4349e)