### PR TITLE
Add obstruction prefab support with collision metadata

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -371,6 +371,7 @@ window.CONFIG = {
     defaultLayoutId: 'defaultdistrict',
     prefabManifests: [
       './config/prefabs/structures/index.json',
+      './config/prefabs/obstructions/index.json',
     ],
     layouts: [
       {

--- a/docs/config/prefabs/obstructions/blocking_crate.prefab.json
+++ b/docs/config/prefabs/obstructions/blocking_crate.prefab.json
@@ -1,0 +1,61 @@
+{
+  "structureId": "Blocking Crate",
+  "type": "obstruction",
+  "tags": ["grippable"],
+  "base": {},
+  "obstruction": {
+    "collision": {
+      "enabled": true,
+      "box": {
+        "width": 140,
+        "height": 110,
+        "offsetX": 0,
+        "offsetY": -60
+      }
+    },
+    "physics": {
+      "enabled": true,
+      "dynamic": true,
+      "mass": 2.5,
+      "drag": 0.2
+    }
+  },
+  "parts": [
+    {
+      "name": "crate_near",
+      "layer": "near",
+      "relX": 0,
+      "relY": 0,
+      "z": 20,
+      "propTemplate": {
+        "id": "crate_near",
+        "url": "./assets/prefabs/structures/towers/tower_commercial_near.png",
+        "w": 220,
+        "h": 180,
+        "pivot": "bottom",
+        "anchorXPct": 50,
+        "anchorYPct": 100,
+        "parallaxX": 1,
+        "parallaxClampPx": 0
+      }
+    },
+    {
+      "name": "crate_far",
+      "layer": "far",
+      "relX": 0,
+      "relY": 0,
+      "z": -10,
+      "propTemplate": {
+        "id": "crate_far",
+        "url": "./assets/prefabs/structures/towers/tower_general_far.png",
+        "w": 220,
+        "h": 180,
+        "pivot": "bottom",
+        "anchorXPct": 50,
+        "anchorYPct": 100,
+        "parallaxX": 0.85,
+        "parallaxClampPx": 64
+      }
+    }
+  ]
+}

--- a/docs/config/prefabs/obstructions/index.json
+++ b/docs/config/prefabs/obstructions/index.json
@@ -1,0 +1,11 @@
+{
+  "id": "obstructions",
+  "label": "Obstructions",
+  "entries": [
+    {
+      "id": "blocking_crate",
+      "label": "Blocking Crate",
+      "path": "./blocking_crate.prefab.json"
+    }
+  ]
+}

--- a/tests/prefabs/normalizePrefabDefinition.test.js
+++ b/tests/prefabs/normalizePrefabDefinition.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizePrefabDefinition } from '../../docs/js/prefab-catalog.js';
+
+test('normalizePrefabDefinition defaults to structure type and sanitizes tags', () => {
+  const prefab = {
+    structureId: 'Test Structure',
+    tags: [' alpha ', 42, null, ''],
+  };
+
+  normalizePrefabDefinition(prefab);
+
+  assert.equal(prefab.type, 'structure');
+  assert.deepEqual(prefab.tags, ['alpha', '42']);
+  assert.equal(prefab.obstruction, undefined);
+});
+
+test('normalizePrefabDefinition enforces obstruction metadata and planes', () => {
+  const prefab = {
+    structureId: 'Blocking Crate',
+    type: 'Obstruction',
+    tags: ['grippable', 'obstruction', 'grippable'],
+    obstruction: {
+      collision: {
+        enabled: true,
+        box: {
+          width: '150',
+          height: '-90',
+          offsetX: '10',
+          offsetY: '-5',
+        },
+      },
+      physics: {
+        enabled: true,
+        dynamic: false,
+        mass: '3.5',
+        drag: '-1',
+      },
+    },
+    parts: [
+      { name: 'front', layer: 'custom', meta: { extra: true } },
+      { name: 'back', layer: 'far' },
+    ],
+  };
+
+  normalizePrefabDefinition(prefab);
+
+  assert.equal(prefab.type, 'obstruction');
+  assert.deepEqual(prefab.tags, ['grippable', 'obstruction']);
+  assert.ok(prefab.obstruction);
+  assert.equal(prefab.obstruction.planes.near.id, 'obstruction:near');
+  assert.equal(prefab.obstruction.planes.far.id, 'obstruction:far');
+  assert.ok(prefab.obstruction.planes.near.locked);
+  assert.ok(prefab.obstruction.planes.far.locked);
+  assert.ok(prefab.obstruction.collision.enabled);
+  assert.equal(prefab.obstruction.collision.box.width, 150);
+  assert.equal(prefab.obstruction.collision.box.height, 90);
+  assert.equal(prefab.obstruction.collision.box.offsetX, 10);
+  assert.equal(prefab.obstruction.collision.box.offsetY, -5);
+  assert.ok(prefab.obstruction.physics.enabled);
+  assert.equal(prefab.obstruction.physics.dynamic, false);
+  assert.equal(prefab.obstruction.physics.mass, null);
+  assert.equal(prefab.obstruction.physics.drag, null);
+  assert.equal(prefab.parts[0].layer, 'near');
+  assert.equal(prefab.parts[0].meta.obstruction.plane, 'near');
+  assert.equal(prefab.parts[0].meta.obstruction.renderLayer, 'obstruction:near');
+  assert.equal(prefab.parts[1].layer, 'far');
+  assert.equal(prefab.parts[1].meta.obstruction.renderLayer, 'obstruction:far');
+});


### PR DESCRIPTION
## Summary
- normalize prefab definitions to support the new `obstruction` type with locked planes, collision boxes, and physics metadata
- expose obstruction prefabs through a dedicated manifest and provide a sample blocking crate configuration
- add regression tests that cover default structure handling and obstruction-specific normalization

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69172d33627483269f5a7cba7606215f)