### PR TITLE
Auto-preview fighter selection

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -725,6 +725,7 @@ function initFighterDropdown() {
       delete window.GAME.selectedAppearance;
 
       showFighterSettings(selectedFighter);
+      scheduleFighterPreview(selectedFighter);
     });
     fighterSelect.dataset.initialized = 'true';
   }


### PR DESCRIPTION
## Summary
- trigger fighter reinitialization whenever the fighter dropdown changes so newly selected fighters (like TLETINGAN) immediately load their sprites

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175aac894c8326b4b55c059a095c78)