### PR TITLE
Set DefaultDistrict as default map and show active area overlay

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -368,16 +368,16 @@ window.CONFIG = {
   map: {
     gridUnit: 30,
     spawnLayerId: 'gameplay',
-    defaultLayoutId: 'examplestreet',
+    defaultLayoutId: 'defaultdistrict',
     prefabManifests: [
       './config/prefabs/structures/index.json',
     ],
     layouts: [
       {
-        id: 'examplestreet',
-        label: 'Example Street',
-        path: './config/maps/examplestreet.layout.json',
-        areaName: 'Example Street',
+        id: 'defaultdistrict',
+        label: 'DefaultDistrict',
+        path: './config/maps/defaultdistrict.layout.json',
+        areaName: 'DefaultDistrict',
       },
     ],
   },

--- a/docs/config/maps/defaultdistrict.layout.json
+++ b/docs/config/maps/defaultdistrict.layout.json
@@ -1,9 +1,9 @@
 {
-  "id": "examplestreet",
-  "name": "Example Street",
-  "source": "map-builder-layered-v15f",
+  "id": "defaultdistrict",
+  "name": "DefaultDistrict",
+  "source": "map-editor",
   "camera": {
-    "startX": 105.75390625,
+    "startX": 585,
     "startZoom": 1
   },
   "ground": {
@@ -15,9 +15,9 @@
       "name": "Parallax 1",
       "type": "parallax",
       "parallaxSpeed": 1,
-      "scale": 0.6,
       "offsetY": -120,
       "separation": 220,
+      "scale": 0.6,
       "source": null,
       "meta": {}
     },
@@ -26,9 +26,9 @@
       "name": "Parallax 1 copy",
       "type": "parallax",
       "parallaxSpeed": 0.95,
-      "scale": 0.5,
       "offsetY": -140,
       "separation": 220,
+      "scale": 0.5,
       "source": null,
       "meta": {}
     },
@@ -37,9 +37,9 @@
       "name": "Parallax 2",
       "type": "parallax",
       "parallaxSpeed": 0.7,
-      "scale": 0.8,
       "offsetY": -90,
       "separation": 220,
+      "scale": 0.8,
       "source": null,
       "meta": {}
     },
@@ -48,9 +48,9 @@
       "name": "Parallax 3",
       "type": "parallax",
       "parallaxSpeed": 0.8,
-      "scale": 0.15,
       "offsetY": -25,
       "separation": 70,
+      "scale": 0.15,
       "source": null,
       "meta": {}
     },
@@ -59,9 +59,9 @@
       "name": "Parallax 4",
       "type": "parallax",
       "parallaxSpeed": 0.9,
-      "scale": 0.2,
       "offsetY": -7,
       "separation": 80,
+      "scale": 0.2,
       "source": null,
       "meta": {}
     },
@@ -70,9 +70,9 @@
       "name": "Parallax 6",
       "type": "parallax",
       "parallaxSpeed": 0.65,
-      "scale": 0.85,
       "offsetY": -40,
       "separation": 220,
+      "scale": 0.85,
       "source": null,
       "meta": {}
     },
@@ -81,9 +81,9 @@
       "name": "Gameplay",
       "type": "gameplay",
       "parallaxSpeed": 1,
-      "scale": 0.3,
       "offsetY": 7,
       "separation": 90,
+      "scale": 0.3,
       "source": null,
       "meta": {}
     },
@@ -92,9 +92,9 @@
       "name": "Foreground 1",
       "type": "foreground",
       "parallaxSpeed": 1.1,
-      "scale": 1.05,
       "offsetY": -10,
       "separation": 180,
+      "scale": 1.05,
       "source": null,
       "meta": {}
     },
@@ -103,9 +103,9 @@
       "name": "Foreground 2",
       "type": "foreground",
       "parallaxSpeed": 1.2,
-      "scale": 1.1,
       "offsetY": 0,
       "separation": 180,
+      "scale": 1.1,
       "source": null,
       "meta": {}
     }
@@ -1502,6 +1502,25 @@
       "meta": {}
     }
   ],
-  "warnings": [],
-  "meta": {}
+  "colliders": [
+    {
+      "id": 1,
+      "label": "Collider 1",
+      "type": "box",
+      "shape": "box",
+      "left": -1000,
+      "width": 2500,
+      "topOffset": 0,
+      "height": 200,
+      "meta": {}
+    }
+  ],
+  "meta": {
+    "areaId": "defaultdistrict",
+    "areaName": "DefaultDistrict",
+    "sourcePath": null,
+    "repositoryId": null,
+    "activeLayerId": "bg1",
+    "exportedAt": "2025-11-14T04:00:54.964Z"
+  }
 }

