### PR TITLE
Add dual wanderer NPC system

### DIFF
--- a/ancient code-monolith of truth V2.html
+++ b/ancient code-monolith of truth V2.html
@@ -1651,7 +1651,7 @@ cx.restore();;
       stamina: 100,
       trailColor: 'cyan'
     }),
-    
+
     npc: createFighter({
       id: 'npc',
       isPlayer: false,
@@ -1661,8 +1661,21 @@ cx.restore();;
       stamina: 100,
       trailColor: 'red',
       ai: true
+    }),
+
+    npc2: createFighter({
+      id: 'npc2',
+      isPlayer: false,
+      pos: {x: CONFIG.canvas.w * 0.35, y: CONFIG.groundY - (CONFIG.parts.hitbox.h * CONFIG.actor.scale) / 2},
+      facingRad: 0,
+      footing: 100,
+      stamina: 100,
+      trailColor: 'orange',
+      ai: true
     })
   };
+
+  const NPCS = [FIGHTERS.npc, FIGHTERS.npc2];
   
   // Legacy aliases for backward compatibility during migration
   const MOVE = FIGHTERS.player;
@@ -1752,13 +1765,93 @@ cx.restore();;
   
   // Legacy alias for NPC (for backward compatibility during migration)
   const NPC_STATE = FIGHTERS.npc;
+  const NPC2_STATE = FIGHTERS.npc2;
   // --- AI field sync to top-level (compat with older code that reads NPC_STATE.mode/cooldown) ---
-  if (!('mode' in NPC_STATE)) NPC_STATE.mode = (NPC_STATE.ai && NPC_STATE.ai.mode) || 'approach'; // used in updateNpc()
-  if (!Number.isFinite(NPC_STATE.cooldown)) NPC_STATE.cooldown = (NPC_STATE.ai && Number.isFinite(NPC_STATE.ai.cooldown) ? NPC_STATE.ai.cooldown : 0); // used in attack gating
+  if (!('mode' in NPC_STATE)) NPC_STATE.mode = 'wander';
+  if (!Number.isFinite(NPC_STATE.cooldown)) NPC_STATE.cooldown = 0;
+  if (!('mode' in NPC2_STATE)) NPC2_STATE.mode = 'wander';
+  if (!Number.isFinite(NPC2_STATE.cooldown)) NPC2_STATE.cooldown = 0;
 
-  
-  // NPC walk cycle (now an alias to npc.walk)
+
+  // NPC walk cycle (legacy alias retained for compatibility)
   const NPC_WALK = FIGHTERS.npc.walk;
+
+  function randomRange(min, max) {
+    return min + Math.random() * (max - min);
+  }
+
+  function ensureWandererState(npc, index) {
+    if (!npc) return;
+    const defaultDir = index % 2 === 0 ? -1 : 1;
+    if (!npc.wander) {
+      npc.wander = {
+        direction: defaultDir,
+        lastDirection: defaultDir,
+        timer: randomRange(1.5, 3.5),
+        speed: CONFIG.movement.maxSpeedX * 0.3,
+        boundsRatio: {
+          min: 0.25 + index * 0.1,
+          max: 0.85 - index * 0.1
+        }
+      };
+    } else {
+      npc.wander.speed = CONFIG.movement.maxSpeedX * 0.3;
+      npc.wander.boundsRatio = npc.wander.boundsRatio || { min: 0.25 + index * 0.1, max: 0.85 - index * 0.1 };
+      npc.wander.boundsRatio.min = 0.25 + index * 0.1;
+      npc.wander.boundsRatio.max = 0.85 - index * 0.1;
+      if (!Number.isFinite(npc.wander.timer)) {
+        npc.wander.timer = randomRange(1.5, 3.5);
+      }
+      if (typeof npc.wander.lastDirection !== 'number') {
+        npc.wander.lastDirection = defaultDir;
+      }
+      if (typeof npc.wander.direction !== 'number') {
+        npc.wander.direction = defaultDir;
+      }
+    }
+
+    npc.mode = 'wander';
+    npc.cooldown = 0;
+    npc.onGround = true;
+    npc.ragdoll = false;
+    npc.recovering = false;
+    if (npc.ai) {
+      npc.ai.mode = 'wander';
+      npc.ai.timer = npc.wander.timer;
+      npc.ai.cooldown = 0;
+    }
+    if (npc.attack) {
+      npc.attack.active = false;
+      npc.attack.currentActiveKeys = [];
+      npc.attack.currentPhase = null;
+    }
+    if (npc.combo) {
+      npc.combo.active = false;
+      npc.combo.sequenceIndex = 0;
+      npc.combo.attackDelay = 0;
+    }
+  }
+
+  function pickNextWanderState(npc) {
+    if (!npc || !npc.wander) return;
+    const choices = [-1, 0, 1];
+    const choice = choices[Math.floor(Math.random() * choices.length)];
+    npc.wander.direction = choice;
+    npc.wander.timer = randomRange(1.5, 3.5);
+    if (choice !== 0) {
+      npc.wander.lastDirection = choice;
+    }
+  }
+
+  function getWanderBounds(npc) {
+    if (!npc || !npc.wander || !npc.wander.boundsRatio) {
+      return { min: WORLD_WIDTH * 0.2, max: WORLD_WIDTH * 0.8 };
+    }
+    return {
+      min: WORLD_WIDTH * npc.wander.boundsRatio.min,
+      max: WORLD_WIDTH * npc.wander.boundsRatio.max
+    };
+  }
 
   // Positions of attack colliders for the current frame. These are populated
   // during skeleton drawing so that the render function can draw simple
@@ -4058,23 +4151,199 @@ const scale = CONFIG.actor.scale; const {upper,lower} = CONFIG.parts.leg;
     const stage = document.getElementById('gameStage');
     const rect = stage.getBoundingClientRect();
     // Canvas matches display size (for proper scaling)
-    cv.width = Math.floor(rect.width); 
+    cv.width = Math.floor(rect.width);
     cv.height = Math.floor(rect.height);
     CONFIG.canvas.w = cv.width; 
     CONFIG.canvas.h = cv.height;
     CONFIG.groundY = Math.round(cv.height * CONFIG.groundRatio);
     
     const hb = CONFIG.parts.hitbox;
-    // Position player in WORLD coordinates (center of 1600px world)
-    MOVE.pos.x = WORLD_WIDTH / 2; 
-    MOVE.pos.y = CONFIG.groundY - (hb.h*CONFIG.actor.scale)/2;
+    const baseY = CONFIG.groundY - (hb.h * CONFIG.actor.scale) / 2;
 
-    // Position NPC in WORLD coordinates
-    NPC_STATE.pos.x = WORLD_WIDTH * 0.65;
-    NPC_STATE.pos.y = CONFIG.groundY - (CONFIG.parts.hitbox.h * CONFIG.actor.scale) / 2;
-    
+    // Position player in WORLD coordinates (center of 1600px world)
+    MOVE.pos.x = WORLD_WIDTH / 2;
+    MOVE.pos.y = baseY;
+
+    // Position wanderer NPCs in WORLD coordinates
+    const defaultRatios = [0.65, 0.45];
+    NPCS.forEach((npc, index) => {
+      ensureWandererState(npc, index);
+      const ratio = (defaultRatios[index] !== undefined) ? defaultRatios[index] : 0.55;
+      npc.pos.x = WORLD_WIDTH * ratio;
+      npc.pos.y = baseY;
+    });
+
     // Initialize camera to center on player
     CAMERA.x = MOVE.pos.x - cv.width / 2;
+  }
+
+  function computeWandererPhysicsOffsets(npc) {
+    const o = {};
+    o.torso = clamp((npc && npc.vel ? npc.vel.x : 0) * 0.04, -25, 25);
+    o.lKnee = 0;
+    o.rKnee = 0;
+    o.lHip = 0;
+    o.rHip = 0;
+    return o;
+  }
+
+  function computeWandererWalkOffsets(npc, dt) {
+    const W = CONFIG.walk;
+    const out = {};
+    if (!npc || !npc.walk || !W || !W.enabled) return out;
+
+    const pureStance = true;
+    const speed = Math.abs(npc.vel.x || 0);
+    const hasWalk = speed > 0.1;
+    const active = pureStance && npc.onGround && speed > W.minSpeed && hasWalk;
+
+    const k = 1 - Math.exp(-8 * dt);
+    const targetAmp = active ? 1 : 0;
+    npc.walk.amp += (targetAmp - npc.walk.amp) * k;
+    if (npc.walk.amp < 1e-3) return out;
+
+    const speedNorm = clamp(speed / CONFIG.movement.maxSpeedX, 0, 1);
+    const hz = W.baseHz * (0.6 + 0.8 * speedNorm) * W.speedScale;
+    npc.walk.phase = (npc.walk.phase + hz * dt * TAU) % TAU;
+    const t = (Math.sin(npc.walk.phase) + 1) / 2;
+
+    const A = W.poses.A || {};
+    const B = W.poses.B || {};
+    const S = CONFIG.poses.Stance || {};
+    const walkPose = {
+      torso: lerp(A.torso || 0, B.torso || 0, t),
+      lHip:  lerp(A.lHip  || 0, B.lHip  || 0, t),
+      lKnee: lerp(A.lKnee || 0, B.lKnee || 0, t),
+      rHip:  lerp(A.rHip  || 0, B.rHip  || 0, t),
+      rKnee: lerp(A.rKnee || 0, B.rKnee || 0, t)
+    };
+
+    out.torso = lerp(S.torso || 0, walkPose.torso, npc.walk.amp);
+    out.lHip  = lerp(S.lHip  || 0, walkPose.lHip , npc.walk.amp);
+    out.lKnee = lerp(S.lKnee || 0, walkPose.lKnee, npc.walk.amp);
+    out.rHip  = lerp(S.rHip  || 0, walkPose.rHip , npc.walk.amp);
+    out.rKnee = lerp(S.rKnee || 0, walkPose.rKnee, npc.walk.amp);
+    out.__overwrite = pureStance;
+    return out;
+  }
+
+  function computeWandererOffsets(npc, dt) {
+    let final = clone(CONFIG.poses.Stance || {});
+    const phys = computeWandererPhysicsOffsets(npc);
+    final = addOffsets(final, scaleOffsets(phys, CONFIG.movement.physicsWeight));
+    const walk = computeWandererWalkOffsets(npc, dt);
+    if (walk.__overwrite) {
+      for (const key of ['torso', 'lHip', 'lKnee', 'rHip', 'rKnee']) {
+        if (Object.prototype.hasOwnProperty.call(walk, key)) {
+          final[key] = walk[key];
+        }
+      }
+    } else {
+      final = addOffsets(final, walk);
+    }
+    return final;
+  }
+
+  function drawWanderers(dt, playerCollidersSnapshot) {
+    if (!NPC_ENABLED) return;
+
+    const savedMirror = {};
+    for (const key in MIRROR) {
+      savedMirror[key] = MIRROR[key];
+    }
+    const savedFlip = {};
+    for (const key in FLIP_STATE) {
+      savedFlip[key] = FLIP_STATE[key];
+    }
+    const savedMove = { x: MOVE.pos.x, y: MOVE.pos.y, facing: MOVE.facingRad };
+
+    NPCS.forEach((npc, index) => {
+      ensureWandererState(npc, index);
+      const hitCenter = { x: npc.pos.x, y: npc.pos.y };
+      const offsets = computeWandererOffsets(npc, dt);
+
+      MOVE.pos.x = npc.pos.x;
+      MOVE.pos.y = npc.pos.y;
+      MOVE.facingRad = npc.facingRad;
+
+      for (const key in MIRROR) { delete MIRROR[key]; }
+      initFlipStateFromMirror();
+      drawSkeleton(offsets, hitCenter, npc);
+    });
+
+    for (const key in MIRROR) { delete MIRROR[key]; }
+    for (const key in savedMirror) { MIRROR[key] = savedMirror[key]; }
+    for (const key in FLIP_STATE) { delete FLIP_STATE[key]; }
+    for (const key in savedFlip) { FLIP_STATE[key] = savedFlip[key]; }
+
+    MOVE.pos.x = savedMove.x;
+    MOVE.pos.y = savedMove.y;
+    MOVE.facingRad = savedMove.facing;
+
+    if (playerCollidersSnapshot) {
+      COLLIDERS_POS.hitCenter.x = playerCollidersSnapshot.hitCenter.x;
+      COLLIDERS_POS.hitCenter.y = playerCollidersSnapshot.hitCenter.y;
+      COLLIDERS_POS.handL = playerCollidersSnapshot.handL;
+      COLLIDERS_POS.handR = playerCollidersSnapshot.handR;
+      COLLIDERS_POS.footL = playerCollidersSnapshot.footL;
+      COLLIDERS_POS.footR = playerCollidersSnapshot.footR;
+    }
+  }
+
+  function updateWanderers(dt) {
+    NPCS.forEach((npc, index) => {
+      ensureWandererState(npc, index);
+      if (!npc || !npc.wander) return;
+
+      npc.wander.timer -= dt;
+      if (npc.wander.timer <= 0) {
+        pickNextWanderState(npc);
+      }
+
+      const bounds = getWanderBounds(npc);
+      const baseY = CONFIG.groundY - (CONFIG.parts.hitbox.h * CONFIG.actor.scale) / 2;
+      const speed = npc.wander.speed;
+      let direction = npc.wander.direction;
+      let desiredVel = direction === 0 ? 0 : direction * speed;
+
+      npc.pos.x += desiredVel * dt;
+
+      if (npc.pos.x <= bounds.min) {
+        npc.pos.x = bounds.min;
+        npc.wander.direction = 1;
+        npc.wander.lastDirection = 1;
+        npc.wander.timer = randomRange(1.5, 3.5);
+      } else if (npc.pos.x >= bounds.max) {
+        npc.pos.x = bounds.max;
+        npc.wander.direction = -1;
+        npc.wander.lastDirection = -1;
+        npc.wander.timer = randomRange(1.5, 3.5);
+      }
+
+      direction = npc.wander.direction;
+      desiredVel = direction === 0 ? 0 : direction * speed;
+
+      npc.vel.x = desiredVel;
+      npc.vel.y = 0;
+      npc.pos.y = baseY;
+      npc.onGround = true;
+      npc.ragdoll = false;
+      npc.recovering = false;
+      npc.landedImpulse = 0;
+      if (npc.stamina) {
+        npc.stamina.isDashing = false;
+        npc.stamina.current = npc.stamina.max;
+      }
+
+      const maxFooting = CONFIG.knockback && CONFIG.knockback.maxFooting ? CONFIG.knockback.maxFooting : 100;
+      npc.footing = Math.min(maxFooting, npc.footing || maxFooting);
+
+      if (direction !== 0) {
+        npc.wander.lastDirection = direction;
+      }
+      const facingDir = npc.wander.lastDirection || 1;
+      npc.facingRad = facingDir >= 0 ? 0 : Math.PI;
+    });
   }
 
   // ====== NPC AI ======
