### PR TITLE
Normalize prefab asset URLs for tower assets

### DIFF
--- a/docs/assets/asset-manifest.json
+++ b/docs/assets/asset-manifest.json
@@ -22,5 +22,7 @@
   "./assets/fightersprites/tletingan/torso.png",
   "./assets/fightersprites/tletingan/untinted_regions/ur-head.png",
   "./assets/fightersprites/tletingan/untinted_regions/ur-arm-lower.png",
-  "./assets/fightersprites/tletingan/untinted_regions/ur-leg-lower.png"
+  "./assets/fightersprites/tletingan/untinted_regions/ur-leg-lower.png",
+  "./assets/prefabs/structures/towers/tower_commercial_near.png",
+  "./assets/prefabs/structures/towers/tower_general_far.png"
 ]

--- a/docs/config/prefabs/structures/tower_commercial.prefab.json
+++ b/docs/config/prefabs/structures/tower_commercial.prefab.json
@@ -10,7 +10,7 @@
       "z": 10,
       "propTemplate": {
         "id": "tower_near",
-        "url": "https://i.imgur.com/tower_commercial_near.png",
+        "url": "./assets/prefabs/structures/towers/tower_commercial_near.png",
         "w": 360,
         "h": 480,
         "pivot": "bottom",
@@ -52,7 +52,7 @@
       "z": 0,
       "propTemplate": {
         "id": "tower_farleft",
-        "url": "https://i.imgur.com/tower_general_far.png",
+        "url": "./assets/prefabs/structures/towers/tower_general_far.png",
         "w": 360,
         "h": 480,
         "pivot": "bottom",
@@ -94,7 +94,7 @@
       "z": 0,
       "propTemplate": {
         "id": "tower_farRight",
-        "url": "https://i.imgur.com/tower_general_far.png",
+        "url": "./assets/prefabs/structures/towers/tower_general_far.png",
         "w": 360,
         "h": 480,
         "pivot": "bottom",

--- a/tools/structure_builder_v10.html
+++ b/tools/structure_builder_v10.html
@@ -222,11 +222,11 @@ const state = {
     base: {},
     parts: [
       { name:'near', layer:'near', relX:0, relY:0, z:10,
-        propTemplate: { id:'tower_near', url:'https://i.imgur.com/tower_commercial_near.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:1, parallaxClampPx:0,
+        propTemplate: { id:'tower_near', url:'./assets/prefabs/structures/towers/tower_commercial_near.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:1, parallaxClampPx:0,
           kf: { radius:800, ease:'smoothstep', translateSpace:'screen', transformOrder:'scaleThenRotate',
                 left:{dx:0,dy:0,scaleX:1,rotZdeg:0}, center:{dx:0,dy:0,scaleX:1,rotZdeg:0}, right:{dx:0,dy:0,scaleX:1,rotZdeg:0} } } },
       { name:'far', layer:'far', relX:0, relY:0, z:0,
-        propTemplate: { id:'tower_far', url:'https://i.imgur.com/tower_general_far.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:0.85, parallaxClampPx:64,
+        propTemplate: { id:'tower_far', url:'./assets/prefabs/structures/towers/tower_general_far.png', w:360, h:480, pivot:'bottom', anchorXPct:50, anchorYPct:100, parallaxX:0.85, parallaxClampPx:64,
           kf: { radius:800, ease:'smoothstep', translateSpace:'screen', transformOrder:'scaleThenRotate',
                 left:{dx:-24,dy:0,scaleX:0.92,rotZdeg:-6}, center:{dx:0,dy:0,scaleX:1,rotZdeg:0}, right:{dx:22,dy:0,scaleX:0.92,rotZdeg:6} } } }
     ]
@@ -348,14 +348,60 @@ function draw(){
 }
 
 // Image cache
+const ABS_URL_RE = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i;
+
+function resolveAssetCandidates(url){
+  if (typeof url !== 'string') return [];
+  const trimmed = url.trim();
+  if (!trimmed) return [];
+  if (ABS_URL_RE.test(trimmed) || trimmed.startsWith('data:')) {
+    return [trimmed];
+  }
+
+  const base = (typeof document !== 'undefined' && document.baseURI)
+    ? document.baseURI
+    : window.location.href;
+
+  const candidates = [];
+  try {
+    candidates.push(new URL(trimmed, base).href);
+  } catch (_err) {
+    // ignore – continue to other fallbacks
+  }
+
+  try {
+    const docsBase = new URL('../docs/', base);
+    const normalized = trimmed.startsWith('./') ? trimmed.slice(2) : trimmed;
+    candidates.push(new URL(normalized, docsBase).href);
+  } catch (_err) {
+    // ignore – repo structure may differ
+  }
+
+  candidates.push(trimmed);
+  return candidates.filter((value, index, self) => value && self.indexOf(value) === index);
+}
+
 function loadImage(url){
   return new Promise(res=>{
     if (!url) return res({ok:false,img:null});
     if (state.images.has(url)) return res({ok:true,img:state.images.get(url)});
+
+    const candidates = resolveAssetCandidates(url);
+    if (!candidates.length) return res({ok:false,img:null});
+
+    let index = 0;
     const i = new Image(); i.crossOrigin = 'anonymous';
     i.onload = ()=>{ state.images.set(url,i); res({ok:true,img:i}); };
-    i.onerror = ()=>{ __DBG('Image load failed: '+url); res({ok:false,img:null}); };
-    i.src = url;
+    i.onerror = ()=>{
+      index += 1;
+      if (index >= candidates.length){
+        __DBG('Image load failed: '+url);
+        res({ok:false,img:null});
+        return;
+      }
+      i.src = candidates[index];
+    };
+    i.src = candidates[index];
   });
 }
 async function ensureImages(){ for (const p of state.prefab.parts){ if (p.propTemplate.url) await loadImage(p.propTemplate.url); } }


### PR DESCRIPTION
## Summary
- normalize prefab asset URLs relative to the document base so locally bundled towers resolve in both preview and standalone
- add asset URL fallback handling in the structure builder tool to try docs-hosted files when loading preview images

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e2e152ec8326a26955c32dd62b8e)