### PR TITLE
Fix duplicate PREFAB_MANIFESTS declaration

### DIFF
--- a/docs/js/map-bootstrap.js
+++ b/docs/js/map-bootstrap.js
@@ -45,9 +45,6 @@ const PREVIEW_STORAGE_PREFIX = 'sok-map-editor-preview:';
 const PREFAB_MANIFESTS = Array.isArray(MAP_CONFIG.prefabManifests)
   ? MAP_CONFIG.prefabManifests.filter((entry) => typeof entry === 'string' && entry.trim())
   : [];
-const PREFAB_MANIFESTS = Array.isArray(MAP_CONFIG.prefabManifests)
-  ? MAP_CONFIG.prefabManifests.filter((entry) => typeof entry === 'string' && entry.trim())
-  : [];
 
 const prefabLibraryPromise = (async () => {
   if (!PREFAB_MANIFESTS.length) {


### PR DESCRIPTION
## Summary
- remove a duplicated PREFAB_MANIFESTS constant definition from the compiled map bootstrap script to prevent runtime syntax errors

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916932e872483268208cfc8d356ec36)