### PR TITLE
Respect fighter config overrides in fighter selection

### DIFF
--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -242,8 +242,26 @@ export function initFighters(cv, cx){
     return null;
   }
 
+  function resolveFighterKey(name) {
+    if (!name) return null;
+    const trimmed = String(name).trim();
+    if (!trimmed) return null;
+    if (C.fighters?.[trimmed]) return trimmed;
+    const lower = trimmed.toLowerCase();
+    if (!lower) return null;
+    const fighters = Object.keys(C.fighters || {});
+    for (const key of fighters) {
+      if (key.toLowerCase() === lower) {
+        return key;
+      }
+    }
+    return null;
+  }
+
   function resolveFighterName(id, characterData, prevProfile) {
-    const selectedFighter = G.selectedFighter;
+    let selectedFighter = typeof G.selectedFighter === 'string'
+      ? G.selectedFighter.trim()
+      : '';
     if (
       selectedFighter &&
       C.fighters?.[selectedFighter] &&
@@ -252,11 +270,19 @@ export function initFighters(cv, cx){
       return selectedFighter;
     }
 
-    const prevFighter = prevProfile?.fighterName;
-    if (prevFighter && C.fighters?.[prevFighter]) return prevFighter;
+    selectedFighter = resolveFighterKey(selectedFighter);
+    if (
+      selectedFighter &&
+      (id === 'player' || prevProfile?.characterKey === 'player')
+    ) {
+      return selectedFighter;
+    }
 
-    const charFighter = characterData?.fighter;
-    if (charFighter && C.fighters?.[charFighter]) return charFighter;
+    const configFighter = resolveFighterKey(characterData?.fighter);
+    if (configFighter) return configFighter;
+
+    const prevFighter = resolveFighterKey(prevProfile?.fighterName);
+    if (prevFighter) return prevFighter;
 
     return fallbackFighterName;
   }


### PR DESCRIPTION
## Summary
- add a helper to normalize fighter names before lookup so case differences are tolerated
- prefer the character-configured fighter over previously cached state while still honoring a valid selected fighter

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173f4699e88326933c54b06c0fe570)