### PR TITLE
Ensure preview listener starts before prefab load

### DIFF
--- a/docs/js-src/map-bootstrap.ts
+++ b/docs/js-src/map-bootstrap.ts
@@ -514,6 +514,9 @@ async function loadStartingArea(): Promise<void> {
   const configPreviewToken = typeof MAP_CONFIG.previewToken === 'string' ? MAP_CONFIG.previewToken : null;
   const previewToken = configPreviewToken || params.get('preview');
   const previewPayload = consumeEditorPreviewLayout(previewToken);
+  const previewMessagePromise: Promise<PreviewPayload | null> = (!previewPayload?.layout && previewToken)
+    ? waitForPreviewMessage(previewToken)
+    : Promise.resolve(null);
   const { prefabs: prefabMap } = await prefabLibraryPromise;
   const prefabResolver = createPrefabResolver(prefabMap);
 
@@ -528,7 +531,7 @@ async function loadStartingArea(): Promise<void> {
     }
   } else if (previewToken) {
     console.warn('[map-bootstrap] Preview token requested but no payload was available in storage; waiting for direct preview message.');
-    const messagePayload = await waitForPreviewMessage(previewToken);
+    const messagePayload = await previewMessagePromise;
     if (messagePayload?.layout) {
       const applied = applyPreviewLayout(messagePayload.layout, {
         previewToken,

--- a/docs/js/map-bootstrap.js
+++ b/docs/js/map-bootstrap.js
@@ -448,6 +448,9 @@ async function loadStartingArea() {
   const configPreviewToken = typeof MAP_CONFIG.previewToken === 'string' ? MAP_CONFIG.previewToken : null;
   const previewToken = configPreviewToken || params.get('preview');
   const previewPayload = consumeEditorPreviewLayout(previewToken);
+  const previewMessagePromise = !previewPayload?.layout && previewToken
+    ? waitForPreviewMessage(previewToken)
+    : Promise.resolve(null);
   const { prefabs: prefabMap } = await prefabLibraryPromise;
   const prefabResolver = createPrefabResolver(prefabMap);
 
@@ -462,7 +465,7 @@ async function loadStartingArea() {
     }
   } else if (previewToken) {
     console.warn('[map-bootstrap] Preview token requested but no payload was available in storage; waiting for direct preview message.');
-    const messagePayload = await waitForPreviewMessage(previewToken);
+    const messagePayload = await previewMessagePromise;
     if (messagePayload?.layout) {
       const applied = applyPreviewLayout(messagePayload.layout, {
         previewToken,


### PR DESCRIPTION
## Summary
- start waiting for map editor preview messages before loading prefab manifests
- reuse the pending preview message promise when falling back to a direct handshake

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916adb233ac8326b2affd73f2f50e2d)