### PR TITLE
Implement ragdoll blend controller and hit pause handling

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1186,13 +1186,19 @@ function updateHUD(){
   if (!P) return;
   const S = P.stamina;
   if (S && staminaFill){
-    const ratio = S.max ? Math.max(0, Math.min(1, S.current / S.max)) : 0;
-    const pct = Math.round(ratio * 100);
+    const normalized = S.max ? Math.max(-1, Math.min(1, S.current / S.max)) : 0;
+    const positiveRatio = Math.max(0, normalized);
+    const pct = Math.round(positiveRatio * 100);
+    const pctDisplay = Math.round(normalized * 100);
+    const exhausted = normalized < 0 || !!S.exhausted;
     staminaFill.style.width = `${pct}%`;
-    staminaFill.classList.toggle('low', ratio <= 0.25);
-    staminaFill.classList.toggle('dashing', !!S.isDashing);
+    staminaFill.classList.toggle('low', positiveRatio <= 0.25);
+    staminaFill.classList.toggle('dashing', positiveRatio > 0 && !!S.isDashing);
+    staminaFill.classList.toggle('exhausted', exhausted);
     if (staminaLabel){
-      staminaLabel.textContent = `Stamina ${pct}%`;
+      staminaLabel.textContent = exhausted
+        ? `Stamina ${pctDisplay}% (Exhausted)`
+        : `Stamina ${pctDisplay}%`;
     }
   } else if (staminaLabel){
     staminaLabel.textContent = 'Stamina';

--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -117,7 +117,8 @@ export function makeCombat(G, C, options = {}){
     chargeStage: 0,
     context: null,
     pendingAbilityId: null,
-    sequenceTimers: []
+    sequenceTimers: [],
+    hitPause: 0,
   };
 
   const CHARGE = {
@@ -846,7 +847,15 @@ export function makeCombat(G, C, options = {}){
       const stamina = context.fighter?.stamina;
       if (stamina){
         const current = Number.isFinite(stamina.current) ? stamina.current : 0;
-        stamina.current = Math.max(0, current - staminaCost);
+        const min = Number.isFinite(stamina.min)
+          ? stamina.min
+          : -(Number.isFinite(stamina.max) ? stamina.max : 100);
+        const next = current - staminaCost;
+        stamina.current = Math.max(min, next);
+        const exhausted = stamina.current < 0;
+        stamina.exhausted = exhausted;
+        const denom = Math.max(1, Math.abs(min));
+        stamina.exhaustionRatio = exhausted ? Math.min(1, Math.abs(stamina.current) / denom) : 0;
       }
     }
   }
@@ -1058,6 +1067,11 @@ export function makeCombat(G, C, options = {}){
     attackState.slot = ATTACK.slot || attackState.slot || null;
     attackState.isHoldRelease = !!ATTACK.isHoldRelease;
     attackState.chargeStage = ATTACK.chargeStage || 0;
+    attackState.hitPause = Number.isFinite(attackState.hitPause) ? attackState.hitPause : 0;
+    if (Number.isFinite(ATTACK.hitPause) && ATTACK.hitPause > attackState.hitPause) {
+      attackState.hitPause = ATTACK.hitPause;
+    }
+    ATTACK.hitPause = attackState.hitPause;
     if (attackState.currentPhase && attackState.currentPhase.toLowerCase().includes('strike')) {
       const explicitKeys = Array.isArray(context?.activeColliderKeys) && context.activeColliderKeys.length
         ? context.activeColliderKeys.slice()
@@ -1115,6 +1129,7 @@ export function makeCombat(G, C, options = {}){
               ATTACK.preset = null;
               ATTACK.context = null;
               updateFighterAttackState('Stance', { active: false, context: null });
+              ATTACK.hitPause = 0;
             });
           });
         });
@@ -1143,6 +1158,7 @@ export function makeCombat(G, C, options = {}){
               ATTACK.preset = null;
               ATTACK.context = null;
               updateFighterAttackState('Stance', { active: false, context: null });
+              ATTACK.hitPause = 0;
             });
           });
         });
