### PR TITLE
Add NPC aggression gating and persist combat instance

### DIFF
--- a/docs/js/hitdetect.js
+++ b/docs/js/hitdetect.js
@@ -112,6 +112,15 @@ function handlePlayerHitsNpc(G, config, player, npc, debug, distance, bodyRadius
     enterRagdoll(npc, angle, force, 0.3);
   }
   npc.stamina && (npc.stamina.isDashing = false);
+  const aggression = npc.aggression || (npc.aggression = {});
+  if (!aggression.triggered) {
+    aggression.triggered = true;
+    const delay = Number.isFinite(aggression.wakeDelay) ? aggression.wakeDelay : 0.4;
+    aggression.wakeTimer = Math.max(aggression.wakeTimer || 0, delay);
+  }
+  if (!aggression.active) {
+    npc.mode = 'alert';
+  }
   if (!attack.strikeLanded) {
     attack.strikeLanded = true;
   }


### PR DESCRIPTION
## Summary
- persist the NPC combat controller when it is initialized
- add an aggression state machine that keeps the NPC idle until provoked
- trigger aggression when the player lands a hit so NPC combat only starts after being attacked

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171fc41ff883269cac61b4ad6e6507)