### PR TITLE
Fix tower prefabs to use bundled assets

### DIFF
--- a/docs/assets/asset-manifest.json
+++ b/docs/assets/asset-manifest.json
@@ -22,5 +22,7 @@
   "./assets/fightersprites/tletingan/torso.png",
   "./assets/fightersprites/tletingan/untinted_regions/ur-head.png",
   "./assets/fightersprites/tletingan/untinted_regions/ur-arm-lower.png",
-  "./assets/fightersprites/tletingan/untinted_regions/ur-leg-lower.png"
+  "./assets/fightersprites/tletingan/untinted_regions/ur-leg-lower.png",
+  "./assets/prefabs/structures/towers/tower_commercial_near.png",
+  "./assets/prefabs/structures/towers/tower_general_far.png"
 ]

--- a/docs/config/prefabs/structures/tower_commercial.prefab.json
+++ b/docs/config/prefabs/structures/tower_commercial.prefab.json
@@ -10,7 +10,7 @@
       "z": 10,
       "propTemplate": {
         "id": "tower_near",
-        "url": "https://i.imgur.com/tower_commercial_near.png",
+        "url": "./assets/prefabs/structures/towers/tower_commercial_near.png",
         "w": 360,
         "h": 480,
         "pivot": "bottom",
@@ -52,7 +52,7 @@
       "z": 0,
       "propTemplate": {
         "id": "tower_farleft",
-        "url": "https://i.imgur.com/tower_general_far.png",
+        "url": "./assets/prefabs/structures/towers/tower_general_far.png",
         "w": 360,
         "h": 480,
         "pivot": "bottom",
@@ -94,7 +94,7 @@
       "z": 0,
       "propTemplate": {
         "id": "tower_farRight",
-        "url": "https://i.imgur.com/tower_general_far.png",
+        "url": "./assets/prefabs/structures/towers/tower_general_far.png",
         "w": 360,
         "h": 480,
         "pivot": "bottom",

--- a/tools/structure_builder_v10.html
+++ b/tools/structure_builder_v10.html
@@ -222,11 +222,11 @@ const state = {
     base: {},
     parts: [
       { name:'near', layer:'near', relX:0, relY:0, z:10,
-        propTemplate: { id:'tower_near', url:'https://i.imgur.com/tower_commercial_near.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:1, parallaxClampPx:0,
+        propTemplate: { id:'tower_near', url:'./assets/prefabs/structures/towers/tower_commercial_near.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:1, parallaxClampPx:0,
           kf: { radius:800, ease:'smoothstep', translateSpace:'screen', transformOrder:'scaleThenRotate',
                 left:{dx:0,dy:0,scaleX:1,rotZdeg:0}, center:{dx:0,dy:0,scaleX:1,rotZdeg:0}, right:{dx:0,dy:0,scaleX:1,rotZdeg:0} } } },
       { name:'far', layer:'far', relX:0, relY:0, z:0,
-        propTemplate: { id:'tower_far', url:'https://i.imgur.com/tower_general_far.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:0.85, parallaxClampPx:64,
+        propTemplate: { id:'tower_far', url:'./assets/prefabs/structures/towers/tower_general_far.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:0.85, parallaxClampPx:64,
           kf: { radius:800, ease:'smoothstep', translateSpace:'screen', transformOrder:'scaleThenRotate',
                 left:{dx:-24,dy:0,scaleX:0.92,rotZdeg:-6}, center:{dx:0,dy:0,scaleX:1,rotZdeg:0}, right:{dx:22,dy:0,scaleX:0.92,rotZdeg:6} } } }
     ]


### PR DESCRIPTION
## Summary
- point the tower structure prefab and related tooling at the locally bundled PNG assets
- register the tower PNGs in the asset manifest so standalone builds can preload them

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e2e152ec8326a26955c32dd62b8e)