### PR TITLE
Fix appearance cosmetic rotation fallback

### DIFF
--- a/docs/js/cosmetics.js
+++ b/docs/js/cosmetics.js
@@ -552,12 +552,18 @@ function ensureAsset(cosmeticId, partKey, imageCfg){
   }
   if (!asset){
     const img = loadImage(imageCfg.url);
-    asset = { url: imageCfg.url, img, alignRad: imageCfg.alignRad ?? 0 };
+    asset = { url: imageCfg.url, img };
     STATE.assets.set(key, asset);
   }
-  if (imageCfg.alignRad != null){
+
+  if (imageCfg.alignDeg != null && Number.isFinite(imageCfg.alignDeg)){
+    asset.alignRad = degToRad(imageCfg.alignDeg);
+  } else if (imageCfg.alignRad != null && Number.isFinite(imageCfg.alignRad)){
     asset.alignRad = imageCfg.alignRad;
+  } else if (imageCfg.alignRad == null && imageCfg.alignDeg == null){
+    delete asset.alignRad;
   }
+
   return asset;
 }
 

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -178,6 +178,7 @@ test('appearance cosmetics inherit character body colors', () => {
   deepStrictEqual(layers[0].hsl, { h: 15, s: 0.3, l: 0.1 });
   deepStrictEqual(layers[0].extra?.appearance?.bodyColors, ['A']);
   strictEqual(layers[0].styleKey, 'torso');
+  strictEqual(layers[0].asset.alignRad, undefined);
 });
 
 test('resolveFighterBodyColors ignores stale palette when fighter changes', () => {


### PR DESCRIPTION
## Summary
- avoid forcing cosmetic assets to carry a zero alignRad so appearance layers inherit fighter sprite rotation
- accept alignDeg on cosmetic assets and clear cached alignment when configuration omits it
- add a regression assertion that appearance cosmetics no longer report a hard-coded alignRad value

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691685a759148326b56804ce0bcc53a9)