--- a/docs/js-src/map-bootstrap.ts
+++ b/docs/js-src/map-bootstrap.ts
@@ -28,6 +28,74 @@ type MapLayoutConfig = {
   areaName: string | null;
 };
 
+const AREA_NAME_ELEMENT_ID = 'areaName';
+const AREA_OVERLAY_UNSUB_KEY = '__sokAreaNameOverlayUnsub__' as const;
+
+function getAreaNameElement(): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  const element = document.getElementById(AREA_NAME_ELEMENT_ID);
+  if (!element) return null;
+  if (typeof HTMLElement !== 'undefined' && element instanceof HTMLElement) {
+    return element;
+  }
+  return (element as Element)?.nodeType === 1 ? (element as HTMLElement) : null;
+}
+
+function updateAreaNameOverlay(area: MapArea | null): void {
+  const element = getAreaNameElement();
+  if (!element) return;
+
+  if (!area) {
+    element.textContent = '';
+    element.setAttribute('aria-hidden', 'true');
+    if (element.style) {
+      element.style.display = 'none';
+    }
+    if ('dataset' in element) {
+      element.dataset.areaId = '';
+      element.dataset.areaName = '';
+    }
+    return;
+  }
+
+  const resolvedName = typeof area.meta?.areaName === 'string' && area.meta.areaName.trim()
+    ? area.meta.areaName.trim()
+    : (area.name || area.id);
+  element.textContent = resolvedName;
+  element.setAttribute('aria-hidden', 'false');
+  if (element.style) {
+    element.style.display = '';
+  }
+  if ('dataset' in element) {
+    element.dataset.areaId = area.id;
+    element.dataset.areaName = resolvedName;
+  }
+}
+
+function bindAreaNameOverlay(registry: MapRegistry): void {
+  if (typeof window === 'undefined') {
+    updateAreaNameOverlay((registry as MapRegistry | undefined)?.getActiveArea?.() ?? null);
+    return;
+  }
+  const globalWindow = window as typeof window & { __sokAreaNameOverlayUnsub__?: () => void };
+  const previous = globalWindow[AREA_OVERLAY_UNSUB_KEY];
+  if (typeof previous === 'function') {
+    try {
+      previous();
+    } catch (error) {
+      console.warn('[map-bootstrap] Failed to remove previous area overlay listener', error);
+    }
+    globalWindow[AREA_OVERLAY_UNSUB_KEY] = undefined;
+  }
+  if (typeof registry?.on === 'function') {
+    const unsubscribe = registry.on('active-area-changed', (activeArea: MapArea | null) => {
+      updateAreaNameOverlay(activeArea);
+    });
+    globalWindow[AREA_OVERLAY_UNSUB_KEY] = unsubscribe;
+  }
+  updateAreaNameOverlay(registry?.getActiveArea?.() ?? null);
+}
+
 function normalizeLayoutEntry(entry: unknown): MapLayoutConfig | null {
   if (!entry || typeof entry !== 'object') return null;
   const record = entry as Record<string, unknown>;
@@ -54,7 +122,7 @@ function resolveLayoutUrl(path: string | null | undefined): URL {
       console.warn('[map-bootstrap] Failed to resolve configured layout path', error);
     }
   }
-  return new URL('../config/maps/examplestreet.layout.json', import.meta.url);
+  return new URL('../config/maps/defaultdistrict.layout.json', import.meta.url);
 }
 
 const MAP_CONFIG = window.CONFIG?.map || {};
@@ -63,13 +131,13 @@ const CONFIG_LAYOUTS = Array.isArray(MAP_CONFIG.layouts)
   : [];
 const PREFERRED_LAYOUT_ID = typeof MAP_CONFIG.defaultLayoutId === 'string' && MAP_CONFIG.defaultLayoutId.trim()
   ? MAP_CONFIG.defaultLayoutId.trim()
-  : 'examplestreet';
+  : 'defaultdistrict';
 const DEFAULT_LAYOUT_ENTRY = CONFIG_LAYOUTS.find((entry) => entry.id === PREFERRED_LAYOUT_ID)
-  || CONFIG_LAYOUTS.find((entry) => entry.id === 'examplestreet')
+  || CONFIG_LAYOUTS.find((entry) => entry.id === 'defaultdistrict')
   || CONFIG_LAYOUTS[0]
   || null;
