### PR TITLE
Rename commercial tower prefab and update references

### DIFF
--- a/docs/config/maps/defaultdistrict.layout.json
+++ b/docs/config/maps/defaultdistrict.layout.json
@@ -279,7 +279,7 @@
     },
     {
       "id": 8,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -622.5948595312665,
@@ -297,7 +297,7 @@
     },
     {
       "id": 9,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -539.6774920478899,
@@ -315,7 +315,7 @@
     },
     {
       "id": 10,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -449.791997534357,
@@ -333,7 +333,7 @@
     },
     {
       "id": 11,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -359.6055576059955,
@@ -351,7 +351,7 @@
     },
     {
       "id": 12,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -267.15509549359047,
@@ -369,7 +369,7 @@
     },
     {
       "id": 13,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -184.6375621227893,
@@ -387,7 +387,7 @@
     },
     {
       "id": 14,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -89.50750736862975,
@@ -405,7 +405,7 @@
     },
     {
       "id": 15,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 3.4972581309769035,
@@ -423,7 +423,7 @@
     },
     {
       "id": 16,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 94.453471169674,
@@ -441,7 +441,7 @@
     },
     {
       "id": 17,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 180.16113071380744,
@@ -459,7 +459,7 @@
     },
     {
       "id": 18,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 264.4677119088877,
@@ -477,7 +477,7 @@
     },
     {
       "id": 19,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 368.36032144170855,
@@ -495,7 +495,7 @@
     },
     {
       "id": 20,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 445.6569767200548,
@@ -513,7 +513,7 @@
     },
     {
       "id": 21,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 539.07754987568,
@@ -531,7 +531,7 @@
     },
     {
       "id": 22,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 626.763104255851,
@@ -549,7 +549,7 @@
     },
     {
       "id": 23,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -1160,
@@ -567,7 +567,7 @@
     },
     {
       "id": 24,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -1080,
@@ -585,7 +585,7 @@
     },
     {
       "id": 25,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -1000,
@@ -603,7 +603,7 @@
     },
     {
       "id": 27,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -840,
@@ -621,7 +621,7 @@
     },
     {
       "id": 28,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -760,
@@ -639,7 +639,7 @@
     },
     {
       "id": 29,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -680,
@@ -657,7 +657,7 @@
     },
     {
       "id": 30,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -600,
@@ -675,7 +675,7 @@
     },
     {
       "id": 31,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -520,
@@ -693,7 +693,7 @@
     },
     {
       "id": 32,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -440,
@@ -711,7 +711,7 @@
     },
     {
       "id": 33,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -360,
@@ -729,7 +729,7 @@
     },
     {
       "id": 34,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -280,
@@ -747,7 +747,7 @@
     },
     {
       "id": 35,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -200,
@@ -765,7 +765,7 @@
     },
     {
       "id": 36,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -120,
@@ -783,7 +783,7 @@
     },
     {
       "id": 37,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -40,
@@ -801,7 +801,7 @@
     },
     {
       "id": 38,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 40,
@@ -819,7 +819,7 @@
     },
     {
       "id": 39,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 120,
@@ -837,7 +837,7 @@
     },
     {
       "id": 40,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 200,
@@ -855,7 +855,7 @@
     },
     {
       "id": 41,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 280,
@@ -873,7 +873,7 @@
     },
     {
       "id": 42,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 360,
@@ -891,7 +891,7 @@
     },
     {
       "id": 43,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 440,
@@ -909,7 +909,7 @@
     },
     {
       "id": 44,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 520,
@@ -927,7 +927,7 @@
     },
     {
       "id": 45,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 600,
@@ -945,7 +945,7 @@
     },
     {
       "id": 46,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 680,
@@ -963,7 +963,7 @@
     },
     {
       "id": 47,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 760,
@@ -981,7 +981,7 @@
     },
     {
       "id": 48,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 840,
@@ -999,7 +999,7 @@
     },
     {
       "id": 49,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 920,
@@ -1017,7 +1017,7 @@
     },
     {
       "id": 50,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 1000,
@@ -1035,7 +1035,7 @@
     },
     {
       "id": 51,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 1080,
@@ -1053,7 +1053,7 @@
     },
     {
       "id": 52,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 1160,
@@ -1071,7 +1071,7 @@
     },
     {
       "id": 53,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -490,
@@ -1089,7 +1089,7 @@
     },
     {
       "id": 54,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -420,
@@ -1107,7 +1107,7 @@
     },
     {
       "id": 55,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -350,
@@ -1125,7 +1125,7 @@
     },
     {
       "id": 56,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -280,
@@ -1143,7 +1143,7 @@
     },
     {
       "id": 57,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -210,
@@ -1161,7 +1161,7 @@
     },
     {
       "id": 58,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -140,
@@ -1179,7 +1179,7 @@
     },
     {
       "id": 59,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -70,
@@ -1197,7 +1197,7 @@
     },
     {
       "id": 60,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 0,
@@ -1215,7 +1215,7 @@
     },
     {
       "id": 61,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 70,
@@ -1233,7 +1233,7 @@
     },
     {
       "id": 62,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 140,
@@ -1251,7 +1251,7 @@
     },
     {
       "id": 63,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 210,
@@ -1269,7 +1269,7 @@
     },
     {
       "id": 64,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 280,
@@ -1287,7 +1287,7 @@
     },
     {
       "id": 65,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 350,
@@ -1305,7 +1305,7 @@
     },
     {
       "id": 66,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 420,
@@ -1323,7 +1323,7 @@
     },
     {
       "id": 67,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 490,

--- a/docs/config/prefabs/structures/index.json
+++ b/docs/config/prefabs/structures/index.json
@@ -3,9 +3,9 @@
   "label": "Structures",
   "entries": [
     {
-      "id": "tower_v1",
-      "label": "Tower v1",
-      "path": "./tower_v1.prefab.json"
+      "id": "tower_commercial",
+      "label": "Commercial Tower",
+      "path": "./tower_commercial.prefab.json"
     }
   ]
 }