@@ -4671,15 +4940,16 @@ const scale = CONFIG.actor.scale; const {upper,lower} = CONFIG.parts.leg;
     const hud = document.getElementById('aiHud');
     if (!hud || hud.style.display==='none') return;
     try{
-      const dx = (typeof MOVE!=='undefined' && MOVE.pos && NPC_STATE && NPC_STATE.pos) ? (MOVE.pos.x - NPC_STATE.pos.x) : 0;
-      const lines = [
-        `NPC_ENABLED: ${typeof NPC_ENABLED!=='undefined' ? NPC_ENABLED : 'n/a'}`,
-        `mode: ${NPC_STATE && NPC_STATE.mode || 'n/a'}`,
-        `attack.active: ${NPC_STATE && NPC_STATE.attack && NPC_STATE.attack.active || false}`,
-        `combo.active: ${NPC_STATE && NPC_STATE.combo && NPC_STATE.combo.active || false}  idx: ${NPC_STATE && NPC_STATE.combo && NPC_STATE.combo.sequenceIndex || 0}`,
-        `cooldown: ${(NPC_STATE && NPC_STATE.cooldown || 0).toFixed ? (NPC_STATE.cooldown).toFixed(2) : '0.00'}`,
-        `dx to player: ${dx.toFixed ? dx.toFixed(1) : dx}`,
-      ];
+      const lines = [`NPC_ENABLED: ${typeof NPC_ENABLED!=='undefined' ? NPC_ENABLED : 'n/a'}`];
+      NPCS.forEach((npc, index) => {
+        ensureWandererState(npc, index);
+        const dx = (MOVE && MOVE.pos && npc && npc.pos) ? (MOVE.pos.x - npc.pos.x) : 0;
+        const wander = npc && npc.wander ? npc.wander : { direction: 0, timer: 0 };
+        const dirLabel = wander.direction > 0 ? 'right' : (wander.direction < 0 ? 'left' : 'idle');
+        lines.push(
+          `NPC${index + 1}: x=${npc.pos.x.toFixed(1)} dir=${dirLabel} timer=${wander.timer.toFixed(1)} dx=${dx.toFixed(1)}`
+        );
+      });
       hud.textContent = lines.join('\n');
     }catch(e){ hud.textContent = 'HUD error: '+e.message; }
   }
@@ -4799,7 +5069,7 @@ const scale = CONFIG.actor.scale; const {upper,lower} = CONFIG.parts.leg;
     
     // Update the NPC's AI before orchestrating animations (only if NPC is enabled)
     if (NPC_ENABLED) {
-      updateNpc(dt);
+      updateWanderers(dt);
     }
     const final = orchestrate(poseOffsets, dt);
     
@@ -5002,345 +5272,12 @@ const scale = CONFIG.actor.scale; const {upper,lower} = CONFIG.parts.leg;
       }
     }
     
-    // Draw the NPC skeleton (only if NPC is enabled)
-    let npcColliders = null;
     if (NPC_ENABLED) {
-      const origPosX = MOVE.pos.x;
-      const origPosY = MOVE.pos.y;
-      const origFacing = MOVE.facingRad;
-      // Set MOVE to NPC state for drawing
-      MOVE.pos.x = NPC_STATE.pos.x;
-      MOVE.pos.y = NPC_STATE.pos.y;
-      MOVE.facingRad = NPC_STATE.facingRad;
-      // The NPC's hit center uses the NPC's x position and the same y
-      // component as the player's hit center (both share ground height).
-      const npcHitCenter = { x: NPC_STATE.pos.x, y: NPC_STATE.pos.y };
-      // Compute the NPC's animation offsets based on its own movement. This
-      // uses a small physics lean and an independent walk cycle so the NPC
-      // animates while moving. The stance pose is blended with these
-      // offsets. LAST_DT is used as the delta time since the last frame.
-      const npcPoseOffsets = computeNpcOffsets(LAST_DT);
-      // Save current MIRROR and FLIP_STATE so we can draw the NPC without
-      // inheriting any limb flips triggered by the player's attacks. We
-      // clear MIRROR, sync FLIP_STATE, draw the NPC, then restore both.
-      const savedMirror = {};
-      for (const key in MIRROR){ savedMirror[key] = MIRROR[key]; }
-      const savedFlip = {};
-      for (const key in FLIP_STATE){ savedFlip[key] = FLIP_STATE[key]; }
-      // Clear existing mirror state
-      for (const key in MIRROR){ delete MIRROR[key]; }
-      initFlipStateFromMirror();
-      // Draw the NPC skeleton without any part-specific flips
-      drawSkeleton(npcPoseOffsets, npcHitCenter, NPC_STATE);
-      
-      // Restore MIRROR and FLIP_STATE
-      for (const key in MIRROR){ delete MIRROR[key]; }
-      for (const key in savedMirror){ MIRROR[key] = savedMirror[key]; }
-      for (const key in FLIP_STATE){ delete FLIP_STATE[key]; }
-      for (const key in savedFlip){ FLIP_STATE[key] = savedFlip[key]; }
-      // Copy the colliders computed for the NPC
-      npcColliders = {
-        hitCenter: { x: COLLIDERS_POS.hitCenter.x, y: COLLIDERS_POS.hitCenter.y },
-        handL: COLLIDERS_POS.handL ? { x: COLLIDERS_POS.handL.x, y: COLLIDERS_POS.handL.y } : null,
-        handR: COLLIDERS_POS.handR ? { x: COLLIDERS_POS.handR.x, y: COLLIDERS_POS.handR.y } : null,
-        footL: COLLIDERS_POS.footL ? { x: COLLIDERS_POS.footL.x, y: COLLIDERS_POS.footL.y } : null,
-        footR: COLLIDERS_POS.footR ? { x: COLLIDERS_POS.footR.x, y: COLLIDERS_POS.footR.y } : null
-      };
-      
-      // Capture NPC attack trail positions
-      if (NPC_ATTACK_TRAIL.enabled && NPC_STATE.attack.active) {
-        NPC_ATTACK_TRAIL.timer += LAST_DT;
-        if (NPC_ATTACK_TRAIL.timer >= NPC_ATTACK_TRAIL.interval) {
-          NPC_ATTACK_TRAIL.timer = 0;
-          
-          const npcActiveKeys = NPC_STATE.attack.currentActiveKeys || [];
-          const baseRad = 8 * CONFIG.actor.scale;
-          for (const key of ['handL', 'handR', 'footL', 'footR']) {
-            if (npcActiveKeys.includes(key) && npcColliders[key]) {
-              // Calculate radius inline
-              let radius = baseRad;
-              if (key === 'handL' || key === 'handR') {
-                radius *= CONFIG.colliders.handMultiplier;
-              } else if (key === 'footL' || key === 'footR') {
-                radius *= CONFIG.colliders.footMultiplier;
-              }
-              
-              // Capture the NPC collider position
-              NPC_ATTACK_TRAIL.colliders[key].unshift({
-                x: npcColliders[key].x,
-                y: npcColliders[key].y,
-                alpha: 1.0,
-                radius: radius
-              });
-              
-              if (NPC_ATTACK_TRAIL.colliders[key].length > NPC_ATTACK_TRAIL.maxLength) {
-                NPC_ATTACK_TRAIL.colliders[key].length = NPC_ATTACK_TRAIL.maxLength;
-              }
-            }
-          }
-        }
-      }
-      
-      // Restore player state
-      MOVE.pos.x = origPosX;
-      MOVE.pos.y = origPosY;
-      MOVE.facingRad = origFacing;
-      // Restore player's colliders
-      COLLIDERS_POS.hitCenter.x = savedColliders.hitCenter.x;
-      COLLIDERS_POS.hitCenter.y = savedColliders.hitCenter.y;
-      COLLIDERS_POS.handL = savedColliders.handL;
-      COLLIDERS_POS.handR = savedColliders.handR;
-      COLLIDERS_POS.footL = savedColliders.footL;
-      COLLIDERS_POS.footR = savedColliders.footR;
+      drawWanderers(LAST_DT, savedColliders);
     }