-const DEFAULT_AREA_ID = DEFAULT_LAYOUT_ENTRY?.id || 'examplestreet';
-const DEFAULT_AREA_NAME = DEFAULT_LAYOUT_ENTRY?.areaName || 'Example Street';
+const DEFAULT_AREA_ID = DEFAULT_LAYOUT_ENTRY?.id || 'defaultdistrict';
+const DEFAULT_AREA_NAME = DEFAULT_LAYOUT_ENTRY?.areaName || 'DefaultDistrict';
 const layoutUrl = resolveLayoutUrl(DEFAULT_LAYOUT_ENTRY?.path);
 const PREVIEW_STORAGE_PREFIX = 'sok-map-editor-preview:';
 const PREFAB_MANIFESTS = Array.isArray(MAP_CONFIG.prefabManifests)
@@ -342,6 +410,8 @@ function applyArea(area: MapArea): void {
   window.GAME.mapRegistry = registry;
   window.GAME.currentAreaId = area.id;
   window.GAME.__onMapRegistryReadyForCamera?.(registry);
+
+  bindAreaNameOverlay(registry);
 
   console.info(`[map-bootstrap] Loaded area "${area.id}" (${area.source || 'unknown source'})`);
 }

--- a/docs/map-editor.html
+++ b/docs/map-editor.html
@@ -553,9 +553,9 @@ const DEFAULT_LAYOUT_META = (() => {
     : null;
   const findEntryById = (id) => REPOSITORY_LAYOUTS.find((entry) => entry.id === id) || null;
   const preferred = preferredId ? findEntryById(preferredId) : null;
-  const examplestreet = findEntryById('examplestreet');
+  const defaultdistrict = findEntryById('defaultdistrict');
   const firstRepository = REPOSITORY_LAYOUTS.find((entry) => entry.id && entry.id !== DEFAULT_CUSTOM_ENTRY.id) || null;
-  const chosen = preferred || examplestreet || firstRepository;
+  const chosen = preferred || defaultdistrict || firstRepository;
   if (!chosen) return fallback;
   return {
     areaId: chosen.id || fallback.areaId,

--- a/src/config/maps/defaultdistrict.layout.json
+++ b/src/config/maps/defaultdistrict.layout.json
@@ -1,9 +1,9 @@
 {
-  "id": "examplestreet",
-  "name": "Example Street",
-  "source": "map-builder-layered-v15f",
+  "id": "defaultdistrict",
+  "name": "DefaultDistrict",
+  "source": "map-editor",
   "camera": {
-    "startX": 105.75390625,
+    "startX": 585,
     "startZoom": 1
   },
   "ground": {
@@ -15,9 +15,9 @@
       "name": "Parallax 1",
       "type": "parallax",
       "parallaxSpeed": 1,
-      "scale": 0.6,
       "offsetY": -120,
       "separation": 220,
+      "scale": 0.6,
       "source": null,
       "meta": {}
     },
@@ -26,9 +26,9 @@
       "name": "Parallax 1 copy",
       "type": "parallax",
       "parallaxSpeed": 0.95,
-      "scale": 0.5,
       "offsetY": -140,
       "separation": 220,
+      "scale": 0.5,
       "source": null,
       "meta": {}
     },
@@ -37,9 +37,9 @@
       "name": "Parallax 2",
       "type": "parallax",
       "parallaxSpeed": 0.7,
-      "scale": 0.8,
       "offsetY": -90,
       "separation": 220,
+      "scale": 0.8,
       "source": null,
       "meta": {}
     },
@@ -48,9 +48,9 @@
       "name": "Parallax 3",
       "type": "parallax",
       "parallaxSpeed": 0.8,
-      "scale": 0.15,
       "offsetY": -25,
       "separation": 70,
+      "scale": 0.15,
       "source": null,
       "meta": {}
     },
@@ -59,9 +59,9 @@
       "name": "Parallax 4",
       "type": "parallax",
       "parallaxSpeed": 0.9,
-      "scale": 0.2,
       "offsetY": -7,
       "separation": 80,
+      "scale": 0.2,
       "source": null,
       "meta": {}
     },
@@ -70,9 +70,9 @@
       "name": "Parallax 6",
       "type": "parallax",
       "parallaxSpeed": 0.65,
-      "scale": 0.85,
       "offsetY": -40,
       "separation": 220,
+      "scale": 0.85,
       "source": null,
       "meta": {}
     },
@@ -81,9 +81,9 @@
       "name": "Gameplay",
       "type": "gameplay",
       "parallaxSpeed": 1,
-      "scale": 0.3,
       "offsetY": 7,
       "separation": 90,
+      "scale": 0.3,
       "source": null,
       "meta": {}
     },
@@ -92,9 +92,9 @@
       "name": "Foreground 1",
       "type": "foreground",
       "parallaxSpeed": 1.1,