--- a/docs/config/prefabs/structures/tower_commercial.prefab.json
+++ b/docs/config/prefabs/structures/tower_commercial.prefab.json
@@ -1,5 +1,5 @@
 {
-  "structureId": "tower_v1",
+  "structureId": "Commercial Tower",
   "base": {},
   "parts": [
     {
@@ -10,7 +10,7 @@
       "z": 10,
       "propTemplate": {
         "id": "tower_near",
-        "url": "https://i.imgur.com/T32ZEPl.png",
+        "url": "https://i.imgur.com/tower_commercial_near.png",
         "w": 360,
         "h": 480,
         "pivot": "bottom",
@@ -52,7 +52,7 @@
       "z": 0,
       "propTemplate": {
         "id": "tower_farleft",
-        "url": "https://i.imgur.com/rwNudcI.png",
+        "url": "https://i.imgur.com/tower_general_far.png",
         "w": 360,
         "h": 480,
         "pivot": "bottom",
@@ -87,14 +87,14 @@
       }
     },
     {
-      "name": "part_3",
+      "name": "tower_farRight",
       "layer": "far",
       "relX": 0,
       "relY": 0,
       "z": 0,
       "propTemplate": {
-        "id": "part_3",
-        "url": "https://i.imgur.com/rwNudcI.png",
+        "id": "tower_farRight",
+        "url": "https://i.imgur.com/tower_general_far.png",
         "w": 360,
         "h": 480,
         "pivot": "bottom",

--- a/src/config/maps/defaultdistrict.layout.json
+++ b/src/config/maps/defaultdistrict.layout.json
@@ -270,7 +270,7 @@
     },
     {
       "id": 8,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -622.5948595312665,
@@ -287,7 +287,7 @@
     },
     {
       "id": 9,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -539.6774920478899,
@@ -304,7 +304,7 @@
     },
     {
       "id": 10,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -449.791997534357,
@@ -321,7 +321,7 @@
     },
     {
       "id": 11,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -359.6055576059955,
@@ -338,7 +338,7 @@
     },
     {
       "id": 12,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -267.15509549359047,
@@ -355,7 +355,7 @@
     },
     {
       "id": 13,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -184.6375621227893,
@@ -372,7 +372,7 @@
     },
     {
       "id": 14,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": -89.50750736862975,
@@ -389,7 +389,7 @@
     },
     {
       "id": 15,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 3.4972581309769035,
@@ -406,7 +406,7 @@
     },
     {
       "id": 16,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 94.453471169674,
@@ -423,7 +423,7 @@
     },
     {
       "id": 17,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 180.16113071380744,
@@ -440,7 +440,7 @@
     },
     {
       "id": 18,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 264.4677119088877,
@@ -457,7 +457,7 @@
     },
     {
       "id": 19,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 368.36032144170855,
@@ -474,7 +474,7 @@
     },
     {
       "id": 20,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 445.6569767200548,
@@ -491,7 +491,7 @@
     },
     {
       "id": 21,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 539.07754987568,
@@ -508,7 +508,7 @@
     },
     {
       "id": 22,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "gameplay",
       "position": {
         "x": 626.763104255851,
@@ -525,7 +525,7 @@
     },
     {
       "id": 23,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -1160,
@@ -542,7 +542,7 @@
     },
     {
       "id": 24,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -1080,
@@ -559,7 +559,7 @@
     },
     {
       "id": 25,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -1000,
@@ -576,7 +576,7 @@
     },
     {
       "id": 27,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -840,
@@ -593,7 +593,7 @@
     },
     {
       "id": 28,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -760,
@@ -610,7 +610,7 @@
     },
     {
       "id": 29,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -680,
@@ -627,7 +627,7 @@
     },
     {
       "id": 30,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -600,
@@ -644,7 +644,7 @@
     },
     {
       "id": 31,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -520,
@@ -661,7 +661,7 @@
     },
     {
       "id": 32,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -440,
@@ -678,7 +678,7 @@
     },
     {
       "id": 33,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -360,
@@ -695,7 +695,7 @@
     },
     {
       "id": 34,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -280,
@@ -712,7 +712,7 @@
     },
     {
       "id": 35,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -200,
@@ -729,7 +729,7 @@
     },
     {
       "id": 36,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -120,
@@ -746,7 +746,7 @@
     },
     {
       "id": 37,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": -40,
@@ -763,7 +763,7 @@
     },
     {
       "id": 38,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 40,
@@ -780,7 +780,7 @@
     },
     {
       "id": 39,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 120,
@@ -797,7 +797,7 @@
     },
     {
       "id": 40,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 200,
@@ -814,7 +814,7 @@
     },
     {
       "id": 41,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 280,
@@ -831,7 +831,7 @@
     },
     {
       "id": 42,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 360,
@@ -848,7 +848,7 @@
     },
     {
       "id": 43,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 440,
@@ -865,7 +865,7 @@
     },
     {
       "id": 44,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 520,
@@ -882,7 +882,7 @@
     },
     {
       "id": 45,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 600,
@@ -899,7 +899,7 @@
     },
     {
       "id": 46,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 680,
@@ -916,7 +916,7 @@
     },
     {
       "id": 47,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 760,
@@ -933,7 +933,7 @@
     },
     {
       "id": 48,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 840,
@@ -950,7 +950,7 @@
     },
     {
       "id": 49,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 920,
@@ -967,7 +967,7 @@
     },
     {
       "id": 50,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 1000,
@@ -984,7 +984,7 @@
     },
     {
       "id": 51,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 1080,
@@ -1001,7 +1001,7 @@
     },
     {
       "id": 52,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg4",
       "position": {
         "x": 1160,
@@ -1018,7 +1018,7 @@
     },
     {
       "id": 53,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -490,
@@ -1035,7 +1035,7 @@
     },
     {
       "id": 54,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -420,
@@ -1052,7 +1052,7 @@
     },
     {
       "id": 55,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -350,
@@ -1069,7 +1069,7 @@
     },
     {
       "id": 56,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -280,
@@ -1086,7 +1086,7 @@
     },
     {
       "id": 57,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -210,
@@ -1103,7 +1103,7 @@
     },
     {
       "id": 58,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -140,
@@ -1120,7 +1120,7 @@
     },
     {
       "id": 59,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": -70,
@@ -1137,7 +1137,7 @@
     },
     {
       "id": 60,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 0,
@@ -1154,7 +1154,7 @@
     },
     {
       "id": 61,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 70,
@@ -1171,7 +1171,7 @@
     },
     {
       "id": 62,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 140,
@@ -1188,7 +1188,7 @@
     },
     {
       "id": 63,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 210,
@@ -1205,7 +1205,7 @@
     },
     {
       "id": 64,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 280,
@@ -1222,7 +1222,7 @@
     },
     {
       "id": 65,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 350,
@@ -1239,7 +1239,7 @@
     },
     {
       "id": 66,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 420,
@@ -1256,7 +1256,7 @@
     },
     {
       "id": 67,
-      "prefabId": "tower_v1",
+      "prefabId": "tower_commercial",
       "layerId": "bg3",
       "position": {
         "x": 490,

--- a/tools/structure_builder_v10.html
+++ b/tools/structure_builder_v10.html
@@ -218,15 +218,15 @@ function initRefs(){
 let cx, ro;
 const state = {
   prefab: {
-    structureId: 'tower_v1',
+    structureId: 'Commercial Tower',
     base: {},
     parts: [
       { name:'near', layer:'near', relX:0, relY:0, z:10,
-        propTemplate: { id:'tower_near', url:'https://i.imgur.com/T32ZEPl.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:1, parallaxClampPx:0,
+        propTemplate: { id:'tower_near', url:'https://i.imgur.com/tower_commercial_near.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:1, parallaxClampPx:0,
           kf: { radius:800, ease:'smoothstep', translateSpace:'screen', transformOrder:'scaleThenRotate',
                 left:{dx:0,dy:0,scaleX:1,rotZdeg:0}, center:{dx:0,dy:0,scaleX:1,rotZdeg:0}, right:{dx:0,dy:0,scaleX:1,rotZdeg:0} } } },
       { name:'far', layer:'far', relX:0, relY:0, z:0,
-        propTemplate: { id:'tower_far', url:'https://i.imgur.com/rwNudcI.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:0.85, parallaxClampPx:64,
+        propTemplate: { id:'tower_far', url:'https://i.imgur.com/tower_general_far.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:0.85, parallaxClampPx:64,
           kf: { radius:800, ease:'smoothstep', translateSpace:'screen', transformOrder:'scaleThenRotate',
                 left:{dx:-24,dy:0,scaleX:0.92,rotZdeg:-6}, center:{dx:0,dy:0,scaleX:1,rotZdeg:0}, right:{dx:22,dy:0,scaleX:0.92,rotZdeg:6} } } }
     ]


### PR DESCRIPTION
## Summary
- rename the tower prefab file to `tower_commercial` and update its structure metadata and art references
- point the structure index and default district layouts at the new prefab id
- refresh the structure builder defaults to reference the commercial tower assets

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916b95a5fa0832692973a5035315f94)