-    // At this point we have both the player's colliders (savedColliders) and the
-    // NPC's colliders (npcColliders). Determine which colliders are active for
-    // each fighter and detect any collisions between them (only if NPC is enabled).
     const playerActiveKeys2 = getActiveColliders();
-    const npcActiveKeys2 = NPC_ENABLED && (NPC_STATE.attack && NPC_STATE.attack.active) ? NPC_STATE.attack.currentActiveKeys : [];
     const playerCollisionKeys2 = [];
-    const npcCollisionKeys2 = [];
-    const baseRad = 8 * CONFIG.actor.scale;
-    
-    // Helper function to get collision radius for a collider key
-    function getColliderRadius(key) {
-      if (key === 'handL' || key === 'handR') {
-        return baseRad * CONFIG.colliders.handMultiplier;
-      } else if (key === 'footL' || key === 'footR') {
-        return baseRad * CONFIG.colliders.footMultiplier;
-      }
-      return baseRad;
-    }
-    // Radius for detecting hits against the NPC's body (hitbox). Use half
-    // of the hitbox width scaled by the actor scale as an approximate body
-    // radius. This allows attack colliders to register hits even when the
-    // opponent has no active colliders.
-    // Body radius for hit detection should be larger than just half the hitbox
-    // width. Use the pre‑authored circular radius on the hitbox (r) scaled by
-    // the actor scale so that hits register when the hand/foot passes near
-    // the opponent’s torso. This avoids missing hits when colliders graze the
-    // edges of the body. See CONFIG.parts.hitbox.r in the fighter config.
-    // Approximate the opponent's torso as a circle whose radius is half
-    // the diagonal of the hitbox rectangle. Using the diagonal ensures
-    // the circle fully contains the rectangular body, making it easier
-    // to register hits when the hand/foot grazes the edges. Both width
-    // and height are scaled by the actor's scale.
-    let bodyRad;
-    {
-      const wHalf = (CONFIG.parts.hitbox.w * CONFIG.actor.scale) * 0.5;
-      const hHalf = (CONFIG.parts.hitbox.h * CONFIG.actor.scale) * 0.5;
-      bodyRad = Math.sqrt(wHalf * wHalf + hHalf * hHalf);
-    }
-    // All collision detection only happens if NPC is enabled
-    if (NPC_ENABLED) {
-      if (playerActiveKeys2.length && npcActiveKeys2.length){
-        for (const pk of playerActiveKeys2){
-          const pPos = savedColliders[pk];
-          if (!pPos) continue;
-          const pRad = getColliderRadius(pk);
-          for (const nk of npcActiveKeys2){
-            const nPos = npcColliders[nk];
-            if (!nPos) continue;
-            const nRad = getColliderRadius(nk);
-            const thresh = pRad + nRad;
-            const dx = pPos.x - nPos.x;
-            const dy = pPos.y - nPos.y;
-            if (Math.hypot(dx, dy) <= thresh){
-              if (!playerCollisionKeys2.includes(pk)) playerCollisionKeys2.push(pk);
-              if (!npcCollisionKeys2.includes(nk)) npcCollisionKeys2.push(nk);
-              HIT_COUNTS.player[pk] = (HIT_COUNTS.player[pk] || 0) + 1;
-              HIT_COUNTS.npc[nk] = (HIT_COUNTS.npc[nk] || 0) + 1;
-            }
-          }
-        }
-      }
-    }
-    // Detect collisions between the player's active colliders and the NPC's
-    // body (hitbox) - only if NPC is enabled
-    let npcBodyHit = false;
-    let knockbackApplied = false;
-    if (NPC_ENABLED && playerActiveKeys2.length){
-      const bodyCenter = npcColliders.hitCenter;
-      for (const pk of playerActiveKeys2){
-        const pPos = savedColliders[pk];
-        if (!pPos || !bodyCenter) continue;
-        const pRad = getColliderRadius(pk);
-        const dx = pPos.x - bodyCenter.x;
-        const dy = pPos.y - bodyCenter.y;
-        const dist = Math.hypot(dx, dy);
-        if (dist <= (bodyRad + pRad)){
-          if (!playerCollisionKeys2.includes(pk)) playerCollisionKeys2.push(pk);
-          HIT_COUNTS.player[pk] = (HIT_COUNTS.player[pk] || 0) + 1;
-          npcBodyHit = true;
-          // Increment NPC body hit counter. Create the key if it does not
-          // exist so that each hit registers.
-          HIT_COUNTS.npc.body = (HIT_COUNTS.npc.body || 0) + 1;
-          
-          // Apply knockback only once per frame when NPC body is hit
-          if (!knockbackApplied && ATTACK.preset) {
-            // Increment combo hits only once per strike
-            if (!ATTACK.strikeLanded) {
-              COMBO.hits++;
-              ATTACK.strikeLanded = true;
-            }
-            
-            const knockbackForce = calculateKnockback(
-              ATTACK.preset,
-              ATTACK.isHoldRelease,
-              ATTACK.holdStartTime,
-              ATTACK.holdWindupDuration,
-              NPC_STATE.footing
-            );
-            
-            // Calculate knockback direction: away from player
-            const knockbackAngle = Math.atan2(
-              npcColliders.hitCenter.y - savedColliders.hitCenter.y,
-              npcColliders.hitCenter.x - savedColliders.hitCenter.x
-            );
-            
-            // Apply knockback velocity to NPC
-            NPC_STATE.vel.x += Math.cos(knockbackAngle) * knockbackForce;
-            NPC_STATE.vel.y += Math.sin(knockbackAngle) * knockbackForce * 0.2; // Minimal vertical component (was 0.5)
-            
-            // Reduce NPC footing on hit (reduced from 10 to 5, then to 2.5)
-            NPC_STATE.footing = Math.max(0, NPC_STATE.footing - 2.5);
-            
-            // ACTIVATE RAGDOLL for NPC when footing reaches 0
-            if (NPC_STATE.footing <= 0 && !NPC_STATE.ragdoll) {
-              NPC_STATE.ragdoll = true;
-              NPC_STATE.ragdollTime = 0;
-              
-              // Store the knockback velocity for continuous ragdoll force
-              NPC_STATE.ragdollVel.x = Math.cos(knockbackAngle) * knockbackForce * 2.0;
-              NPC_STATE.ragdollVel.y = Math.sin(knockbackAngle) * knockbackForce * 0.3; // Reduced vertical
-              
-              // Initialize NPC's actual velocity for ragdoll (important!)
-              NPC_STATE.vel.x = NPC_STATE.ragdollVel.x;
-              NPC_STATE.vel.y = Math.abs(Math.sin(knockbackAngle) * knockbackForce * 0.2); // Small upward pop, ensure positive (downward in canvas)
-              
-              // Get current NPC pose for initialization
-              const npcCurrentPose = current; // Use same pose structure
-              
-              // Add rotational spin based on knockback direction and force
-              const spinDirection = Math.sign(Math.cos(knockbackAngle)); // Left or right
-              const spinMagnitude = knockbackForce * 0.8; // Scale with knockback
-              
-              // Initialize joint angles and velocities for full collapse WITH SPIN
-              NPC_STATE.jointAngles = {
-                torso: npcCurrentPose.torso || 0,
-                torsoVel: (Math.random() - 0.5) * 400 + spinDirection * spinMagnitude * 0.3,
-                lShoulder: npcCurrentPose.lShoulder || 0,
-                lShoulderVel: (Math.random() - 0.5) * 600 + spinDirection * spinMagnitude * 0.5,
-                rShoulder: npcCurrentPose.rShoulder || 0,
-                rShoulderVel: (Math.random() - 0.5) * 600 + spinDirection * spinMagnitude * 0.5,
-                lElbow: npcCurrentPose.lElbow || 0,
-                lElbowVel: (Math.random() - 0.5) * 500 + spinDirection * spinMagnitude * 0.4,
-                rElbow: npcCurrentPose.rElbow || 0,
-                rElbowVel: (Math.random() - 0.5) * 500 + spinDirection * spinMagnitude * 0.4,
-                lHip: npcCurrentPose.lHip || 0,
-                lHipVel: (Math.random() - 0.5) * 400 + spinDirection * spinMagnitude * 0.3,
-                rHip: npcCurrentPose.rHip || 0,
-                rHipVel: (Math.random() - 0.5) * 400 + spinDirection * spinMagnitude * 0.3,
-                lKnee: npcCurrentPose.lKnee || 0,
-                lKneeVel: (Math.random() - 0.5) * 350 + spinDirection * spinMagnitude * 0.2,
-                rKnee: npcCurrentPose.rKnee || 0,
-                rKneeVel: (Math.random() - 0.5) * 350 + spinDirection * spinMagnitude * 0.2
-              };
-            }
-            
-            knockbackApplied = true;
-          }
-        }
-      }
-    }
-    
-    // Detect collisions between the NPC's active colliders and the PLAYER's
-    // body (hitbox) - only if NPC is enabled
-    let playerBodyHit = false;
-    let playerKnockbackApplied = false;
-    if (NPC_ENABLED && npcActiveKeys2.length){
-      const playerBodyCenter = savedColliders.hitCenter;
-      for (const nk of npcActiveKeys2){
-        const nPos = npcColliders[nk];
-        if (!nPos || !playerBodyCenter) continue;
-        const nRad = getColliderRadius(nk);
-        const dx = nPos.x - playerBodyCenter.x;
-        const dy = nPos.y - playerBodyCenter.y;
-        const dist = Math.hypot(dx, dy);
-        if (dist <= (bodyRad + nRad)){
-          if (!npcCollisionKeys2.includes(nk)) npcCollisionKeys2.push(nk);
-          HIT_COUNTS.npc[nk] = (HIT_COUNTS.npc[nk] || 0) + 1;
-          playerBodyHit = true;
-          
-          // Apply knockback to PLAYER only once per frame
-          if (!playerKnockbackApplied && NPC_STATE.attack.preset) {
-            // Mark that NPC landed this strike (no combo tracking for NPC)
-            if (!NPC_STATE.attack.strikeLanded) {
-              NPC_STATE.attack.strikeLanded = true;
-            }
-            
-            const knockbackForce = calculateKnockback(
-              NPC_STATE.attack.preset,
-              false, // NPC attacks are never hold-release
-              0,
-              0,
-              MOVE.footing
-            );
-            
-            // Calculate knockback direction: away from NPC
-            const knockbackAngle = Math.atan2(
-              savedColliders.hitCenter.y - npcColliders.hitCenter.y,
-              savedColliders.hitCenter.x - npcColliders.hitCenter.x
-            );
-            
-            // Apply knockback velocity to PLAYER
-            MOVE.vel.x += Math.cos(knockbackAngle) * knockbackForce;
-            MOVE.vel.y += Math.sin(knockbackAngle) * knockbackForce * 0.2;
-            
-            // Reduce PLAYER footing on hit (reduced from 10 to 5, then to 2.5)
-            MOVE.footing = Math.max(0, MOVE.footing - 2.5);
-            
-            // ACTIVATE RAGDOLL when footing reaches 0
-            if (MOVE.footing <= 0 && !MOVE.ragdoll) {
-              MOVE.ragdoll = true;
-              MOVE.ragdollTime = 0;
-              // Store the knockback velocity for continuous ragdoll force
-              MOVE.ragdollVel.x = Math.cos(knockbackAngle) * knockbackForce * 2.0;
-              MOVE.ragdollVel.y = Math.sin(knockbackAngle) * knockbackForce * 0.8;
-              
-              // Add rotational spin based on knockback direction and force
-              const spinDirection = Math.sign(Math.cos(knockbackAngle)); // Left or right
-              const spinMagnitude = knockbackForce * 0.8; // Scale with knockback
-              
-              // Initialize joint angles and velocities for full collapse WITH SPIN
-              MOVE.jointAngles = {
-                torso: current.torso || 0,
-                torsoVel: (Math.random() - 0.5) * 400 + spinDirection * spinMagnitude * 0.3,
-                lShoulder: current.lShoulder || 0,
-                lShoulderVel: (Math.random() - 0.5) * 600 + spinDirection * spinMagnitude * 0.5,
-                rShoulder: current.rShoulder || 0,
-                rShoulderVel: (Math.random() - 0.5) * 600 + spinDirection * spinMagnitude * 0.5,
-                lElbow: current.lElbow || 0,
-                lElbowVel: (Math.random() - 0.5) * 500 + spinDirection * spinMagnitude * 0.4,
-                rElbow: current.rElbow || 0,
-                rElbowVel: (Math.random() - 0.5) * 500 + spinDirection * spinMagnitude * 0.4,
-                lHip: current.lHip || 0,
-                lHipVel: (Math.random() - 0.5) * 400 + spinDirection * spinMagnitude * 0.3,
-                rHip: current.rHip || 0,
-                rHipVel: (Math.random() - 0.5) * 400 + spinDirection * spinMagnitude * 0.3,
-                lKnee: current.lKnee || 0,
-                lKneeVel: (Math.random() - 0.5) * 350 + spinDirection * spinMagnitude * 0.2,
-                rKnee: current.rKnee || 0,
-                rKneeVel: (Math.random() - 0.5) * 350 + spinDirection * spinMagnitude * 0.2
-              };
-            }
-            
-            playerKnockbackApplied = true;
-          }
-        }
-      }
-    }
-    
+
     // Draw player attack collider trails (afterimages)
     if (ATTACK_TRAIL.enabled) {
       for (const key of ['handL', 'handR', 'footL', 'footR']) {
@@ -5366,66 +5303,9 @@ const scale = CONFIG.actor.scale; const {upper,lower} = CONFIG.parts.leg;
       }
     }
     