-      "scale": 1.05,
       "offsetY": -10,
       "separation": 180,
+      "scale": 1.05,
       "source": null,
       "meta": {}
     },
@@ -103,9 +103,9 @@
       "name": "Foreground 2",
       "type": "foreground",
       "parallaxSpeed": 1.2,
-      "scale": 1.1,
       "offsetY": 0,
       "separation": 180,
+      "scale": 1.1,
       "source": null,
       "meta": {}
     }
@@ -125,7 +125,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [
         "spawn:player"
       ],
@@ -145,7 +144,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [
         "spawn:npc"
       ],
@@ -165,7 +163,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -183,7 +180,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -201,7 +197,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -219,7 +214,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -237,7 +231,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -255,7 +248,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -273,7 +265,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -291,7 +282,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -309,7 +299,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -327,7 +316,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -345,7 +333,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -363,7 +350,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -381,7 +367,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -399,7 +384,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -417,7 +401,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -435,7 +418,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -453,7 +435,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -471,7 +452,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -489,7 +469,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -507,7 +486,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -525,7 +503,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -543,7 +520,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -561,7 +537,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -579,7 +554,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -597,7 +571,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -615,7 +588,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -633,7 +605,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -651,7 +622,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -669,7 +639,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -687,7 +656,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -705,7 +673,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -723,7 +690,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -741,7 +707,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -759,7 +724,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -777,7 +741,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -795,7 +758,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -813,7 +775,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -831,7 +792,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -849,7 +809,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -867,7 +826,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -885,7 +843,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -903,7 +860,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -921,7 +877,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -939,7 +894,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -957,7 +911,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -975,7 +928,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -993,7 +945,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1011,7 +962,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1029,7 +979,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1047,7 +996,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1065,7 +1013,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1083,7 +1030,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1101,7 +1047,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1119,7 +1064,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1137,7 +1081,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1155,7 +1098,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1173,7 +1115,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1191,7 +1132,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1209,7 +1149,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1227,7 +1166,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1245,7 +1183,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1263,7 +1200,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1281,7 +1217,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1299,7 +1234,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1317,7 +1251,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1335,7 +1268,6 @@
       },
       "rotationDeg": 0,
       "locked": false,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1353,7 +1285,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1371,7 +1302,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1389,7 +1319,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1407,7 +1336,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1425,7 +1353,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1443,7 +1370,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1461,7 +1387,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1479,7 +1404,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     },
@@ -1497,7 +1421,6 @@
       },
       "rotationDeg": 0,
       "locked": true,
-      "prefab": null,
       "tags": [],
       "meta": {}
     }
@@ -1505,25 +1428,22 @@
   "colliders": [
     {
       "id": 1,
-      "label": "Main Street",
+      "label": "Collider 1",
       "type": "box",
-      "left": -960,
-      "width": 1920,
-      "topOffset": -6,
-      "height": 18,
-      "meta": {}
-    },
-    {
-      "id": 2,
-      "label": "Rooftop",
-      "type": "box",
-      "left": -220,
-      "width": 440,
-      "topOffset": -220,
-      "height": 20,
+      "shape": "box",
+      "left": -1000,
+      "width": 2500,
+      "topOffset": 0,
+      "height": 200,
       "meta": {}
     }
   ],
-  "warnings": [],
-  "meta": {}
+  "meta": {
+    "areaId": "defaultdistrict",
+    "areaName": "DefaultDistrict",
+    "sourcePath": null,
+    "repositoryId": null,
+    "activeLayerId": "bg1",
+    "exportedAt": "2025-11-14T04:00:54.964Z"
+  }
 }

--- a/tools/copy-map-layout.mjs
+++ b/tools/copy-map-layout.mjs
@@ -6,9 +6,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const projectRoot = resolve(__dirname, '..');
-const source = resolve(projectRoot, 'src/config/maps/examplestreet.layout.json');
+const source = resolve(projectRoot, 'src/config/maps/defaultdistrict.layout.json');
 const destinationDir = resolve(projectRoot, 'docs/config/maps');
-const destination = resolve(destinationDir, 'examplestreet.layout.json');
+const destination = resolve(destinationDir, 'defaultdistrict.layout.json');
 
 await mkdir(destinationDir, { recursive: true });
 await copyFile(source, destination);


### PR DESCRIPTION
## Summary
- rename the starter layout to DefaultDistrict and replace its JSON data in both config bundles
- update the map bootstrap logic to default to the new area and surface the active area name overlay
- align the map editor defaults and layout copy helper with the DefaultDistrict starter selection

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916aa0d03008326bc028e4d58ea571d)