### PR TITLE
Fix cosmetic overlay tinting and activation

### DIFF
--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -538,7 +538,7 @@ export function renderSprites(ctx){
 
   // RENDER.MIRROR flags control per-limb mirroring (e.g., for attack animations)
   
-  const { assets, style, offsets, cosmetics, bodyColors } = ensureFighterSprites(C, fname);
+  const { assets, style, offsets, cosmetics, bodyColors, untintedOverlays: activeUntintedOverlays } = ensureFighterSprites(C, fname);
 
   const zOf = buildZMap(C);
   const queue = [];
@@ -562,8 +562,7 @@ export function renderSprites(ctx){
     return undefined;
   }
 
-  const untintedOverlays = ensureFighterSprites.__lastResult?.untintedOverlays || {};
-  const overlayMap = untintedOverlays || {};
+  const overlayMap = activeUntintedOverlays || {};
   function drawUntintedOverlays(partKey, bone, styleKey){
     const overlays = overlayMap[partKey];
     if (!overlays || overlays.length === 0) return;
@@ -694,7 +693,7 @@ export function renderSprites(ctx){
           withBranchMirror(ctx, originX, mirror, ()=>{
             drawBoneSprite(ctx, layer.asset, bone, styleKey, style, offsets, {
               styleOverride: layer.styleOverride,
-              hsv: layer.hsv,
+              hsl: layer.hsl ?? layer.hsv,
               warp: layer.warp,
               alignRad: layer.alignRad,
               alignDeg: layer.alignRad == null ? layer.alignDeg : undefined,


### PR DESCRIPTION
## Summary
- pull the active untinted overlay map directly from ensureFighterSprites results when rendering
- pass the cosmetic layer HSL data to drawBoneSprite so tints and appearance layers render correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162a446b6883268be3a46827a301e1)