-    // Draw NPC attack collider trails (red/orange tint for enemy)
-    if (NPC_ENABLED && NPC_ATTACK_TRAIL.enabled) {
-      for (const key of ['handL', 'handR', 'footL', 'footR']) {
-        const trail = NPC_ATTACK_TRAIL.colliders[key];
-        for (let i = trail.length - 1; i >= 0; i--) {
-          const pos = trail[i];
-          const alpha = pos.alpha * 0.5;
-          
-          cx.save();
-          cx.globalAlpha = alpha;
-          
-          // Red/orange tint for NPC
-          cx.beginPath();
-          cx.arc(pos.x, pos.y, pos.radius, 0, TAU);
-          cx.fillStyle = `rgba(255, 100, 80, ${alpha * 0.8})`;
-          cx.strokeStyle = `rgba(255, 150, 100, ${alpha})`;
-          cx.lineWidth = 2;
-          cx.fill();
-          cx.stroke();
-          
-          cx.restore();
-        }
-      }
-    }
-    
     // Draw the player's colliders with active/highlight information and counts
     drawAttackColliders(savedColliders, playerActiveKeys2, playerCollisionKeys2, HIT_COUNTS.player, MOVE.facingRad);
-    // Draw the NPC's attack colliders (only if NPC is enabled)
-    if (NPC_ENABLED) {
-      drawAttackColliders(npcColliders, npcActiveKeys2, npcCollisionKeys2, HIT_COUNTS.npc, NPC_STATE.facingRad);
-    }
-
-    // If the NPC's body was struck, draw visual feedback (only if NPC is enabled)
-    if (NPC_ENABLED && npcBodyHit){
-      cx.save();
-      // Draw semi-transparent red circle over the NPC's body
-      cx.beginPath();
-      cx.arc(npcColliders.hitCenter.x, npcColliders.hitCenter.y, bodyRad, 0, TAU);
-      cx.fillStyle = 'rgba(255, 60, 60, 0.25)';
-      cx.fill();
-      // Draw the body hit count in the centre
-      const cnt = HIT_COUNTS.npc.body || 0;
-      cx.fillStyle = '#ffffff';
-      cx.font = `${Math.round(10 * CONFIG.actor.scale)}px system-ui, sans-serif`;
-      cx.textAlign = 'center';
-      cx.textBaseline = 'middle';
-      cx.fillText(String(cnt), npcColliders.hitCenter.x, npcColliders.hitCenter.y);
-      cx.restore();
-    }
-    
-    // If the PLAYER's body was struck by an active NPC collider, draw visual feedback
-    if (playerBodyHit){
-      cx.save();
-      // Draw semi-transparent red circle over the PLAYER's body
-      cx.beginPath();
-      cx.arc(savedColliders.hitCenter.x, savedColliders.hitCenter.y, bodyRad, 0, TAU);
-      cx.fillStyle = 'rgba(255, 60, 60, 0.25)';
-      cx.fill();
-      cx.restore();
-    }
+    // NPC wanderers are non-aggressive, so no additional collider overlays are drawn.
     
     // HUD - Debug display commented out for clean gameplay
     /* 

--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -69,6 +69,7 @@ export function initFighters(cv, cx){
   const DEFAULT_FIGHTER_SPACING = 120;
   const defaultPlayerX = (C.canvas?.w||720) * 0.5 - DEFAULT_FIGHTER_SPACING * 0.5;
   const defaultNpcX = defaultPlayerX + DEFAULT_FIGHTER_SPACING;
+  const secondNpcOffset = DEFAULT_FIGHTER_SPACING * 1.1;
 
   function normalizeSpawnValue(value) {
     return Number.isFinite(value) ? value : null;
@@ -193,6 +194,9 @@ export function initFighters(cv, cx){
   const resolvedNpcYOffset = npcSpawnYOffset ?? playerSpawnYOffset ?? 0;
   const playerSpawnY = gy - 1 + playerSpawnYOffset;
   const npcSpawnY = gy - 1 + resolvedNpcYOffset;
+  const worldWidth = C.world?.width || C.camera?.worldWidth || (C.canvas?.w || 720);
+  const npc2SpawnX = Math.max(0, Math.min(npcSpawnX + secondNpcOffset, worldWidth - DEFAULT_FIGHTER_SPACING * 0.5));
+  const npc2SpawnY = npcSpawnY;
 
   const fallbackFighterName = pickFighterName(C);
   const characters = C.characters || {};
@@ -393,7 +397,8 @@ export function initFighters(cv, cx){
 
   G.FIGHTERS = {
     player: makeF('player', playerSpawnX, 1, playerSpawnY),
-    npc:    makeF('npc',    npcSpawnX, -1, npcSpawnY)
+    npc:    makeF('npc',    npcSpawnX, -1, npcSpawnY),
+    npc2:   makeF('npc2',   npc2SpawnX, -1, npc2SpawnY),
   };
   G.spawnPoints = {
     player: {
@@ -407,6 +412,12 @@ export function initFighters(cv, cx){
       y: npcSpawnY,
       yOffset: resolvedNpcYOffset,
       source: npcSpawn ?? null,
+    },
+    npc2: {
+      x: npc2SpawnX,
+      y: npc2SpawnY,
+      yOffset: resolvedNpcYOffset,
+      source: null,
     },
   };
   const characterState = {};
@@ -426,6 +437,11 @@ export function initFighters(cv, cx){
         x: npcSpawnX,
         yOffset: resolvedNpcYOffset,
         worldY: npcSpawnY,
+      },
+      npc2: {
+        x: npc2SpawnX,
+        yOffset: resolvedNpcYOffset,
+        worldY: npc2SpawnY,
       },
     };
   }

--- a/docs/js/npc.js
+++ b/docs/js/npc.js
@@ -1,6 +1,15 @@
-// npc.js — Reimplements the NPC systems from the monolith build in a modular form
+// npc.js — wanderer NPC systems for modular build
 
-import { initCombatForFighter } from './combat.js?v=19';
+const DEFAULT_WORLD_WIDTH = 1600;
+const NPC_IDS = ['npc', 'npc2'];
+
+const DASH_TRAIL_TEMPLATE = {
+  enabled: true,
+  positions: [],
+  maxLength: 8,
+  interval: 0.18,
+  timer: 0,
+};
 
 function clamp(value, min, max) {
   if (value < min) return min;
@@ -8,178 +17,51 @@ function clamp(value, min, max) {
   return value;
 }
 
-const DEFAULT_WORLD_WIDTH = 1600;
-const TWO_PI = Math.PI * 2;
-
-const DEFAULT_DURATION_KEY_FALLBACKS = {
-  toWindup: 320,
-  toStrike: 160,
-  toRecoil: 180,
-  toStance: 120,
-  toSlam: 160,
-};
-
-const DASH_TRAIL_TEMPLATE = {
-  enabled: true,
-  positions: [],
-  maxLength: 8,
-  interval: 0.03,
-  timer: 0,
-};
-
-const ATTACK_TRAIL_TEMPLATE = {
-  enabled: true,
-  colliders: {
-    handL: [],
-    handR: [],
-    footL: [],
-    footR: [],
-  },
-  maxLength: 6,
-  interval: 0.02,
-  timer: 0,
-};
-
-function clone(value) {
-  return value ? JSON.parse(JSON.stringify(value)) : value;
+function randomInRange(min, max) {
+  return min + Math.random() * (max - min);
 }
 
 function ensureGameState() {
   const G = (window.GAME ||= {});
-  G.HIT_COUNTS ||= {
-    player: { handL: 0, handR: 0, footL: 0, footR: 0 },
-    npc: { handL: 0, handR: 0, footL: 0, footR: 0, body: 0 },
-  };
+  const counts = (G.HIT_COUNTS ||= {});
+  counts.player ||= { handL: 0, handR: 0, footL: 0, footR: 0, body: 0 };
+  counts.npc ||= { handL: 0, handR: 0, footL: 0, footR: 0, body: 0 };
+  const perNpc = (counts.npcs ||= {});
+  for (const id of NPC_IDS) {
+    perNpc[id] ||= { body: 0, handL: 0, handR: 0, footL: 0, footR: 0 };
+  }
   return G;
 }
 
-function ensureNpcContainers(G) {
-  const npcSystems = (G.NPC ||= {});
-  if (!npcSystems.dashTrail) {
-    npcSystems.dashTrail = clone(DASH_TRAIL_TEMPLATE);
+function ensureNpcCollections(G) {
+  const systems = (G.NPC ||= {});
+  const wanderers = (systems.wanderers ||= {});
+  for (const id of NPC_IDS) {
+    const entry = (wanderers[id] ||= {});
+    const dashTrail = (entry.dashTrail ||= JSON.parse(JSON.stringify(DASH_TRAIL_TEMPLATE)));
+    dashTrail.positions ||= [];
+    dashTrail.maxLength = Number.isFinite(dashTrail.maxLength) ? dashTrail.maxLength : DASH_TRAIL_TEMPLATE.maxLength;
+    dashTrail.interval = Number.isFinite(dashTrail.interval) ? dashTrail.interval : DASH_TRAIL_TEMPLATE.interval;
+    dashTrail.timer = Number.isFinite(dashTrail.timer) ? dashTrail.timer : 0;
+
+    const attackTrail = (entry.attackTrail ||= {
+      enabled: false,
+      colliders: { handL: [], handR: [], footL: [], footR: [] },
+      maxLength: 6,
+      interval: 0.02,
+      timer: 0,
+    });
+    attackTrail.enabled = false;
+    attackTrail.maxLength = Number.isFinite(attackTrail.maxLength) ? attackTrail.maxLength : 6;
+    attackTrail.interval = Number.isFinite(attackTrail.interval) ? attackTrail.interval : 0.02;
+    attackTrail.timer = Number.isFinite(attackTrail.timer) ? attackTrail.timer : 0;
+    const colliders = (attackTrail.colliders ||= {});
+    colliders.handL ||= [];
+    colliders.handR ||= [];
+    colliders.footL ||= [];
+    colliders.footR ||= [];
   }
-  if (!npcSystems.attackTrail) {
-    npcSystems.attackTrail = clone(ATTACK_TRAIL_TEMPLATE);
-  }
-  return npcSystems;
-}
-
-function ensureNpcInputState(state) {
-  if (!state) return {};
-  const input = state.aiInput || {
-    buttonA: { down: false },
-    buttonB: { down: false },
-    left: false,
-    right: false,
-  };
-  if (!state.aiInput) state.aiInput = input;
-  input.buttonA ||= { down: false };
-  input.buttonB ||= { down: false };
-  return input;
-}
-
-function ensureNpcPressRegistry(state) {
-  if (!state) return {};
-  state.aiButtonPresses ||= {};
-  return state.aiButtonPresses;
-}
-
-function releaseNpcButton(state, combat, slotKey) {
-  if (!state || !combat) return;
-  const presses = state.aiButtonPresses;
-  if (!presses) return;
-  const press = presses[slotKey];
-  if (!press || !press.down) return;
-  press.down = false;
-  press.timer = 0;
-  const input = ensureNpcInputState(state);
-  if (slotKey === 'A') {
-    input.buttonA.down = false;
-  } else if (slotKey === 'B') {
-    input.buttonB.down = false;
-  }
-  combat.slotUp(slotKey);
-}
-
-function pressNpcButton(state, combat, slotKey, holdSeconds = 0.12) {
-  if (!state || !combat) return false;
-  const presses = ensureNpcPressRegistry(state);
-  const press = presses[slotKey] || (presses[slotKey] = { down: false, timer: 0 });
-  if (press.down) return false;
-  press.down = true;
-  press.timer = Math.max(0, holdSeconds);
-  const input = ensureNpcInputState(state);
-  if (slotKey === 'A') {
-    input.buttonA.down = true;
-  } else if (slotKey === 'B') {
-    input.buttonB.down = true;
-  }
-  combat.slotDown(slotKey);
-  return true;
-}
-
-function updateNpcAutomatedInput(state, combat, dt) {
-  if (!state || !combat) return;
-  const presses = state.aiButtonPresses;
-  if (!presses) return;
-  for (const [slotKey, press] of Object.entries(presses)) {
-    if (!press?.down) continue;
-    press.timer -= dt;
-    if (press.timer <= 0) {
-      releaseNpcButton(state, combat, slotKey);
-    }
-  }
-}
-
-function ensureNpcCombat(G) {
-  if (G.npcCombat) return G.npcCombat;
-  const combat = initCombatForFighter('npc', {
-    fighterLabel: 'npc',
-    poseTarget: 'npc',
-    autoProcessInput: false,
-    neutralizeInputMovement: false,
-    storeKey: 'npcCombat',
-    inputSource: () => {
-      const npc = G.FIGHTERS?.npc;
-      return npc ? ensureNpcInputState(npc) : {};
-    },
-  });
-  return combat;
-}
-
-function ensureAttackState(state) {
-  const attack = (state.attack ||= {});
-  attack.active = !!attack.active;
-  attack.preset = attack.preset || null;
-  attack.slot = attack.slot || null;
-  attack.currentPhase = attack.currentPhase || null;
-  attack.currentActiveKeys = Array.isArray(attack.currentActiveKeys)
-    ? attack.currentActiveKeys
-    : [];
-  attack.strikeLanded = !!attack.strikeLanded;
-  attack.isHoldRelease = !!attack.isHoldRelease;
-  attack.chargeStage = Number.isFinite(attack.chargeStage) ? attack.chargeStage : 0;
-  attack.context = attack.context || null;
-  return attack;
-}
-
-function ensureComboState(state) {
-  const combo = (state.combo ||= {});
-  combo.active = !!combo.active;
-  combo.sequenceIndex = Number.isFinite(combo.sequenceIndex) ? combo.sequenceIndex : 0;
-  combo.attackDelay = Number.isFinite(combo.attackDelay) ? combo.attackDelay : 0;
-  return combo;
-}
-
-function ensureAimState(state) {
-  const aim = (state.aim ||= {});
-  aim.targetAngle = Number.isFinite(aim.targetAngle) ? aim.targetAngle : 0;
-  aim.currentAngle = Number.isFinite(aim.currentAngle) ? aim.currentAngle : 0;
-  aim.torsoOffset = Number.isFinite(aim.torsoOffset) ? aim.torsoOffset : 0;
-  aim.shoulderOffset = Number.isFinite(aim.shoulderOffset) ? aim.shoulderOffset : 0;
-  aim.hipOffset = Number.isFinite(aim.hipOffset) ? aim.hipOffset : 0;
-  aim.active = !!aim.active;
-  return aim;
+  return systems;
 }
 
 function computeGroundY(config) {
@@ -192,675 +74,216 @@ function getWorldWidth(config) {
   return config.world?.width || config.camera?.worldWidth || DEFAULT_WORLD_WIDTH;
 }
 
-function getPresetActiveColliders(preset) {
-  if (!preset) return [];
-  const name = preset.toUpperCase();
-  if (name.startsWith('KICK')) return ['footL', 'footR'];
-  if (name.startsWith('PUNCH')) return ['handL', 'handR'];
-  if (name.startsWith('SLAM')) return ['handL', 'handR', 'footL', 'footR'];
-  return [];
+function ensureNpcDefaults(npc, id) {
+  if (!npc || typeof npc !== 'object') return;
+  npc.mode = 'wander';
+  npc.cooldown = 0;
+  npc.vel = npc.vel || { x: 0, y: 0 };
+  npc.pos = npc.pos || { x: 0, y: 0 };
+  npc.attack = npc.attack || {};
+  npc.attack.active = false;
+  npc.attack.currentPhase = null;
+  npc.attack.currentActiveKeys = [];
+  npc.attack.strikeLanded = false;
+  npc.combo = npc.combo || {};
+  npc.combo.active = false;
+  npc.combo.sequenceIndex = 0;
+  npc.combo.attackDelay = 0;
+  npc.ai = npc.ai || {};
+  npc.ai.mode = 'wander';
+  npc.ai.role = 'wanderer';
+  npc.aiInput = null;
+  npc.aiButtonPresses = null;
+
+  const wander = (npc.wander ||= {});
+  const startX = Number.isFinite(wander.anchorX) ? wander.anchorX : npc.pos.x ?? 0;
+  wander.anchorX = startX;
+  wander.range = Number.isFinite(wander.range) ? Math.max(48, wander.range) : 240;
+  wander.targetX = Number.isFinite(wander.targetX) ? wander.targetX : startX;
+  wander.waitTimer = Number.isFinite(wander.waitTimer) ? wander.waitTimer : randomInRange(0.6, 1.6);
+  wander.speed = Number.isFinite(wander.speed) ? Math.max(20, wander.speed) : null;
+  wander.id = id;
 }
 
-const PRIMARY_DURATION_KEYS = {
-  Windup: ['toWindup'],
-  Strike: ['toStrike'],
-  Recoil: ['toRecoil'],
-  Stance: ['toStance'],
-  Slam: ['toStrike', 'toSlam'],
-};
-
-function deriveDurationKeyCandidates(poseName) {
-  if (!poseName || typeof poseName !== 'string') return [];
-  const trimmed = poseName.trim();
-  if (!trimmed) return [];
-  const candidates = [];
-  const canonical = trimmed.replace(/\s+/g, '');
-  const base = PRIMARY_DURATION_KEYS[canonical];
-  if (Array.isArray(base)) candidates.push(...base);
-
-  const match = canonical.match(/^(Windup|Strike|Recoil|Stance)(.+)$/i);
-  if (match) {
-    const [, prefix, suffix] = match;
-    const cap = prefix[0].toUpperCase() + prefix.slice(1).toLowerCase();
-    candidates.push(`to${cap}${suffix}`);
-    candidates.push(`to${cap}`);
-  }
-
-  if (!PRIMARY_DURATION_KEYS[canonical]) {
-    const cap = canonical[0].toUpperCase() + canonical.slice(1);
-    candidates.push(`to${cap}`);
-  }
-
-  return [...new Set(candidates)];
+function pickWanderTarget(wander, worldWidth, margin) {
+  const anchor = Number.isFinite(wander.anchorX) ? wander.anchorX : 0;
+  const range = Math.max(48, Math.min(wander.range || 240, worldWidth * 0.45));
+  const minX = clamp(anchor - range, margin, worldWidth - margin);
+  const maxX = clamp(anchor + range, margin, worldWidth - margin);
+  return randomInRange(minX, maxX);
 }
 
-function resolveDurationMsForPose(poseName, presetDurations, fallbackDurations) {
-  const sources = [];
-  if (presetDurations) sources.push(presetDurations);
-  if (fallbackDurations && fallbackDurations !== presetDurations) {
-    sources.push(fallbackDurations);
-  }
-  const config = window.CONFIG || {};
-  const globalDurations = config.durations;
-  if (globalDurations) sources.push(globalDurations);
-  const attackDefaultDurations = config.attacks?.defaults?.durations;
-  if (attackDefaultDurations) sources.push(attackDefaultDurations);
-
-  const keys = deriveDurationKeyCandidates(poseName);
-  let zeroDurationDetected = false;
-
-  for (const key of keys) {
-    if (!key) continue;
-    for (const source of sources) {
-      if (!source) continue;
-      const value = source?.[key];
-      if (!Number.isFinite(value)) continue;
-      if (value > 0) return value;
-      if (value === 0) zeroDurationDetected = true;
-    }
-  }
-
-  for (const key of keys) {
-    if (!key) continue;
-    const normalizedKey = key.replace(/\d+$/, '');
-    const fallback = DEFAULT_DURATION_KEY_FALLBACKS[key]
-      ?? DEFAULT_DURATION_KEY_FALLBACKS[normalizedKey];
-    if (Number.isFinite(fallback) && fallback > 0) {
-      return fallback;
-    }
-  }
-
-  return zeroDurationDetected ? 1 : 0;
-}
-
-function cancelNpcLayerHandles(attack) {
-  if (!attack?.layerHandles) return;
-  while (attack.layerHandles.length) {
-    const handle = attack.layerHandles.pop();
-    try {
-      if (handle && typeof handle.cancel === 'function') handle.cancel();
-    } catch (err) {
-      console.warn('[npc] Failed to cancel NPC layer override', err);
-    }
-  }
-}
-
-function resolvePreset(presetName) {
-  if (!presetName) return null;
-  const C = window.CONFIG || {};
-  return (
-    C.presets?.[presetName]
-    || C.moves?.[presetName]
-    || C.attacks?.presets?.[presetName]
-    || null
-  );
-}
-
-function resolvePoseForPhase(preset, phaseName) {
-  if (!phaseName) return null;
-  if (preset?.poses?.[phaseName]) return clone(preset.poses[phaseName]);
-  const C = window.CONFIG || {};
-  if (C.poses?.[phaseName]) return clone(C.poses[phaseName]);
-  if (phaseName === 'Stance' && C.poses?.Stance) return clone(C.poses.Stance);
-  return null;
-}
-
-function applyNpcLayerOverrides(attack, overrides, stageDurMs) {
-  if (!Array.isArray(overrides) || overrides.length === 0) return;
-  overrides.forEach((layer, index) => {
-    if (!layer || layer.enabled === false) return;
-    const pose = layer.pose ? clone(layer.pose) : {};
-    const opts = {
-      mask: layer.mask || layer.joints,
-      priority: layer.priority,
-      suppressWalk: layer.suppressWalk,
-      useAsBase: layer.useAsBase,
-      durMs: Number.isFinite(layer.durMs)
-        ? layer.durMs
-        : Number.isFinite(layer.durationMs)
-          ? layer.durationMs
-          : Number.isFinite(layer.dur)
-            ? layer.dur
-            : stageDurMs,
-      delayMs: Number.isFinite(layer.delayMs)
-        ? layer.delayMs
-        : Number.isFinite(layer.offsetMs)
-          ? layer.offsetMs
-          : 0,
-    };
-    const layerId = layer.id || `npc-layer-${index}`;
-    const handle = pushPoseLayerOverride('npc', layerId, pose, opts);
-    if (handle && typeof handle.cancel === 'function') {
-      attack.layerHandles.push(handle);
-    }
-  });
-}
-
-function applyNpcPoseForCurrentPhase(state, { force = false } = {}) {
-  const attack = ensureAttackState(state);
-  if (!force && !attack.active) return;
-
-  const sequence = Array.isArray(attack.sequence) ? attack.sequence : [];
-  if (!sequence.length) return;
-
-  const idx = Math.max(0, Math.min(attack.phaseIndex, sequence.length - 1));
-  const phaseName = sequence[idx] || 'Stance';
-  if (!force && attack.lastAppliedPhase === phaseName && attack.lastPhaseIndex === idx) return;
-
-  const preset = resolvePreset(attack.preset);
-  const poseDef = resolvePoseForPhase(preset, phaseName);
-  const durSec = Array.isArray(attack.durations) ? attack.durations[idx] : null;
-  const durMs = Number.isFinite(durSec) ? Math.max(1, durSec * 1000) : 300;
-
-  cancelNpcLayerHandles(attack);
-
-  if (poseDef) {
-    const { layerOverrides, ...primaryPose } = poseDef;
-    pushPoseOverride('npc', primaryPose, durMs, { suppressWalk: true });
-    applyNpcLayerOverrides(attack, layerOverrides, durMs);
-  } else if (phaseName === 'Stance') {
-    const stance = resolvePoseForPhase(null, 'Stance');
-    if (stance) {
-      pushPoseOverride('npc', stance, durMs, { suppressWalk: false });
-    }
-  }
-
-  attack.lastAppliedPhase = phaseName;
-  attack.lastPhaseIndex = idx;
-}
-
-function resetAttackState(state) {
-  const attack = ensureAttackState(state);
-  const wasActive = attack.active;
-  cancelNpcLayerHandles(attack);
-  attack.active = false;
-  attack.preset = null;
-  attack.sequence = [];
-  attack.durations = [];
-  attack.phaseIndex = 0;
-  attack.timer = 0;
-  attack.currentPhase = null;
-  attack.currentActiveKeys = [];
-  attack.strikeLanded = false;
-  attack.isHoldRelease = false;
-  attack.holdWindupDuration = 0;
-  attack.lunge.active = false;
-  attack.lastAppliedPhase = null;
-  attack.lastPhaseIndex = -1;
-  if (wasActive) {
-    const stance = resolvePoseForPhase(null, 'Stance');
-    if (stance) {
-      pushPoseOverride('npc', stance, 180, { suppressWalk: false });
-    }
-  }
-}
-
-function startNpcQuickAttack(state, presetName) {
-  const C = window.CONFIG || {};
-  const attack = ensureAttackState(state);
-  const combo = ensureComboState(state);
-  const preset = C.presets?.[presetName];
-
-  attack.active = true;
-  attack.preset = presetName;
-  attack.phaseIndex = 0;
-  attack.timer = 0;
-  attack.currentActiveKeys = [];
-  attack.strikeLanded = false;
-  attack.currentPhase = null;
-  attack.isHoldRelease = false;
-  attack.holdWindupDuration = 0;
-
-  if (preset?.sequence) {
-    attack.sequence = [];
-    attack.durations = [];
-    const fallbackDurations = getPresetDurations(presetName) || {};
-    for (const step of preset.sequence) {
-      const pose = typeof step === 'string'
-        ? step
-        : step?.pose || step?.poseKey || 'Stance';
-      attack.sequence.push(pose);
-      let durMs = 0;
-      if (step && typeof step === 'object') {
-        if (Number.isFinite(step.durMs)) {
-          durMs = step.durMs;
-        } else if (Number.isFinite(step.durationMs)) {
-          durMs = step.durationMs;
-        } else if (Number.isFinite(step.dur)) {
-          durMs = step.dur;
-        }
-        if (!durMs && step.durKey) {
-          const durs = preset.durations || fallbackDurations || C.durations || {};
-          durMs = durs[step.durKey] || 0;
-        }
-      }
-      if (!durMs) {
-        durMs = resolveDurationMsForPose(pose, preset.durations, fallbackDurations);
-      }
-      attack.durations.push((durMs || 0) / 1000);
-    }
-  } else {
-    const durs = getPresetDurations(presetName) || {};
-    const w = durs.toWindup || 0;
-    const s = durs.toStrike || 0;
-    const r = durs.toRecoil || 0;
-    const st = durs.toStance || 0;
-    attack.sequence = ['Windup', 'Strike', 'Recoil', 'Stance'];
-    attack.durations = [w, s, r, st].map((ms) => (ms || 0) / 1000);
-  }
-
-  combo.attackDelay = 0;
-  attack.lastAppliedPhase = null;
-  attack.lastPhaseIndex = -1;
-  applyNpcPoseForCurrentPhase(state, { force: true });
-}
-
-function startNpcHoldReleaseAttack(state, presetName, windupMs) {
-  const attack = ensureAttackState(state);
-  const durs = getPresetDurations(presetName) || {};
-  const windup = Number(windupMs) || 1000;
-  attack.active = true;
-  attack.preset = presetName;
-  attack.sequence = ['Windup', 'Strike', 'Recoil', 'Stance'];
-  attack.durations = [windup / 1000, (durs.toStrike || 0) / 1000, (durs.toRecoil || 0) / 1000, (durs.toStance || 0) / 1000];
-  attack.phaseIndex = 0;
-  attack.timer = 0;
-  attack.currentActiveKeys = [];
-  attack.isHoldRelease = true;
-  attack.holdWindupDuration = windup;
-  attack.strikeLanded = false;
-  attack.currentPhase = null;
-  attack.lastAppliedPhase = null;
-  attack.lastPhaseIndex = -1;
-  applyNpcPoseForCurrentPhase(state, { force: true });
-}
-
-function updateNpcAttack(G, state, dt) {
-  const combo = ensureComboState(state);
-  const attack = ensureAttackState(state);
-  const MOVE = G.FIGHTERS?.player;
-  const C = window.CONFIG || {};
-
-  if (combo.active && !attack.active) {
-    combo.attackDelay -= dt;
-    if (combo.attackDelay <= 0) {
-      combo.sequenceIndex += 1;
-      if (combo.sequenceIndex < 4) {
-        const preset = C.combo?.sequence?.[combo.sequenceIndex];
-        startNpcQuickAttack(state, preset || 'KICK');
-        combo.attackDelay = 0.15;
-      } else if (combo.sequenceIndex === 4) {
-        const idx = 0;
-        const preset = C.combo?.altSequence?.[idx] || C.combo?.sequence?.[idx] || 'KICK';
-        startNpcQuickAttack(state, preset);
-        combo.attackDelay = 0.15;
-        combo.sequenceIndex += 1;
-      } else {
-        combo.active = false;
-        combo.sequenceIndex = 0;
-      }
-    }
-  }
-
-  if (!attack.active) {
-    applyNpcPoseForCurrentPhase(state);
-    return;
-  }
-
-  attack.timer += dt;
-  while (attack.phaseIndex < attack.durations.length && attack.timer >= attack.durations[attack.phaseIndex]) {
-    attack.timer -= attack.durations[attack.phaseIndex];
-    const oldPhase = attack.sequence[attack.phaseIndex];
-    attack.phaseIndex += 1;
-    if (attack.phaseIndex >= attack.durations.length) {
-      resetAttackState(state);
-      if (combo.active) combo.attackDelay = 0.15;
-      return;
-    }
-    const newPhase = attack.sequence[attack.phaseIndex];
-    if (newPhase === 'Strike' && oldPhase !== 'Strike') {
-      attack.strikeLanded = false;
-      attack.currentPhase = 'Strike';
-      attack.currentActiveKeys = getPresetActiveColliders(attack.preset);
-      attack.lunge.active = true;
-      attack.lunge.paused = false;
-      attack.lunge.distance = 0;
-      const dx = (MOVE?.pos?.x ?? state.pos.x) - state.pos.x;
-      const dy = (MOVE?.pos?.y ?? state.pos.y) - state.pos.y;
-      const aimAngle = Math.atan2(dy, dx);
-      const lungeSpeed = attack.lunge.speed;
-      attack.lunge.lungeVel.x = Math.cos(aimAngle) * lungeSpeed;
-      attack.lunge.lungeVel.y = Math.sin(aimAngle) * lungeSpeed * 0.3;
-    } else if (newPhase === 'Recoil' && oldPhase === 'Strike') {
-      if (!attack.strikeLanded) {
-        combo.hits = 0;
-      }
-      attack.currentPhase = 'Recoil';
-    }
-  }
-
-  const phaseName = attack.sequence[attack.phaseIndex];
-  if (phaseName === 'Strike') {
-    attack.currentPhase = 'Strike';
-    attack.currentActiveKeys = getPresetActiveColliders(attack.preset);
-  } else {
-    attack.currentActiveKeys = [];
-    attack.currentPhase = phaseName || null;
-  }
-  applyNpcPoseForCurrentPhase(state);
-}
-
-function updateNpcAiming(state, player) {
-  const aim = ensureAimState(state);
-  if (!player) {
-    aim.active = false;
-    aim.torsoOffset = 0;
-    aim.shoulderOffset = 0;
-    aim.hipOffset = 0;
-    return;
-  }
-  const shouldAim = !state.onGround;
-  if (!shouldAim) {
-    aim.active = false;
-    aim.torsoOffset = 0;
-    aim.shoulderOffset = 0;
-    aim.hipOffset = 0;
-    return;
-  }
-  aim.active = true;
-  const dx = (player.pos?.x ?? state.pos.x) - state.pos.x;
-  const dy = (player.pos?.y ?? state.pos.y) - state.pos.y;
-  const targetAngle = Math.atan2(dy, dx);
-  const relative = targetAngle - (state.facingRad || 0);
-  const wrapped = ((relative + Math.PI) % TWO_PI) - Math.PI;
-  const smoothing = 0.12;
-  aim.currentAngle += (wrapped - aim.currentAngle) * smoothing;
-  const aimDeg = (aim.currentAngle * 180) / Math.PI;
-  const C = window.CONFIG || {};
-  const aimingCfg = C.aiming || {};
-  aim.torsoOffset = clamp(aimDeg * 0.5, -aimingCfg.maxTorsoAngle || 45, aimingCfg.maxTorsoAngle || 45);
-  aim.shoulderOffset = clamp(aimDeg * 0.7, -aimingCfg.maxShoulderAngle || 65, aimingCfg.maxShoulderAngle || 65);
-  aim.hipOffset = 0;
-}
-
-function updateDashTrail(npcSystems, state, dt) {
-  const dashTrail = npcSystems.dashTrail;
-  if (!dashTrail || !dashTrail.enabled) return;
-  if (state.stamina?.isDashing && state.stamina.current > 0) {
-    dashTrail.timer += dt;
-    if (dashTrail.timer >= dashTrail.interval) {
-      dashTrail.timer = 0;
-      dashTrail.positions.unshift({
-        x: state.pos.x,
-        y: state.pos.y,
-        facingRad: state.facingRad || 0,
+function updateDashTrail(trail, npc, dt) {
+  if (!trail?.enabled) return;
+  if (Math.abs(npc.vel?.x || 0) > 5) {
+    trail.timer += dt;
+    if (trail.timer >= trail.interval) {
+      trail.timer = 0;
+      trail.positions.unshift({
+        x: npc.pos.x,
+        y: npc.pos.y,
+        facingRad: npc.facingRad || 0,
         alpha: 1,
       });
-      if (dashTrail.positions.length > dashTrail.maxLength) {
-        dashTrail.positions.length = dashTrail.maxLength;
+      if (trail.positions.length > trail.maxLength) {
+        trail.positions.length = trail.maxLength;
       }
     }
-  }
-  for (const pos of dashTrail.positions) {
-    pos.alpha -= dt * 3;
-  }
-  dashTrail.positions = dashTrail.positions.filter((pos) => pos.alpha > 0);
-}
-
-function regenerateStamina(state, dt) {
-  const stamina = state.stamina;
-  if (!stamina) return;
-  if (stamina.isDashing && stamina.current > 0) {
-    stamina.current = Math.max(0, stamina.current - stamina.drainRate * dt);
-    if (stamina.current <= 0) {
-      stamina.isDashing = false;
-    }
   } else {
-    stamina.isDashing = false;
-    stamina.current = Math.min(stamina.max, stamina.current + stamina.regenRate * dt);
+    trail.timer = 0;
   }
+  for (const pos of trail.positions) {
+    pos.alpha = Math.max(0, pos.alpha - dt * 1.5);
+  }
+  trail.positions = trail.positions.filter((pos) => pos.alpha > 0);
 }
 
-function resolveBodyRadius(config) {
-  const wHalf = (config.parts?.hitbox?.w || 40) * (config.actor?.scale || 1) * 0.5;
-  const hHalf = (config.parts?.hitbox?.h || 80) * (config.actor?.scale || 1) * 0.5;
-  return Math.sqrt(wHalf * wHalf + hHalf * hHalf);
-}
-
-function updateNpcRagdoll(state, config, dt) {
-  if (!state.ragdoll) return;
-  const groundY = computeGroundY(config);
-  state.ragdollTime += dt;
-  state.vel.y += (config.movement?.gravity || 0) * dt * 1.8;
-  state.pos.x += state.vel.x * dt;
-  state.pos.y += state.vel.y * dt;
-  const margin = 40;
-  const worldWidth = getWorldWidth(config);
-  state.pos.x = clamp(state.pos.x, margin, worldWidth - margin);
-  if (state.pos.y >= groundY) {
-    state.pos.y = groundY;
-    if (state.vel.y > 0) state.vel.y = -state.vel.y * 0.2;
-    state.onGround = true;
-  } else {
-    state.onGround = false;
-  }
-  if (state.onGround && state.ragdollTime > 2.5) {
-    state.ragdoll = false;
-    state.recovering = true;
-    state.recoveryTime = 0;
-    state.recoveryStartY = state.pos.y;
-    state.recoveryTargetY = groundY;
-  }
-}
-
-function updateNpcRecovery(state, config, dt) {
-  if (!state.recovering) return;
-  state.recoveryTime += dt;
-  const t = Math.min(1, state.recoveryTime / (state.recoveryDuration || 0.8));
-  const groundY = computeGroundY(config);
-  const startY = Number.isFinite(state.recoveryStartY) ? state.recoveryStartY : groundY;
-  state.pos.y = startY + (groundY - startY) * t;
-  if (t >= 1) {
-    state.recovering = false;
-    state.recoveryTime = 0;
-    state.footing = Math.max(state.footing, 30);
-  }
-}
-
-function updateNpcMovement(G, npcSystems, state, dt) {
+function updateNpcWanderer(npc, entry, dt) {
   const C = window.CONFIG || {};
-  const player = G.FIGHTERS?.player;
-  if (!player) return;
-
-  const combat = ensureNpcCombat(G);
-  const attack = ensureAttackState(state);
-  ensureComboState(state);
-  ensureNpcInputState(state);
-  updateNpcAutomatedInput(state, combat, dt);
-
-  if (state.ragdoll) {
-    updateNpcRagdoll(state, C, dt);
-    updateNpcRecovery(state, C, dt);
-    updateNpcAiming(state, player);
-    updateDashTrail(npcSystems, state, dt);
-    regenerateStamina(state, dt);
-    return;
-  }
-
-  updateNpcRecovery(state, C, dt);
-
-  const attackActive = typeof combat?.isFighterAttacking === 'function'
-    ? combat.isFighterAttacking()
-    : !!attack?.active;
-  state.cooldown = Math.max(0, (state.cooldown || 0) - dt);
-
-  const dx = (player.pos?.x ?? state.pos.x) - state.pos.x;
-  const absDx = Math.abs(dx);
-  const maxSpeed = (C.movement?.maxSpeedX || 420) * 0.8;
-  const nearDist = 70;
-  const isPressing = !!state.aiButtonPresses?.A?.down || !!state.aiButtonPresses?.B?.down;
-
-  if (attackActive) {
-    state.vel.x = 0;
-    state.facingRad = dx >= 0 ? 0 : Math.PI;
-  } else {
-    if (state.mode === 'attack') {
-      state.mode = 'evade';
-      state.timer = 0.3;
-      state.cooldown = Math.max(state.cooldown, 0.35);
-      state.vel.x = -(dx > 0 ? 1 : -1) * maxSpeed;
-    } else if (absDx <= nearDist && state.cooldown <= 0 && !isPressing) {
-      if (pressNpcButton(state, combat, 'A', 0.12)) {
-        state.mode = 'attack';
-        state.vel.x = 0;
-        state.facingRad = dx >= 0 ? 0 : Math.PI;
-        state.cooldown = 0.45;
-      }
-    }
-
-    if (state.mode === 'approach') {
-      if (absDx > nearDist) {
-        state.vel.x = (dx > 0 ? 1 : -1) * maxSpeed;
-      } else {
-        state.vel.x = (dx > 0 ? 1 : -1) * maxSpeed * 0.3;
-      }
-      state.stamina.isDashing = false;
-    } else if (state.mode === 'evade') {
-      const dashMult = state.stamina.current >= state.stamina.minToDash
-        ? C.movement?.dashSpeedMultiplier || 1.8
-        : 1;
-      state.vel.x = -(dx > 0 ? 1 : -1) * maxSpeed * dashMult;
-      state.stamina.isDashing = dashMult > 1;
-      state.timer = (state.timer || 0) - dt;
-      if (state.timer <= 0) {
-        state.mode = 'approach';
-        state.stamina.isDashing = false;
-      }
-    }
-  }
-
-  if (state.mode === 'attack' && !attackActive && !isPressing) {
-    state.mode = 'approach';
-  }
-
-  regenerateStamina(state, dt);
-  updateDashTrail(npcSystems, state, dt);
-
-  state.pos.x += (state.vel?.x || 0) * dt;
-  state.pos.y += (state.vel?.y || 0) * dt;
-
-  const margin = 40;
-  const worldWidth = getWorldWidth(C);
-  state.pos.x = clamp(state.pos.x, margin, worldWidth - margin);
-
+  const wander = npc.wander || {};
   const groundY = computeGroundY(C);
-  state.pos.y = groundY;
-  state.onGround = true;
-  state.vel.y = 0;
-  state.facingRad = dx >= 0 ? 0 : Math.PI;
+  const worldWidth = getWorldWidth(C);
+  const margin = 40;
+  const baseSpeed = (C.movement?.maxSpeedX || 420) * 0.28;
+  const speed = wander.speed != null ? wander.speed : baseSpeed;
+  wander.speed = speed;
 
-  updateNpcAiming(state, player);
+  wander.waitTimer -= dt;
+  if (wander.waitTimer <= 0) {
+    const dx = (wander.targetX ?? npc.pos.x) - npc.pos.x;
+    if (Math.abs(dx) <= 4) {
+      wander.targetX = pickWanderTarget(wander, worldWidth, margin);
+      wander.waitTimer = randomInRange(1.2, 3.4);
+      npc.vel.x = 0;
+    } else {
+      const dir = dx > 0 ? 1 : -1;
+      npc.vel.x = dir * speed;
+      npc.pos.x += npc.vel.x * dt;
+      npc.facingRad = dir >= 0 ? 0 : Math.PI;
+    }
+  } else {
+    npc.vel.x *= 0.6;
+    if (Math.abs(npc.vel.x) < 1) npc.vel.x = 0;
+  }
+
+  const clampedX = clamp(npc.pos.x, margin, worldWidth - margin);
+  if (clampedX !== npc.pos.x) {
+    npc.pos.x = clampedX;
+    npc.vel.x = 0;
+    wander.targetX = pickWanderTarget(wander, worldWidth, margin);
+    wander.waitTimer = randomInRange(0.8, 2.2);
+  }
+
+  npc.pos.y = groundY;
+  npc.onGround = true;
+  npc.vel.y = 0;
+  if (npc.stamina) {
+    npc.stamina.isDashing = false;
+    if (Number.isFinite(npc.stamina.max)) {
+      const max = npc.stamina.max;
+      npc.stamina.current = Math.min(max, Math.max(0, npc.stamina.current ?? max));
+    }
+  }
+
+  updateDashTrail(entry?.dashTrail, npc, dt);
 }
 
 function updateNpcHud(G) {
   const hud = document.getElementById('aiHud');
   if (!hud || hud.style.display === 'none') return;
-  const npc = G.FIGHTERS?.npc;
-  const player = G.FIGHTERS?.player;
-  if (!npc || !player) {
-    hud.textContent = 'NPC unavailable';
-    return;
+  const fighters = G.FIGHTERS || {};
+  const lines = [];
+  let any = false;
+  for (const id of NPC_IDS) {
+    const npc = fighters[id];
+    if (!npc) continue;
+    any = true;
+    const wander = npc.wander || {};
+    lines.push(
+      `${id}: mode=${npc.mode || 'wander'} x=${(npc.pos?.x ?? 0).toFixed(1)} target=${(wander.targetX ?? npc.pos?.x ?? 0).toFixed(1)} wait=${Math.max(0, wander.waitTimer ?? 0).toFixed(2)}`,
+    );
   }
-  const dx = (player.pos?.x ?? 0) - (npc.pos?.x ?? 0);
-  hud.textContent = [
-    `NPC_ENABLED: true`,
-    `mode: ${npc.mode || 'n/a'}`,
-    `attack.active: ${!!npc.attack?.active}`,
-    `combo.active: ${!!npc.combo?.active} idx: ${npc.combo?.sequenceIndex ?? 0}`,
-    `cooldown: ${(npc.cooldown || 0).toFixed(2)}`,
-    `dx to player: ${dx.toFixed(1)}`,
-  ].join('\n');
+  hud.textContent = any ? ['NPC_ENABLED: true', ...lines].join('\n') : 'NPC unavailable';
 }
 
 export function initNpcSystems() {
   const G = ensureGameState();
-  const npc = G.FIGHTERS?.npc;
-  if (!npc) return;
-  ensureNpcContainers(G);
-  ensureNpcCombat(G);
-  ensureAttackState(npc);
-  ensureComboState(npc);
-  ensureAimState(npc);
-  ensureNpcInputState(npc);
-  npc.mode = npc.mode || npc.ai?.mode || 'approach';
-  npc.cooldown = Number.isFinite(npc.cooldown) ? npc.cooldown : npc.ai?.cooldown || 0;
+  const systems = ensureNpcCollections(G);
+  for (const id of NPC_IDS) {
+    const npc = G.FIGHTERS?.[id];
+    if (!npc) continue;
+    ensureNpcDefaults(npc, id);
+    const entry = systems.wanderers[id];
+    if (entry?.dashTrail) {
+      entry.dashTrail.positions.length = 0;
+      entry.dashTrail.timer = 0;
+    }
+  }
+  updateNpcHud(G);
 }
 
 export function updateNpcSystems(dt) {
   if (!Number.isFinite(dt) || dt <= 0) return;
   const G = ensureGameState();
-  const npc = G.FIGHTERS?.npc;
-  if (!npc) return;
-  const combat = ensureNpcCombat(G);
-  if (combat?.tick) combat.tick(dt);
-  const npcSystems = ensureNpcContainers(G);
-  ensureNpcInputState(npc);
-  updateNpcMovement(G, npcSystems, npc, dt);
-  updateNpcHud(G);
+  const systems = ensureNpcCollections(G);
+  let updated = false;
+  for (const id of NPC_IDS) {
+    const npc = G.FIGHTERS?.[id];
+    if (!npc) continue;
+    ensureNpcDefaults(npc, id);
+    const entry = systems.wanderers[id];
+    updateNpcWanderer(npc, entry, dt);
+    updated = true;
+  }
+  if (updated) {
+    updateNpcHud(G);
+  }
 }
 
 export function getNpcDashTrail() {
-  const G = window.GAME || {};
-  return G.NPC?.dashTrail || null;
+  const G = ensureGameState();
+  const systems = ensureNpcCollections(G);
+  const trails = [];
+  for (const id of NPC_IDS) {
+    const entry = systems.wanderers[id];
+    if (!entry?.dashTrail) continue;
+    trails.push({ id, dashTrail: entry.dashTrail });
+  }
+  return trails;
 }
 
 export function getNpcAttackTrail() {
-  const G = window.GAME || {};
-  return G.NPC?.attackTrail || null;
+  const G = ensureGameState();
+  const systems = ensureNpcCollections(G);
+  const trails = [];
+  for (const id of NPC_IDS) {
+    const entry = systems.wanderers[id];
+    if (!entry?.attackTrail) continue;
+    trails.push({ id, attackTrail: entry.attackTrail });
+  }
+  return trails;
 }
 
-export function recordNpcAttackTrailSample(colliders, dt) {
-  const G = window.GAME || {};
-  const npc = G.FIGHTERS?.npc;
-  const npcSystems = ensureNpcContainers(ensureGameState());
-  const attackTrail = npcSystems.attackTrail;
-  const attack = npc?.attack;
-  if (!attackTrail?.enabled || !attack?.active) return;
-  attackTrail.timer += dt;
-  if (attackTrail.timer < attackTrail.interval) return;
-  attackTrail.timer = 0;
-  let keys = attack.currentActiveKeys || [];
-  if ((!keys || keys.length === 0) && attack.currentPhase?.toLowerCase().includes('strike')) {
-    keys = getPresetActiveColliders(attack.context?.preset || attack.preset);
-  }
-  if (!Array.isArray(keys) || keys.length === 0) return;
-  for (const key of keys) {
-    const pos = colliders?.[key];
-    if (!pos) continue;
-    const radius = colliders?.[`${key}Radius`] ?? 12;
-    const list = attackTrail.colliders[key] || (attackTrail.colliders[key] = []);
-    list.unshift({ x: pos.x, y: pos.y, radius, alpha: 1 });
-    if (list.length > attackTrail.maxLength) list.length = attackTrail.maxLength;
-  }
-  for (const key of Object.keys(attackTrail.colliders)) {
-    const list = attackTrail.colliders[key];
-    for (const sample of list) {
-      sample.alpha -= dt * 4;
-    }
-    attackTrail.colliders[key] = list.filter((sample) => sample.alpha > 0);
-  }
+export function recordNpcAttackTrailSample(_colliders, _dt) {
+  // Wanderers do not attack; retain function for compatibility.
 }
 
 export function fadeNpcAttackTrail(dt) {
-  const npcSystems = ensureNpcContainers(ensureGameState());
-  const attackTrail = npcSystems.attackTrail;
-  if (!attackTrail) return;
-  for (const key of Object.keys(attackTrail.colliders)) {
-    const list = attackTrail.colliders[key];
-    for (const sample of list) {
-      sample.alpha -= dt * 4;
+  if (!Number.isFinite(dt) || dt <= 0) return;
+  const G = ensureGameState();
+  const systems = ensureNpcCollections(G);
+  for (const id of NPC_IDS) {
+    const entry = systems.wanderers[id];
+    const attackTrail = entry?.attackTrail;
+    if (!attackTrail?.enabled) continue;
+    for (const list of Object.values(attackTrail.colliders || {})) {
+      for (const sample of list) {
+        sample.alpha = Math.max(0, (sample.alpha ?? 0) - dt * 4);
+      }
+      const filtered = list.filter((sample) => (sample.alpha ?? 0) > 0);
+      list.length = 0;
+      list.push(...filtered);
     }
-    attackTrail.colliders[key] = list.filter((sample) => sample.alpha > 0);
   }
 }
 
@@ -870,5 +293,7 @@ export function updateNpcDebugHud() {
 
 export function getNpcBodyRadius() {
   const C = window.CONFIG || {};
-  return resolveBodyRadius(C);
+  const wHalf = (C.parts?.hitbox?.w || 40) * (C.actor?.scale || 1) * 0.5;
+  const hHalf = (C.parts?.hitbox?.h || 80) * (C.actor?.scale || 1) * 0.5;
+  return Math.sqrt(wHalf * wHalf + hHalf * hHalf);
 }

--- a/docs/js/render.js
+++ b/docs/js/render.js
@@ -421,15 +421,24 @@ export function renderAll(ctx){
     ctx.restore();
   }
 
-  const npcDashTrail = getNpcDashTrail();
-  if (npcDashTrail?.positions?.length) {
-    for (let i = npcDashTrail.positions.length - 1; i >= 0; i -= 1) {
-      const pos = npcDashTrail.positions[i];
+  const npcDashTrails = getNpcDashTrail();
+  const dashEntries = Array.isArray(npcDashTrails)
+    ? npcDashTrails
+    : npcDashTrails
+      ? [{ id: npcDashTrails.id || 'npc', dashTrail: npcDashTrails.dashTrail || npcDashTrails }]
+      : [];
+  for (const entry of dashEntries) {
+    const dashTrail = entry?.dashTrail;
+    if (!dashTrail?.positions?.length) continue;
+    for (let i = dashTrail.positions.length - 1; i >= 0; i -= 1) {
+      const pos = dashTrail.positions[i];
       const alpha = Math.max(0, pos.alpha ?? 0);
       if (alpha <= 0) continue;
       ctx.save();
       ctx.globalAlpha = alpha * 0.5;
-      ctx.fillStyle = 'rgba(248, 113, 113, 0.35)';
+      ctx.fillStyle = entry?.id === 'npc2'
+        ? 'rgba(96, 165, 250, 0.35)'
+        : 'rgba(248, 113, 113, 0.35)';
       const radius = (C.parts?.hitbox?.w || 40) * (C.actor?.scale || 1) * 0.3;
       ctx.beginPath();
       ctx.arc(pos.x, pos.y, radius, 0, Math.PI * 2);
@@ -438,10 +447,17 @@ export function renderAll(ctx){
     }
   }
 
-  const npcAttackTrail = getNpcAttackTrail();
-  if (npcAttackTrail?.enabled) {
+  const npcAttackTrails = getNpcAttackTrail();
+  const attackEntries = Array.isArray(npcAttackTrails)
+    ? npcAttackTrails
+    : npcAttackTrails
+      ? [{ id: npcAttackTrails.id || 'npc', attackTrail: npcAttackTrails.attackTrail || npcAttackTrails }]
+      : [];
+  for (const entry of attackEntries) {
+    const attackTrail = entry?.attackTrail;
+    if (!attackTrail?.enabled) continue;
     for (const key of ['handL', 'handR', 'footL', 'footR']) {
-      const trail = npcAttackTrail.colliders?.[key];
+      const trail = attackTrail.colliders?.[key];
       if (!trail || !trail.length) continue;
       for (let i = trail.length - 1; i >= 0; i -= 1) {
         const sample = trail[i];
@@ -451,8 +467,14 @@ export function renderAll(ctx){
         ctx.globalAlpha = alpha * 0.6;
         ctx.beginPath();
         ctx.arc(sample.x, sample.y, sample.radius ?? 14, 0, Math.PI * 2);
-        ctx.fillStyle = `rgba(239, 68, 68, ${alpha * 0.65})`;
-        ctx.strokeStyle = `rgba(248, 113, 22, ${alpha * 0.85})`;
+        const fillColor = entry?.id === 'npc2'
+          ? `rgba(37, 99, 235, ${alpha * 0.65})`
+          : `rgba(239, 68, 68, ${alpha * 0.65})`;
+        const strokeColor = entry?.id === 'npc2'
+          ? `rgba(59, 130, 246, ${alpha * 0.85})`
+          : `rgba(248, 113, 22, ${alpha * 0.85})`;
+        ctx.fillStyle = fillColor;
+        ctx.strokeStyle = strokeColor;
         ctx.lineWidth = 2;
         ctx.fill();
         ctx.stroke();


### PR DESCRIPTION
## Summary
- replace the combat-focused npc module with a wanderer system that supports two NPC entries by default
- spawn a second NPC fighter alongside the existing one and expose their wander state in the HUD
- update hit detection and rendering helpers to iterate across multi-NPC trails and collisions

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916f494bac08326a0dbf4283cc676e2)