### PR TITLE
Inherit align angles for untinted overlays

### DIFF
--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -755,7 +755,7 @@ function resolveSpriteAssets(spriteMap){
   }
 }
 
-function resolveUntintedOverlayMap(fighterConfig = {}){
+function resolveUntintedOverlayMap(fighterConfig = {}, spriteMap = {}){
   const source = fighterConfig.untintedOverlays
     || fighterConfig.sprites?.untintedOverlays
     || fighterConfig.sprites?.untinted_regions;
@@ -805,10 +805,17 @@ function resolveUntintedOverlayMap(fighterConfig = {}){
       const partKey = String(rawPart || '').trim();
       if (!partKey) continue;
       const list = map[partKey] || (map[partKey] = []);
+      const options = { ...baseOptions };
+      if (!Number.isFinite(options.alignRad)){
+        const baseAsset = spriteMap?.[partKey];
+        if (Number.isFinite(baseAsset?.alignRad)){
+          options.alignRad = baseAsset.alignRad;
+        }
+      }
       list.push({
         asset,
         styleKey: entry.styleKey,
-        options: { ...baseOptions }
+        options
       });
     }
   }
@@ -846,7 +853,7 @@ export function ensureFighterSprites(C, fname){
   
   const cosmetics = ensureCosmeticLayers(C, fname, style);
   const bodyColors = resolveFighterBodyColors(C, fname);
-  const untintedOverlays = resolveUntintedOverlayMap(f);
+  const untintedOverlays = resolveUntintedOverlayMap(f, S);
 
   const result = { assets: S, style, offsets, cosmetics, bodyColors, untintedOverlays };
   ensureFighterSprites.__lastResult = result;

--- a/tests/untinted-overlay-alignment.test.js
+++ b/tests/untinted-overlay-alignment.test.js
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test';
+import { readFileSync } from 'fs';
+import { strictEqual } from 'assert';
+
+describe('Untinted overlay alignment inheritance', () => {
+  const spritesContent = readFileSync('docs/js/sprites.js', 'utf8');
+
+  it('ensureFighterSprites passes sprite map to resolveUntintedOverlayMap', () => {
+    const callPattern = /const\s+untintedOverlays\s*=\s*resolveUntintedOverlayMap\(f,\s*S\);/;
+    strictEqual(callPattern.test(spritesContent), true,
+      'resolveUntintedOverlayMap should receive the sprite asset map');
+  });
+
+  it('resolveUntintedOverlayMap falls back to sprite alignRad for overlays', () => {
+    const fallbackPattern = /const\s+baseAsset\s*=\s*spriteMap\?\?\.\[partKey\];/;
+    const fallbackPatternAlt = /const\s+baseAsset\s*=\s*spriteMap\?\.\[partKey\];/;
+    const usesBaseAsset = fallbackPattern.test(spritesContent) || fallbackPatternAlt.test(spritesContent);
+    strictEqual(usesBaseAsset, true, 'resolveUntintedOverlayMap should read alignRad from spriteMap');
+
+    const assignmentPattern = /if \(!Number\.isFinite\(options\.alignRad\)\)\s*{\s*const baseAsset = spriteMap\?\.\[partKey\];[\s\S]*?options\.alignRad = baseAsset\.alignRad;/;
+    strictEqual(assignmentPattern.test(spritesContent), true,
+      'Overlays should inherit alignRad from their base sprite when not provided');
+  });
+});


### PR DESCRIPTION
## Summary
- let untinted overlays inherit alignRad from their base sprite when no explicit alignment is provided
- pass the sprite map into resolveUntintedOverlayMap and reuse it for overlay alignment fallback
- add a regression test that ensures the overlay alignment fallback remains wired through ensureFighterSprites

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163f758acc8326b23f6dc895267cfe)