### PR TITLE
Add ASCII fallback prefabs for missing prefab errors

### DIFF
--- a/src/map/builderConversion.js
+++ b/src/map/builderConversion.js
@@ -1,5 +1,186 @@
 const SOURCE_ID = 'map-builder-layered-v15f';
 
+const FALLBACK_BOX_MIN_WIDTH = 18;
+
+function normalizeErrorInfo(raw) {
+  if (!raw) {
+    return { code: null, message: null };
+  }
+
+  if (typeof raw === 'string') {
+    const text = raw.trim();
+    return { code: text || null, message: text || null };
+  }
+
+  if (raw instanceof Error) {
+    const code = typeof raw.code === 'string' && raw.code.trim()
+      ? raw.code.trim()
+      : typeof raw.name === 'string' && raw.name.trim()
+        ? raw.name.trim()
+        : null;
+    return {
+      code,
+      message: typeof raw.message === 'string' && raw.message.trim() ? raw.message.trim() : null,
+    };
+  }
+
+  const record = typeof raw === 'object' ? raw : {};
+  const innerError = record && typeof record.error === 'object' ? record.error : null;
+
+  const codeCandidates = [
+    record.code,
+    record.errorCode,
+    record.statusCode,
+    record.status,
+    record.type,
+    innerError?.code,
+    innerError?.status,
+    innerError?.name,
+  ];
+  let code = null;
+  for (const candidate of codeCandidates) {
+    if (candidate == null) continue;
+    const text = String(candidate).trim();
+    if (text) {
+      code = text.slice(0, 32);
+      break;
+    }
+  }
+
+  const messageCandidates = [
+    record.message,
+    record.errorMessage,
+    record.reason,
+    record.detail,
+    record.details,
+    innerError?.message,
+  ];
+  let message = null;
+  for (const candidate of messageCandidates) {
+    if (candidate == null) continue;
+    const value = typeof candidate === 'string'
+      ? candidate
+      : candidate instanceof Error && typeof candidate.message === 'string'
+        ? candidate.message
+        : String(candidate);
+    const text = value.trim();
+    if (text) {
+      message = text.slice(0, 140);
+      break;
+    }
+  }
+
+  return { code, message };
+}
+
+function sanitizeBoxLine(text) {
+  if (text == null) return '';
+  return String(text)
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/[^\x20-\x7e]+/g, '?')
+    .trim();
+}
+
+function createAsciiBox(lines) {
+  const sanitized = lines.map((line) => sanitizeBoxLine(line));
+  const innerWidth = Math.max(
+    FALLBACK_BOX_MIN_WIDTH,
+    ...sanitized.map((line) => line.length),
+  );
+  const horizontal = `+${'-'.repeat(innerWidth + 2)}+`;
+  const body = sanitized.map((line) => {
+    const padded = line.padEnd(innerWidth, ' ');
+    return `| ${padded} |`;
+  });
+  return [horizontal, ...body, horizontal];
+}
+
+function createPrefabFallback(prefabId, errorInfo = {}) {
+  const { code, message } = normalizeErrorInfo(errorInfo);
+  const label = prefabId ? `Prefab ${prefabId}` : 'Prefab (unknown)';
+  const headline = 'Prefab Missing';
+  const codeLine = code ? `Code: ${code}` : 'Code: unavailable';
+  const messageLine = message ? `Msg: ${message.slice(0, 70)}` : 'Msg: no details';
+  const box = createAsciiBox([headline, codeLine, label, messageLine]);
+  const asciiArt = box.join('\n');
+
+  return {
+    id: prefabId ?? 'missing_prefab',
+    type: 'fallback-prefab',
+    name: 'Missing Prefab',
+    asciiArt,
+    boxLines: box,
+    isFallback: true,
+    meta: {
+      fallback: {
+        reason: 'prefab-missing',
+        prefabId: prefabId ?? null,
+        errorCode: code,
+        message: message ?? null,
+      },
+    },
+  };
+}
+
+function lookupPrefabError(prefabId, lookup) {
+  if (!prefabId || !lookup) return null;
+
+  if (typeof lookup === 'function') {
+    try {
+      return lookup(prefabId) ?? null;
+    } catch (error) {
+      return { code: 'lookup-failed', error };
+    }
+  }
+
+  if (lookup instanceof Map) {
+    return lookup.get(prefabId) ?? null;
+  }
+
+  if (Array.isArray(lookup)) {
+    for (const entry of lookup) {
+      if (!entry || typeof entry !== 'object') continue;
+      const id = entry.prefabId ?? entry.id ?? entry.slug ?? null;
+      if (id === prefabId) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  if (typeof lookup === 'object') {
+    const direct = lookup[prefabId];
+    if (direct != null) return direct;
+  }
+
+  return null;
+}
+
+function resolvePrefab(prefabId, providedPrefab, prefabResolver, prefabErrorLookup, warnings) {
+  if (providedPrefab) {
+    return { prefab: providedPrefab, fallback: null };
+  }
+
+  const resolved = prefabResolver(prefabId ?? null);
+  if (resolved) {
+    return { prefab: resolved, fallback: null };
+  }
+
+  const errorInfo = lookupPrefabError(prefabId, prefabErrorLookup);
+  const fallbackPrefab = createPrefabFallback(prefabId, errorInfo);
+  const codeNote = fallbackPrefab.meta?.fallback?.errorCode ? ` (code ${fallbackPrefab.meta.fallback.errorCode})` : '';
+  if (Array.isArray(warnings)) {
+    warnings.push(`Prefab "${prefabId ?? 'unknown'}" missing; generated ASCII fallback${codeNote}`);
+  }
+  return {
+    prefab: fallbackPrefab,
+    fallback: fallbackPrefab.meta?.fallback ?? {
+      reason: 'prefab-missing',
+      prefabId: prefabId ?? null,
+    },
+  };
+}
+
 function isAreaDescriptor(candidate) {
   if (!candidate || typeof candidate !== 'object') return false;
   if (candidate.camera || candidate.ground) return true;
@@ -18,6 +199,7 @@ function normalizeAreaDescriptor(area, options = {}) {
     areaName = area.name || area.areaName || areaId,
     layerImageResolver = () => null,
     prefabResolver = () => null,
+    prefabErrorLookup = null,
   } = options;
 
   const rawLayers = Array.isArray(area.layers) ? area.layers : [];
@@ -28,7 +210,7 @@ function normalizeAreaDescriptor(area, options = {}) {
       : [];
   const rawColliders = Array.isArray(area.colliders) ? area.colliders : [];
 
-  const warnings = [];
+  const warnings = Array.isArray(area.warnings) ? [...area.warnings] : [];
   if (!Array.isArray(area.layers)) {
     warnings.push('area.layers missing – produced area has zero parallax layers');
   }
@@ -51,6 +233,19 @@ function normalizeAreaDescriptor(area, options = {}) {
   const convertedInstances = rawInstances.map((inst) => {
     const tags = Array.isArray(inst.tags) ? inst.tags.map((tag) => String(tag)) : [];
     const meta = inst.meta ? safeClone(inst.meta) : {};
+    const { prefab: resolvedPrefab, fallback } = resolvePrefab(
+      inst.prefabId ?? null,
+      inst.prefab ?? null,
+      prefabResolver,
+      prefabErrorLookup,
+      warnings,
+    );
+    if (fallback) {
+      meta.fallback = {
+        ...(meta.fallback || {}),
+        ...fallback,
+      };
+    }
     return {
       id: inst.id,
       prefabId: inst.prefabId ?? null,
@@ -65,7 +260,7 @@ function normalizeAreaDescriptor(area, options = {}) {
       },
       rotationDeg: toNumber(inst.rotationDeg ?? inst.rot ?? 0, 0),
       locked: !!inst.locked,
-      prefab: inst.prefab ?? prefabResolver(inst.prefabId ?? null),
+      prefab: resolvedPrefab,
       tags,
       meta,
     };
@@ -110,6 +305,7 @@ export function convertLayoutToArea(layout, options = {}) {
   const resolvedAreaName = options.areaName ?? layout.areaName ?? layout.name ?? resolvedAreaId;
   const layerImageResolver = options.layerImageResolver ?? (() => null);
   const prefabResolver = options.prefabResolver ?? (() => null);
+  const prefabErrorLookup = options.prefabErrorLookup ?? null;
   const includeRaw = options.includeRaw ?? false;
 
   const layers = Array.isArray(layout.layers) ? layout.layers : [];
@@ -118,6 +314,7 @@ export function convertLayoutToArea(layout, options = {}) {
 
   const layerMap = new Map(layers.map((layer) => [layer.id, layer]));
   const slotCenters = computeLayerSlotCenters(instances);
+  const warnings = [];
 
   const convertedLayers = layers.map((layer, index) => ({
     id: layer.id || `layer_${index}`,
@@ -142,12 +339,28 @@ export function convertLayoutToArea(layout, options = {}) {
       ? inst.x
       : (toNumber(inst.slot, 0) - center) * separation + nudge;
 
-    const prefab = prefabResolver(inst.prefabId);
+    const { prefab, fallback } = resolvePrefab(
+      inst.prefabId ?? null,
+      inst.prefab ?? null,
+      prefabResolver,
+      prefabErrorLookup,
+      warnings,
+    );
     const tags = Array.isArray(inst.tags) ? inst.tags.map((tag) => String(tag)) : [];
 
     const original = safeClone(inst);
     if (tags.length && !Array.isArray(original.tags)) {
       original.tags = [...tags];
+    }
+
+    const meta = {
+      original,
+    };
+    if (fallback) {
+      meta.fallback = {
+        ...(meta.fallback || {}),
+        ...fallback,
+      };
     }
 
     return {
@@ -166,15 +379,12 @@ export function convertLayoutToArea(layout, options = {}) {
       locked: !!inst.locked,
       prefab,
       tags,
-      meta: {
-        original,
-      },
+      meta,
     };
   });
 
   const convertedColliders = colliders.map((col, index) => normalizeCollider(col, index));
 
-  const warnings = [];
   if (!Array.isArray(layout.layers)) {
     warnings.push('layout.layers missing – produced area has zero parallax layers');
   }


### PR DESCRIPTION
## Summary
- add utilities to convert missing prefab error details into ASCII box fallbacks during map conversion
- mirror the fallback prefab generation logic in the docs runtime copy
- cover fallback prefab generation with unit tests

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917207bfd548326bcff5aa0ae4d946f)