### PR TITLE
Expose balance multipliers in config

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -586,7 +586,18 @@ window.CONFIG = {
     handMultiplier: 2.0,
     footMultiplier: 1.0
   },
-  
+
+  balance: {
+    footingDamage: 1.0,
+    baseMovementSpeed: 1.0,
+    baseRecoveryRate: 1.0,
+    statPointEffects: {
+      strength: 1.0,
+      agility: 1.0,
+      endurance: 1.0
+    }
+  },
+
   knockback: {
     maxFooting: 100,
     weaponTypes: {

--- a/docs/js/hitdetect.js
+++ b/docs/js/hitdetect.js
@@ -8,6 +8,13 @@ function clamp(value, min, max) {
   return value;
 }
 
+function getBalanceScalar(key, fallback = 1) {
+  if (typeof window === 'undefined') return fallback;
+  const balance = window.CONFIG?.balance;
+  const value = balance?.[key];
+  return Number.isFinite(value) ? Number(value) : fallback;
+}
+
 function ensureDebugState() {
   const G = (window.GAME ||= {});
   const state = (G.HITDEBUG ||= {
@@ -81,7 +88,8 @@ function computeFootingDamage(config, footingBefore, force, defender) {
   const normalizedForce = Math.max(0, force) / (config.knockback?.referenceForce || 220);
   const baseLoss = 4 + normalizedForce * 4.5;
   const instabilityBonus = 1 + (1 - stabilityRatio) * 0.75;
-  let totalLoss = baseLoss * instabilityBonus;
+  const footingDamageMultiplier = getBalanceScalar('footingDamage', 1);
+  let totalLoss = baseLoss * instabilityBonus * footingDamageMultiplier;
   if (defender) {
     const statProfile = getStatProfile(defender);
     const mitigation = getFootingMitigation(statProfile);


### PR DESCRIPTION
## Summary
- add balance multipliers for footing damage, movement speed, recovery, and per-stat effects to the main config
- apply the balance scalars when computing footing loss, movement physics, and stat-derived multipliers
- update stat profile caching so changes to balance scalars invalidate cached results

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176a6e8bf083269ef7dabbdce29930)