### PR TITLE
Fix cosmetic palette module bootstrap

### DIFF
--- a/docs/js/cosmetic-palettes.js
+++ b/docs/js/cosmetic-palettes.js
@@ -2,6 +2,8 @@
 // Palette sidecar support was removed; these helpers remain for editors that
 // still need deterministic shade derivation from base colours.
 
+const ROOT = typeof window !== 'undefined' ? window : globalThis;
+
 const COLOR_KEYS = ['primary', 'secondary', 'tertiary'];
 const SHADE_KEYS = ['primary', 'secondary', 'tertiary'];
 
@@ -18,7 +20,7 @@ function isSameOrigin(url){
   }
 }
 
-function clamp01(value){
+function clampChannel(value){
   if (!Number.isFinite(value)) return 0;
   if (value < 0) return 0;
   if (value > 255) return 255;


### PR DESCRIPTION
## Summary
- ensure the cosmetic palette utilities use a defined ROOT reference so optional chaining works in browsers and Node
- rename the 0-255 clamp helper to avoid duplicate clamp01 declarations that prevented the module from loading

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166fae74b08326a4efabaa43525a14)