### PR TITLE
Fix joystick release aim fallback on mobile

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -757,14 +757,15 @@ function updateAiming(F, currentPose, fighterId){
     // Joystick aiming - use joystick angle directly
     targetAngle = G.AIMING.targetAngle;
     aimSource = 'joystick';
-  } else if (G.MOUSE) {
+  } else if (G.MOUSE?.hasPosition) {
     // Mouse aiming - calculate angle from fighter to mouse position
-    const dx = G.MOUSE.worldX - (F.pos?.x || 0);
-    const dy = G.MOUSE.worldY - (F.pos?.y || 0);
+    const mouse = G.MOUSE;
+    const dx = mouse.worldX - (F.pos?.x || 0);
+    const dy = mouse.worldY - (F.pos?.y || 0);
     targetAngle = Math.atan2(dy, dx);
     aimSource = 'mouse';
     mouseDX = dx;
-    
+
   } else {
     // Fallback to facingRad
     targetAngle = F.facingRad || 0;

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -391,7 +391,8 @@ window.GAME.MOUSE = {
   y: 0,              // Canvas-space Y
   worldX: 0,         // World-space X (accounting for camera)
   worldY: 0,         // World-space Y
-  isInCanvas: false  // Whether mouse is over canvas
+  isInCanvas: false, // Whether mouse is over canvas
+  hasPosition: false // Whether a real pointer position has been recorded
 };
 
 // Joystick state for touch controls
@@ -1450,6 +1451,7 @@ function updateMousePosition(e) {
   const verticalOffset = cv.height * (1 - zoom);
   window.GAME.MOUSE.worldX = pixelX / zoom + camX;
   window.GAME.MOUSE.worldY = (pixelY - verticalOffset) / zoom;
+  window.GAME.MOUSE.hasPosition = true;
 }
 
 if (cv) {


### PR DESCRIPTION
## Summary
- track whether a real pointer position has been recorded
- only use mouse aiming when a pointer has provided coordinates so joystick release keeps facing direction

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917327256e883269919dc69877696c1)