### PR TITLE
Add mode-aware tint preview to cosmetic editor

### DIFF
--- a/docs/cosmetic-editor.css
+++ b/docs/cosmetic-editor.css
@@ -140,115 +140,75 @@ button.is-active {
   padding: 10px;
 }
 
-.bucket-actions {
+.mode-toggle {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
 }
 
-.bucket-settings {
-  display: grid;
-  gap: 10px;
-  margin-top: 12px;
+.mode-toggle__btn {
+  flex: 1 1 30%;
 }
 
-.bucket-targets {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
-  gap: 8px;
-  margin: 10px 0 6px;
-}
-
-.bucket-targets__empty {
-  grid-column: 1 / -1;
-  text-align: center;
-  font-size: 12px;
-  color: rgba(148,163,184,0.75);
-}
-
-.bucket-target {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 8px 10px 8px 28px;
-  border-radius: 10px;
-  border: 1px solid rgba(148,163,184,0.28);
-  background: rgba(15,23,42,0.45);
-  color: #e2e8f0;
-  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
-}
-
-.bucket-target::before {
-  content: '';
-  position: absolute;
-  left: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 14px;
-  height: 14px;
-  border-radius: 4px;
-  background: var(--bucket-color, rgba(148,163,184,0.45));
-  box-shadow: inset 0 0 0 1px rgba(15,23,42,0.45);
-}
-
-.bucket-target:hover {
-  transform: translateY(-1px);
-  border-color: rgba(59,130,246,0.45);
-  box-shadow: 0 10px 20px rgba(37,99,235,0.28);
-}
-
-.bucket-target.is-active {
-  border-color: var(--bucket-color, rgba(251,191,36,0.85));
-  box-shadow: 0 0 0 2px rgba(56,189,248,0.35);
-  background: linear-gradient(160deg, rgba(56,189,248,0.35), rgba(37,99,235,0.25));
+.mode-toggle__btn.is-active {
+  border-color: rgba(251,191,36,0.85);
+  box-shadow: 0 0 0 2px rgba(251,191,36,0.35);
+  background: linear-gradient(160deg, rgba(251,191,36,0.8), rgba(217,119,6,0.6));
   color: #0f172a;
 }
 
-.bucket-target__label {
+.tint-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tint-preview__context {
+  font-size: 12px;
+  color: rgba(148,163,184,0.85);
+}
+
+.tint-table {
+  display: grid;
+  gap: 10px;
+}
+
+.tint-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.9fr) minmax(110px, 0.9fr) minmax(110px, 0.9fr) minmax(120px, 0.9fr) auto;
+  gap: 8px;
+  align-items: center;
+  background: rgba(15,23,42,0.45);
+  border-radius: 10px;
+  padding: 10px 12px;
+  border: 1px solid rgba(148,163,184,0.2);
+}
+
+.tint-row__label {
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  font-weight: 600;
+  color: rgba(203,213,225,0.85);
 }
 
-.bucket-target__hex {
+.tint-row__value {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 12px;
-  color: inherit;
+  color: rgba(226,232,240,0.95);
 }
 
-.bucket-settings label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.bucket-settings input[type="number"] {
-  background: rgba(15,23,42,0.36);
-  border: 1px solid rgba(148,163,184,0.4);
+.tint-row__swatch {
+  width: 36px;
+  height: 16px;
   border-radius: 6px;
-  padding: 6px 8px;
-  color: #e2e8f0;
+  border: 1px solid rgba(148,163,184,0.35);
+  box-shadow: inset 0 0 0 1px rgba(15,23,42,0.35);
 }
 
-.bucket-settings input[type="number"]:focus {
-  border-color: rgba(129,140,248,0.8);
-  outline: none;
-  box-shadow: 0 0 0 2px rgba(129,140,248,0.2);
-}
-
-.bucket-actions button {
-  flex: 1 1 auto;
-}
-
-.bucket-actions button:last-child {
-  flex-basis: 100%;
-}
-
-.bucket-hint[hidden] {
-  display: none;
+.tint-row__note {
+  font-size: 11px;
+  color: rgba(148,163,184,0.75);
+  grid-column: 1 / -1;
 }
 
 #editorStatus {

--- a/docs/cosmetic-editor.html
+++ b/docs/cosmetic-editor.html
@@ -18,34 +18,25 @@
         <select id="fighterSelect" aria-label="Select fighter"></select>
         <p style="margin-top:8px;">Loads cosmetics from config.js so you can preview a fighter's wardrobe quickly.</p>
       </div>
+      <div class="panel" id="modePanel">
+        <h2>Editor Mode</h2>
+        <div class="mode-toggle" role="group" aria-label="Select editor mode">
+          <button type="button" class="mode-toggle__btn" data-mode="appearance">Appearance</button>
+          <button type="button" class="mode-toggle__btn" data-mode="clothing">Clothing</button>
+          <button type="button" class="mode-toggle__btn" data-mode="fighterSprites">Fighter Sprites</button>
+        </div>
+        <p class="panel-hint">Switch modes to focus on appearance overlays, clothing items, or fighter sprite data.</p>
+      </div>
       <div class="panel">
         <h2>Cosmetic Slots</h2>
         <div id="cosmeticSlotRows"></div>
         <p style="margin-top:12px;">Use "Edit" to tweak sprite style overrides live.</p>
       </div>
-      <div class="panel">
-        <h2>Bucket Tool</h2>
-        <label style="display:flex;flex-direction:column;gap:6px;">
-          <span>Hex colour</span>
-          <input id="bucketColor" type="text" placeholder="#ff3366" value="#ff3366" spellcheck="false" aria-label="Bucket fill hex colour">
-        </label>
-        <div id="bucketTargets" class="bucket-targets" role="group" aria-label="Palette buckets"></div>
-        <div class="bucket-settings">
-          <label>
-            <span>Colour tolerance</span>
-            <input id="bucketTolerance" type="number" min="0" max="255" step="1" value="24" aria-label="Bucket fill colour tolerance (0-255)">
-          </label>
-          <label>
-            <span>Edge expand (px)</span>
-            <input id="bucketExpand" type="number" min="0" max="24" step="1" value="1" aria-label="Expand bucket fill region by this many pixels">
-          </label>
+      <div class="panel" id="tintPanel">
+        <h2>Tint Preview</h2>
+        <div id="tintPreview" class="tint-preview" aria-live="polite">
+          <p class="panel-hint">Pick a slot and part to preview palette colours and shaded results.</p>
         </div>
-        <div class="bucket-actions" style="margin-top:12px;">
-          <button type="button" id="bucketToggle">🎨 Bucket Mode</button>
-          <button type="button" id="bucketUndo" disabled>↩ Undo</button>
-          <button type="button" id="bucketClear">🧹 Clear Paint</button>
-        </div>
-        <p style="margin-top:10px;">Bucket fill paints directly on the preview layer. Undo is limited to the last 20 fills.</p>
       </div>
       <div class="panel style-inspector" id="styleInspector" data-active="false">
         <div class="style-header">


### PR DESCRIPTION
## Summary
- add a mode toggle with dedicated tint preview replacing the bucket tool in the cosmetic editor UI
- style new mode buttons and tint preview rows while removing legacy bucket styling
- refactor cosmetic editor logic to share mode-aware state, update palette/tint preview behaviour, and export fighter sprite entries when applicable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162bc3159c8326871c26302ba0ddd0)