### PR TITLE
Respect selected fighter when reinitializing player

### DIFF
--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -206,11 +206,22 @@ export function initFighters(cv, cx){
     return null;
   }
 
-  function resolveFighterName(characterData, prevProfile) {
+  function resolveFighterName(id, characterData, prevProfile) {
+    const selectedFighter = G.selectedFighter;
+    if (
+      selectedFighter &&
+      C.fighters?.[selectedFighter] &&
+      (id === 'player' || prevProfile?.characterKey === 'player')
+    ) {
+      return selectedFighter;
+    }
+
     const prevFighter = prevProfile?.fighterName;
     if (prevFighter && C.fighters?.[prevFighter]) return prevFighter;
+
     const charFighter = characterData?.fighter;
     if (charFighter && C.fighters?.[charFighter]) return charFighter;
+
     return fallbackFighterName;
   }
 
@@ -230,7 +241,7 @@ export function initFighters(cv, cx){
       characterData = clone(characters[characterKey]);
     }
 
-    const fighterName = resolveFighterName(characterData, prevProfile);
+    const fighterName = resolveFighterName(id, characterData, prevProfile);
     const bodyColorsBase = prevProfile?.bodyColors
       ?? (characterData?.bodyColors ? clone(characterData.bodyColors) : null);
     const cosmeticsBase = prevProfile?.cosmetics

--- a/tests/player-fighter-selection.test.js
+++ b/tests/player-fighter-selection.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const fighterJsPath = join(__dirname, '..', 'docs', 'js', 'fighter.js');
+const fighterJsSrc = readFileSync(fighterJsPath, 'utf-8');
+
+function extractResolveFunction() {
+  const match = fighterJsSrc.match(/function\s+resolveFighterName[\s\S]*?return fallbackFighterName;\s*\}/);
+  return match ? match[0] : '';
+}
+
+describe('player fighter selection pipeline', () => {
+  it('resolveFighterName prioritizes the selected fighter for the player preview', () => {
+    const snippet = extractResolveFunction();
+    assert.notStrictEqual(snippet, '', 'resolveFighterName function should be present in fighter.js');
+    assert.ok(
+      snippet.includes('function resolveFighterName(id, characterData, prevProfile)'),
+      'resolveFighterName should accept the fighter id so it can detect the player entity'
+    );
+    assert.ok(
+      /id\s*===\s*['"]player['"]/u.test(snippet),
+      'resolveFighterName should check for the player id when applying the selected fighter override'
+    );
+    assert.ok(
+      /selectedFighter\s*&&[\s\S]*C\.fighters\?\.[\[]selectedFighter[\]]/u.test(snippet),
+      'resolveFighterName should ensure the selected fighter exists before using it'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- update `resolveFighterName` so the player's selected fighter overrides previously cached profiles
- add a regression test that asserts the helper checks for the player id and validates the selected fighter entry

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d7149ccc832699ba86b859f242d5)