@@ -1205,12 +1221,13 @@ export function makeCombat(G, C, options = {}){
           if (finishedContext?.onComplete){
             try { finishedContext.onComplete(); } catch(err){ console.warn('[combat] heavy onComplete error', err); }
           }
-          ATTACK.active = false;
-          ATTACK.preset = null;
-          ATTACK.isHoldRelease = false;
-          ATTACK.context = null;
-          updateFighterAttackState('Stance', { active: false, context: null });
-        });
+        ATTACK.active = false;
+        ATTACK.preset = null;
+        ATTACK.isHoldRelease = false;
+        ATTACK.context = null;
+        updateFighterAttackState('Stance', { active: false, context: null });
+        ATTACK.hitPause = 0;
+      });
       });
     });
   }
@@ -1442,6 +1459,7 @@ export function makeCombat(G, C, options = {}){
         ATTACK.active = false;
         ATTACK.isCharging = false;
         ATTACK.context = null;
+        ATTACK.hitPause = 0;
       }
       const ability = getAbilityForSlot(slotKey, 'light');
       if (ability){
@@ -1472,6 +1490,7 @@ export function makeCombat(G, C, options = {}){
             cancelQueuedLayerOverrides();
             pushPoseOverride(poseTarget, buildPoseFromKey('Stance'), 200);
             updateFighterAttackState('Stance', { active: false, context: null });
+            ATTACK.hitPause = 0;
           }
         }
       }
