### PR TITLE
Set examplestreet as demo default and sync ground settings

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -368,6 +368,7 @@ window.CONFIG = {
   map: {
     gridUnit: 30,
     spawnLayerId: 'gameplay',
+    defaultLayoutId: 'examplestreet',
     prefabManifests: [
       './config/prefabs/structures/index.json',
     ],
@@ -379,6 +380,9 @@ window.CONFIG = {
         areaName: 'Example Street',
       },
     ],
+  },
+  ground: {
+    offset: 140,
   },
   groundY: 0,
   // Debug options are surfaced in the debug panel; freezeAngles lets animators hold joints for edits

--- a/docs/js/map-bootstrap.js
+++ b/docs/js/map-bootstrap.js
@@ -1,10 +1,50 @@
 import { MapRegistry, convertLayoutToArea } from './vendor/map-runtime.js';
 import { loadPrefabsFromManifests, createPrefabResolver, summarizeLoadErrors } from './prefab-catalog.js';
 
-const layoutUrl = new URL('../config/maps/examplestreet.layout.json', import.meta.url);
-const DEFAULT_AREA_ID = 'examplestreet';
-const PREVIEW_STORAGE_PREFIX = 'sok-map-editor-preview:';
+function normalizeLayoutEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const path = typeof entry.path === 'string' && entry.path.trim() ? entry.path.trim() : null;
+  if (!path) return null;
+  const label = typeof entry.label === 'string' && entry.label.trim() ? entry.label.trim() : null;
+  const areaName = typeof entry.areaName === 'string' && entry.areaName.trim() ? entry.areaName.trim() : label;
+  const id = typeof entry.id === 'string' && entry.id.trim()
+    ? entry.id.trim()
+    : typeof entry.areaId === 'string' && entry.areaId.trim()
+      ? entry.areaId.trim()
+      : label || path.replace(/\.json$/i, '');
+  return { id, path, areaName };
+}
+
+function resolveLayoutUrl(path) {
+  if (typeof path === 'string' && path.trim()) {
+    try {
+      const base = typeof window !== 'undefined' && window.location ? window.location.href : import.meta.url;
+      return new URL(path, base);
+    } catch (error) {
+      console.warn('[map-bootstrap] Failed to resolve configured layout path', error);
+    }
+  }
+  return new URL('../config/maps/examplestreet.layout.json', import.meta.url);
+}
+
 const MAP_CONFIG = window.CONFIG?.map || {};
+const CONFIG_LAYOUTS = Array.isArray(MAP_CONFIG.layouts)
+  ? MAP_CONFIG.layouts.map((entry) => normalizeLayoutEntry(entry)).filter((entry) => !!entry)
+  : [];
+const PREFERRED_LAYOUT_ID = typeof MAP_CONFIG.defaultLayoutId === 'string' && MAP_CONFIG.defaultLayoutId.trim()
+  ? MAP_CONFIG.defaultLayoutId.trim()
+  : 'examplestreet';
+const DEFAULT_LAYOUT_ENTRY = CONFIG_LAYOUTS.find((entry) => entry.id === PREFERRED_LAYOUT_ID)
+  || CONFIG_LAYOUTS.find((entry) => entry.id === 'examplestreet')
+  || CONFIG_LAYOUTS[0]
+  || null;
+const DEFAULT_AREA_ID = DEFAULT_LAYOUT_ENTRY?.id || 'examplestreet';
+const DEFAULT_AREA_NAME = DEFAULT_LAYOUT_ENTRY?.areaName || 'Example Street';
+const layoutUrl = resolveLayoutUrl(DEFAULT_LAYOUT_ENTRY?.path);
+const PREVIEW_STORAGE_PREFIX = 'sok-map-editor-preview:';
+const PREFAB_MANIFESTS = Array.isArray(MAP_CONFIG.prefabManifests)
+  ? MAP_CONFIG.prefabManifests.filter((entry) => typeof entry === 'string' && entry.trim())
+  : [];
 const PREFAB_MANIFESTS = Array.isArray(MAP_CONFIG.prefabManifests)
   ? MAP_CONFIG.prefabManifests.filter((entry) => typeof entry === 'string' && entry.trim())
   : [];
@@ -104,6 +144,31 @@ function ensureParallaxContainer() {
   return parallax;
 }
 
