### PR TITLE
Add citywatch helmet cosmetic layering

### DIFF
--- a/docs/config/cosmetics/citywatch_helmet.json
+++ b/docs/config/cosmetics/citywatch_helmet.json
@@ -1,1 +1,45 @@
-
+{
+  "slot": "hat",
+  "hsv": {
+    "defaults": { "h": 0, "s": 0, "v": 0 },
+    "limits": { "h": [-90, 90], "s": [-0.5, 0.5], "v": [-0.35, 0.35] }
+  },
+  "parts": {
+    "head": {
+      "layers": {
+        "back": {
+          "image": {
+            "url": "./assets/cosmetics/clothes/hat/citywatch_helmet-back.png"
+          },
+          "spriteStyle": {
+            "base": {
+              "xform": {
+                "head": { "ax": -0.05, "ay": -0.12, "scaleX": 1.15, "scaleY": 1.12 }
+              }
+            }
+          }
+        },
+        "front": {
+          "image": {
+            "url": "./assets/cosmetics/clothes/hat/citywatch_helmet-front.png"
+          },
+          "spriteStyle": {
+            "base": {
+              "xform": {
+                "head": { "ax": -0.05, "ay": -0.12, "scaleX": 1.15, "scaleY": 1.12 }
+              }
+            }
+          },
+          "warp": {
+            "base": {
+              "units": "percent",
+              "tl": { "y": -0.05 },
+              "tr": { "y": -0.05 },
+              "center": { "y": -0.02 }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define the Citywatch helmet cosmetic configuration for the hat slot
- render the helmet with separate back and front layers so it wraps the head sprite

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691797e96ab88326814fb1e491b7d122)