@@ -1591,9 +1610,29 @@ export function makeCombat(G, C, options = {}){
 
   // Update transitions
   function updateTransitions(dt){
+    const fighter = P();
+    let pauseApplied = 0;
+    if (fighter?.attack) {
+      const pauseRemaining = Number.isFinite(fighter.attack.hitPause) ? fighter.attack.hitPause : 0;
+      if (pauseRemaining > 0 && Number.isFinite(dt) && dt > 0) {
+        pauseApplied = Math.min(pauseRemaining, dt);
+        fighter.attack.hitPause = Math.max(0, pauseRemaining - pauseApplied);
+        ATTACK.hitPause = fighter.attack.hitPause;
+      } else {
+        ATTACK.hitPause = 0;
+      }
+    } else {
+      ATTACK.hitPause = 0;
+    }
+
     if (!TRANSITION.active) return;
-    
-    TRANSITION.elapsed += dt * 1000;
+
+    const progressDt = dt - pauseApplied;
+    if (progressDt <= 0) {
+      return;
+    }
+
+    TRANSITION.elapsed += progressDt * 1000;
     
     // Apply flips at the specified progress point
     if (TRANSITION.flipAt !== null && !TRANSITION.flipApplied && TRANSITION.flipParts){

--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -435,10 +435,13 @@ export function initFighters(cv, cx){
       stamina: {
         current: maxStamina,
         max: maxStamina,
+        min: -maxStamina,
         drainRate: staminaDrainRate,
         regenRate: staminaRegenRate,
         minToDash: staminaMinToDash,
         isDashing: false,
+        exhausted: false,
+        exhaustionRatio: 0,
       },
       attack: {
         active: false,

--- a/docs/js/physics.js
+++ b/docs/js/physics.js
@@ -1,4 +1,9 @@
-import { getFootingRecovery, getMovementMultipliers, getStatProfile } from './stat-hooks.js?v=1';
+import {
+  computeRagdollBlendController,
+  getFootingRecovery,
+  getMovementMultipliers,
+  getStatProfile,
+} from './stat-hooks.js?v=1';
 
 const JOINT_LIMITS = {
   torso: [-0.8, 0.8],
@@ -61,6 +66,7 @@ function ensurePhysicsState(fighter) {
   state.partialBlendTimer ||= 0;
   state.partialBlendDuration ||= 0.45;
   state.airBlend ||= 0;
+  state.controllerBlend ||= 0;
   state.lastFootingOnFall = Number.isFinite(state.lastFootingOnFall)
     ? state.lastFootingOnFall
     : fighter.footing ?? 0;
@@ -140,7 +146,13 @@ function updateRagdollTargets(fighter, state, dt) {
 
 function updateJointPhysics(fighter, config, dt) {
   const state = ensurePhysicsState(fighter);
-  const blendSources = [fighter.ragdoll ? 1 : 0, state.partialBlend || 0, state.airBlend || 0, state.recoveryBlend || 0];
+  const blendSources = [
+    fighter.ragdoll ? 1 : 0,
+    state.partialBlend || 0,
+    state.airBlend || 0,
+    state.recoveryBlend || 0,
+    state.controllerBlend || 0,
+  ];
   const totalBlend = Math.max(...blendSources);
   state.totalBlend = clamp(totalBlend, 0, 1);
 
@@ -417,6 +429,14 @@ export function updateFighterPhysics(fighter, config, dt, options = {}) {
     }
   }
 
+  const controller = computeRagdollBlendController(fighter, config);
+  const controllerBlend = Number.isFinite(controller?.ratio) ? controller.ratio : 0;
+  state.controllerBlend = clamp(controllerBlend, 0, 1);
+  fighter.ragdollBlend ||= {};
+  fighter.ragdollBlend.ratio = state.controllerBlend;
+  fighter.ragdollBlend.base = controller?.base ?? 0;
+  fighter.ragdollBlend.contributions = controller?.contributions || {};
+
   decayPartialBlend(state, dt);
   updateAirBlend(fighter, state, dt);
   applyRecoveryBlend(fighter, state, dt);
@@ -478,6 +498,14 @@ export function applyHitReactionRagdoll(fighter, config, {
   state.partialBlendStart = state.partialBlend;
   state.partialBlendTimer = 0;
   state.partialBlendDuration = 0.3 + instability * 0.7;
+
+  if (!fighter.ragdoll && fighter.attack?.active) {
+    const forceFactor = Number.isFinite(force) ? Math.min(Math.abs(force) / 900, 0.25) : 0;
+    const pause = clamp(0.08 + blend * 0.35 + forceFactor, 0.08, 0.5);
+    fighter.attack.hitPause = Math.max(fighter.attack.hitPause || 0, pause);
+    fighter.anim = fighter.anim || {};
+    fighter.anim.hitPause = Math.max(fighter.anim.hitPause || 0, pause);
+  }
 
   perturbJoints(state, blend);
   const impulseMag = force * (0.12 + 0.35 * instability);

--- a/docs/js/stat-hooks.js
+++ b/docs/js/stat-hooks.js
@@ -188,18 +188,97 @@ export function applyStaminaTick(fighter, dt) {
   if (!fighter || !Number.isFinite(dt) || dt <= 0) return;
   const stamina = fighter.stamina;
   if (!stamina) return;
-  const current = Number.isFinite(stamina.current) ? stamina.current : 0;
-  if (stamina.isDashing && current > 0) {
+  const max = Number.isFinite(stamina.max) ? stamina.max : 100;
+  if (!Number.isFinite(stamina.min)) {
+    stamina.min = -max;
+  }
+  const min = Number.isFinite(stamina.min) ? stamina.min : -max;
+  const current = Number.isFinite(stamina.current) ? stamina.current : max;
+  if (stamina.isDashing && current > min) {
     const drainRate = Number.isFinite(stamina.drainRate) ? stamina.drainRate : 40;
-    const next = Math.max(0, current - drainRate * dt);
+    const next = Math.max(min, current - drainRate * dt);
     stamina.current = next;
     if (next <= 0) {
       stamina.isDashing = false;
     }
   } else {
     const regenRate = Number.isFinite(stamina.regenRate) ? stamina.regenRate : 20;
-    const max = Number.isFinite(stamina.max) ? stamina.max : 100;
     stamina.isDashing = false;
-    stamina.current = Math.min(max, current + regenRate * dt);
+    if (current < 0) {
+      const next = Math.min(0, current + regenRate * dt);
+      stamina.current = next;
+    } else {
+      const next = Math.min(max, current + regenRate * dt);
+      stamina.current = next;
+    }
   }
+  const exhausted = stamina.current < 0;
+  stamina.exhausted = exhausted;
+  const denom = Math.max(1, Math.abs(min));
+  stamina.exhaustionRatio = exhausted ? Math.min(1, Math.abs(stamina.current) / denom) : 0;
+}
+
+function combineContributions(values = []) {
+  let combined = 0;
+  for (const raw of values) {
+    if (!Number.isFinite(raw) || raw <= 0) continue;
+    const value = clamp(raw, 0, 1);
+    combined = combined + value - combined * value;
+  }
+  return clamp(combined, 0, 1);
+}
+
+function resolveStaminaBase(stamina) {
+  if (!stamina) {
+    return { base: 0, min: -100 };
+  }
+  const max = Number.isFinite(stamina.max) ? Math.max(1, stamina.max) : 100;
+  const min = Number.isFinite(stamina.min) ? stamina.min : -max;
+  const current = Number.isFinite(stamina.current) ? stamina.current : max;
+  const exhaustedRatio = current < 0 ? Math.min(1, Math.abs(current) / Math.max(1, Math.abs(min))) : 0;
+  return { base: clamp(exhaustedRatio, 0, 1), min };
+}
+
+export function computeRagdollBlendController(fighter, config) {
+  if (!fighter) {
+    return { ratio: 0, base: 0, contributions: {} };
+  }
+
+  const { base: exhaustionBase } = resolveStaminaBase(fighter.stamina);
+
+  const contributions = {};
+
+  const movementCfg = config?.movement || {};
+  const maxSpeedX = Number.isFinite(movementCfg.maxSpeedX) ? Math.max(60, movementCfg.maxSpeedX) : 420;
+  const velX = Number.isFinite(fighter.vel?.x) ? Math.abs(fighter.vel.x) : 0;
+  const velRatio = maxSpeedX > 0 ? clamp(velX / (maxSpeedX * 1.2), 0, 1) : 0;
+  const airBonus = fighter.onGround === false ? 0.2 : 0;
+  contributions.movement = clamp(velRatio * 0.35 + airBonus, 0, 0.45);
+
+  const attack = fighter.attack || null;
+  if (attack?.active) {
+    const phase = String(attack.currentPhase || '').toLowerCase();
+    let weight = 0.25;
+    if (phase.includes('strike')) {
+      weight = 0.5;
+    } else if (phase.includes('windup')) {
+      weight = 0.35;
+    } else if (phase.includes('recoil')) {
+      weight = 0.32;
+    }
+    const pauseInfluence = Number.isFinite(attack.hitPause) ? clamp(attack.hitPause / 0.5, 0, 1) * 0.25 : 0;
+    contributions.attack = clamp(weight + pauseInfluence, 0, 0.6);
+  }
+
+  const maxFooting = Number.isFinite(config?.knockback?.maxFooting) ? config.knockback.maxFooting : 100;
+  if (maxFooting > 0) {
+    const footing = Number.isFinite(fighter.footing) ? clamp(fighter.footing, 0, maxFooting) : maxFooting;
+    const instability = 1 - footing / maxFooting;
+    contributions.footing = clamp(instability * 0.5, 0, 0.5);
+  }
+
+  const combined = combineContributions(Object.values(contributions));
+  const ratio = clamp(exhaustionBase + (1 - exhaustionBase) * combined, 0, 1);
+
+  return { ratio, base: exhaustionBase, contributions };
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -316,6 +316,7 @@ canvas#game{
 .stamina-fill{background:linear-gradient(90deg,#22c55e 0%,#86efac 55%,#22c55e 100%);box-shadow:0 0 12px rgba(34,197,94,0.45);}
 .stamina-fill.low{background:linear-gradient(90deg,#ef4444 0%,#fca5a5 55%,#ef4444 100%);box-shadow:0 0 12px rgba(239,68,68,0.45);}
 .stamina-fill.dashing{background:linear-gradient(90deg,#3b82f6 0%,#60a5fa 55%,#3b82f6 100%);box-shadow:0 0 16px rgba(59,130,246,0.55);animation:pulse 0.32s ease-in-out infinite alternate;}
+.stamina-fill.exhausted{background:linear-gradient(90deg,#7f1d1d 0%,#b91c1c 55%,#7f1d1d 100%);box-shadow:0 0 18px rgba(185,28,28,0.55);animation:none;}
 @keyframes pulse{from{opacity:0.8;}to{opacity:1;}}
 .footing-fill{background:linear-gradient(90deg,#d4d4d8 0%,#f4f4f5 60%,#d4d4d8 100%);box-shadow:0 0 10px rgba(212,212,216,0.4);}
 


### PR DESCRIPTION
## Summary
- centralize ragdoll blend computation that factors stamina exhaustion, movement intensity, and attack state while keeping physics blend authoritative
- allow stamina to drop into negative exhaustion, updating HUD styling and CSS to reflect the exhausted state
- pause ongoing attack animations on hit for both player and NPC fighters without resetting transitions while feeding hit pauses into ragdoll blending

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175e122c3083269af7cce531f93743)