+function syncConfigGround(area) {
+  const CONFIG = (window.CONFIG = window.CONFIG || {});
+  const canvasConfig = CONFIG.canvas || {};
+  const canvasHeight = Number.isFinite(canvasConfig.h) ? canvasConfig.h : 460;
+  const rawOffset = Number(area?.ground?.offset);
+
+  if (!Number.isFinite(rawOffset)) {
+    return;
+  }
+
+  const offset = Math.max(0, rawOffset);
+
+  if (canvasHeight > 0) {
+    const ratioRaw = 1 - offset / canvasHeight;
+    const ratio = Math.max(0.1, Math.min(0.95, ratioRaw));
+    CONFIG.groundRatio = ratio;
+    CONFIG.groundY = Math.round(canvasHeight * ratio);
+  }
+
+  CONFIG.ground = {
+    ...(typeof CONFIG.ground === 'object' && CONFIG.ground ? CONFIG.ground : {}),
+    offset,
+  };
+}
+
 function adaptAreaToParallax(area) {
   return {
     id: area.id,
@@ -144,6 +209,8 @@ function applyArea(area) {
   window.CONFIG = window.CONFIG || {};
   window.CONFIG.areas = window.CONFIG.areas || {};
   window.CONFIG.areas[area.id] = parallax.areas[area.id];
+
+  syncConfigGround(area);
 
   window.GAME = window.GAME || {};
   window.GAME.mapRegistry = registry;
@@ -277,13 +344,13 @@ async function loadStartingArea() {
     const layout = await response.json();
     console.debug('[map-bootstrap] Loaded raw layout descriptor', {
       id: layout?.areaId || layout?.id || DEFAULT_AREA_ID,
-      name: layout?.areaName || layout?.name || null,
+      name: layout?.areaName || layout?.name || DEFAULT_AREA_NAME,
       source: layoutUrl.href,
       layout,
     });
     const area = convertLayoutToArea(layout, {
       areaId: layout.areaId || layout.id || DEFAULT_AREA_ID,
-      areaName: layout.areaName || layout.name || 'Example Street',
+      areaName: layout.areaName || layout.name || DEFAULT_AREA_NAME,
       prefabResolver,
     });
     applyArea(area);

--- a/docs/map-editor.html
+++ b/docs/map-editor.html
@@ -450,7 +450,23 @@
 
 <script>
 const $ = s => document.querySelector(s);
-const MAP_CONFIG = window.CONFIG?.map || {};
+const ROOT_CONFIG = window.CONFIG || {};
+const MAP_CONFIG = ROOT_CONFIG.map || {};
+const DEFAULT_CANVAS_HEIGHT = Number.isFinite(ROOT_CONFIG.canvas?.h) && ROOT_CONFIG.canvas.h > 0
+  ? ROOT_CONFIG.canvas.h
+  : 460;
+const DEFAULT_GROUND_OFFSET = (() => {
+  const configGround = ROOT_CONFIG.ground;
+  const configuredOffset = configGround && typeof configGround === 'object' ? Number(configGround.offset) : NaN;
+  if (Number.isFinite(configuredOffset)) {
+    return Math.max(0, configuredOffset);
+  }
+  const ratio = Number(ROOT_CONFIG.groundRatio);
+  if (Number.isFinite(ratio) && ratio > 0 && ratio < 1 && DEFAULT_CANVAS_HEIGHT > 0) {
+    return Math.max(0, Math.round(DEFAULT_CANVAS_HEIGHT * (1 - ratio)));
+  }
+  return 140;
+})();
 const DEFAULT_CUSTOM_ENTRY = { id: 'custom_area', label: 'Empty Layout', path: null, areaName: 'Custom Area' };
 const REPOSITORY_LAYOUTS = (() => {
   const normalized = Array.isArray(MAP_CONFIG.layouts) && MAP_CONFIG.layouts.length
@@ -473,12 +489,29 @@ const REPOSITORY_LAYOUTS = (() => {
   normalized.forEach(add);
   return result;
 })();
-const DEFAULT_LAYOUT_META = {
-  areaId: REPOSITORY_LAYOUTS[0]?.id || 'custom_area',
-  areaName: REPOSITORY_LAYOUTS[0]?.areaName || REPOSITORY_LAYOUTS[0]?.label || 'Custom Area',
-  sourcePath: REPOSITORY_LAYOUTS[0]?.path || null,
-  repositoryId: REPOSITORY_LAYOUTS[0]?.id || null,
-};
+const DEFAULT_LAYOUT_META = (() => {
+  const fallback = {
+    areaId: DEFAULT_CUSTOM_ENTRY.id,
+    areaName: DEFAULT_CUSTOM_ENTRY.areaName || DEFAULT_CUSTOM_ENTRY.label || 'Custom Area',
+    sourcePath: DEFAULT_CUSTOM_ENTRY.path,
+    repositoryId: DEFAULT_CUSTOM_ENTRY.id,
+  };
+  const preferredId = typeof MAP_CONFIG.defaultLayoutId === 'string' && MAP_CONFIG.defaultLayoutId.trim()
+    ? MAP_CONFIG.defaultLayoutId.trim()
+    : null;
+  const findEntryById = (id) => REPOSITORY_LAYOUTS.find((entry) => entry.id === id) || null;
+  const preferred = preferredId ? findEntryById(preferredId) : null;
+  const examplestreet = findEntryById('examplestreet');
+  const firstRepository = REPOSITORY_LAYOUTS.find((entry) => entry.id && entry.id !== DEFAULT_CUSTOM_ENTRY.id) || null;
+  const chosen = preferred || examplestreet || firstRepository;
+  if (!chosen) return fallback;
+  return {
+    areaId: chosen.id || fallback.areaId,
+    areaName: chosen.areaName || chosen.label || chosen.id || fallback.areaName,
+    sourcePath: chosen.path || fallback.sourcePath,
+    repositoryId: chosen.id || fallback.repositoryId,
+  };
+})();
 const GRID_UNIT = (Number.isFinite(MAP_CONFIG.gridUnit) && MAP_CONFIG.gridUnit > 0) ? MAP_CONFIG.gridUnit : 10;
 const SPAWN_LAYER_ID = MAP_CONFIG.spawnLayerId || 'gameplay';
 const PREFAB_MANIFESTS = Array.isArray(MAP_CONFIG.prefabManifests)
@@ -487,6 +520,8 @@ const PREFAB_MANIFESTS = Array.isArray(MAP_CONFIG.prefabManifests)
 const PREVIEW_STORAGE_PREFIX = 'sok-map-editor-preview:';
 let runtimeModulePromise = null;
 let prefabBootstrapPromise = null;
+
+$('#groundOffset').value = DEFAULT_GROUND_OFFSET;
 
 function getRuntimeModule(){
   if (!runtimeModulePromise){
@@ -546,7 +581,7 @@ function restoreState(state){
   activeLayerId = adopted.activeLayerId || layoutMeta.activeLayerId || getDefaultSpawnLayerId();
   cameraX = toNumber(adopted.camera?.startX, 0);
   zoom = toNumber(adopted.camera?.startZoom, 1);
-  $('#groundOffset').value = toNumber(adopted.ground?.offset, 140);
+  $('#groundOffset').value = toNumber(adopted.ground?.offset, DEFAULT_GROUND_OFFSET);
   selectedInstId = getPlayerSpawnInstance()?.id || (instances[0]?.id ?? null);
 
   rebuildActiveLayerSelect();
@@ -856,7 +891,7 @@ function adoptAreaState(area, context = {}){
     startZoom: toNumber(raw.camera?.startZoom ?? raw.zoomStart, 1),
   };
   const ground = {
-    offset: toNumber(raw.ground?.offset ?? raw.groundOffset, 140),
+    offset: toNumber(raw.ground?.offset ?? raw.groundOffset, DEFAULT_GROUND_OFFSET),
   };
   const layersList = Array.isArray(raw.layers) && raw.layers.length
     ? raw.layers.map((layer, index) => normalizeLayer(layer, index))
@@ -1021,7 +1056,7 @@ let zoom = 1;
 let debugOverlay = false;
 
 function getGroundOffset(){
-  return parseFloat($('#groundOffset').value) || 140;
+  return parseFloat($('#groundOffset').value) || DEFAULT_GROUND_OFFSET;
 }
 
 /*** Layer UI & stack ***/


### PR DESCRIPTION
## Summary
- derive the demo map bootstrap defaults from the config so examplestreet loads in demo mode and update ground syncing
- expose the preferred layout and ground offset defaults to the map editor so its initial state matches the runtime config

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691683fda7c48326a99c193427b34cf8)