### PR TITLE
Ensure fighter reinit loads latest character data

### DIFF
--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -331,12 +331,13 @@ export function initFighters(cv, cx){
     if (!characterKey || !characters[characterKey]) {
       characterKey = resolveCharacterKey(id);
     }
-    let characterData = prevProfile?.character ? clone(prevProfile.character) : null;
+    let characterData = null;
     if (id === 'npc' && hasNpcCharacter) {
       characterData = clone(characters.npc);
-    }
-    if (!characterData && characterKey && characters[characterKey]) {
+    } else if (characterKey && characters[characterKey]) {
       characterData = clone(characters[characterKey]);
+    } else if (prevProfile?.character) {
+      characterData = clone(prevProfile.character);
     }
 
     const fighterName = resolveFighterName(id, characterData, prevProfile);


### PR DESCRIPTION
## Summary
- rebuild fighter character data from the current CONFIG on each reinitialization so sprite swaps apply immediately
- keep previous profile data only as a fallback when no config entry exists

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177283e1a88326a8a9448b1f246805)