### PR TITLE
Implement watchman template for bounty NPCs

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -909,6 +909,112 @@ window.CONFIG = {
       }
     }
   },
+
+  characterTemplates: {
+    citywatch_watchman: {
+      label: 'City Watch Watchman',
+      description: 'Standardized city watch guard template used for bounty spawns.',
+      baseCharacter: 'citywatch_sarrarru',
+      overrides: {
+        fighter: { $kind: 'pool', items: ['Mao-ao_M'] },
+        weapon: {
+          $kind: 'pool',
+          items: [
+            { value: 'sarrarru', weight: 3 },
+            { value: 'hatchets', weight: 1 },
+            { value: 'greatclub', weight: 1 }
+          ]
+        },
+        slottedAbilities: {
+          $kind: 'pool',
+          items: [
+            ['combo_light', 'heavy_hold', 'quick_light', 'heavy_hold', 'quick_punch', 'evade_defensive'],
+            ['combo_light', 'heavy_hold', 'quick_punch', 'heavy_hold', 'quick_light', 'evade_defensive'],
+            ['combo_light', 'heavy_hold', 'quick_light', 'heavy_hold', 'quick_light', 'evade_defensive']
+          ]
+        },
+        stats: {
+          baseline: {
+            $kind: 'rangePool',
+            ranges: [
+              { min: 9, max: 11, weight: 2, round: true },
+              { min: 11, max: 12, weight: 1, round: true }
+            ]
+          },
+          strength: {
+            $kind: 'rangePool',
+            ranges: [
+              { min: 8, max: 11, weight: 2, round: true },
+              { min: 11, max: 13, weight: 1, round: true }
+            ]
+          },
+          agility: {
+            $kind: 'rangePool',
+            ranges: [
+              { min: 6, max: 9, weight: 2, round: true },
+              { min: 9, max: 11, weight: 1, round: true }
+            ]
+          },
+          endurance: {
+            $kind: 'rangePool',
+            ranges: [
+              { min: 7, max: 10, weight: 2, round: true },
+              { min: 10, max: 12, weight: 1, round: true }
+            ]
+          }
+        },
+        bodyColors: {
+          A: {
+            $kind: 'playerBodyColor',
+            channel: 'A',
+            adjustments: {
+              v: {
+                $kind: 'rangePool',
+                ranges: [
+                  { min: -0.45, max: -0.25, weight: 2 },
+                  { min: -0.25, max: -0.1, weight: 1 }
+                ]
+              }
+            }
+          },
+          B: {
+            $kind: 'playerBodyColor',
+            channel: 'B',
+            adjustments: {
+              v: {
+                $kind: 'rangePool',
+                ranges: [
+                  { min: -0.05, max: 0.2, weight: 2 },
+                  { min: 0.2, max: 0.35, weight: 1 }
+                ]
+              }
+            }
+          }
+        },
+        cosmetics: {
+          slots: {
+            hat: { id: 'citywatch_helmet', hsv: { h: -12, s: 0.05, v: 0.08 } },
+            legs: {
+              id: 'basic_pants',
+              hsv: {
+                h: { $kind: 'range', min: -140, max: -80 },
+                s: { $kind: 'rangePool', ranges: [{ min: 0.6, max: 0.8, weight: 2 }, { min: 0.8, max: 1, weight: 1 }] },
+                v: { $kind: 'rangePool', ranges: [{ min: -0.05, max: 0.1, weight: 1 }, { min: 0.1, max: 0.3, weight: 2 }] }
+              }
+            },
+            overwear: {
+              $kind: 'pool',
+              items: [
+                { value: { id: 'layered_travel_cloak', hsv: { h: -18, s: -0.12, v: 0.04 } }, weight: 2 },
+                { value: { id: 'layered_travel_cloak', hsv: { h: -6, s: -0.05, v: 0.12 } }, weight: 1 }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+
   // Add more characters or pools for randomization as needed
 
   weaponCombos: {

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -422,7 +422,7 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 import { initNpcSystems, updateNpcSystems } from './npc.js?v=2';
 import { initPresets, ensureAltSequenceUsesKickAlt } from './presets.js?v=6';
-import { initFighters } from './fighter.js?v=7';
+import { initFighters } from './fighter.js?v=8';
 import { initControls } from './controls.js?v=7';
 import { initCombat } from './combat.js?v=19';
 import { updatePoses } from './animator.js?v=4';

--- a/docs/js/bounty.js
+++ b/docs/js/bounty.js
@@ -1,4 +1,4 @@
-import { spawnAdditionalNpc, removeNpcFighter, reviveFighter } from './fighter.js?v=7';
+import { spawnAdditionalNpc, removeNpcFighter, reviveFighter } from './fighter.js?v=8';
 import { getActiveNpcFighters, registerNpcFighter, unregisterNpcFighter } from './npc.js?v=2';
 
 const DEFAULT_BOUNTY_CONFIG = {
@@ -16,6 +16,16 @@ const DEFAULT_BOUNTY_CONFIG = {
   starKillThresholds: [0, 3, 7, 12, 18],
   maxStars: 5,
 };
+
+const DEFAULT_BOUNTY_TEMPLATE_ID = 'citywatch_watchman';
+
+function getBountyNpcTemplateId() {
+  const raw = window.CONFIG?.bounty?.npcTemplateId;
+  if (typeof raw === 'string' && raw.trim().length) {
+    return raw.trim();
+  }
+  return DEFAULT_BOUNTY_TEMPLATE_ID;
+}
 
 function getBountyConfig() {
   const raw = window.CONFIG?.bounty || {};
@@ -133,6 +143,7 @@ function spawnWave(state, config) {
       y: spawn.y ?? 0,
       facingSign: -1,
       waveId: state.wave + 1,
+      templateId: getBountyNpcTemplateId(),
     });
     if (!npc) continue;
     registerNpcFighter(npc, { immediateAggro: true });
@@ -236,7 +247,7 @@ export function updateBountySystem(dt) {
       state.idleRespawnTimer += dt;
       if (state.idleRespawnTimer >= (config.idleRespawnDelay || DEFAULT_BOUNTY_CONFIG.idleRespawnDelay)) {
         const spawn = window.GAME?.spawnPoints?.npc || { x: 0, y: 0 };
-        const npc = spawnAdditionalNpc({ x: spawn.x ?? 0, y: spawn.y ?? 0, facingSign: -1 });
+        const npc = spawnAdditionalNpc({ x: spawn.x ?? 0, y: spawn.y ?? 0, facingSign: -1, templateId: getBountyNpcTemplateId() });
         if (npc) {
           registerNpcFighter(npc, { immediateAggro: false });
           state.idleRespawnTimer = 0;

--- a/docs/js/character-templates.js
+++ b/docs/js/character-templates.js
@@ -1,0 +1,283 @@
+// character-templates.js — Data-driven fighter character template instantiation
+// Provides weighted pools, numeric range selection, and context-aware resolution helpers
+
+const ROOT = typeof window !== 'undefined' ? window : globalThis;
+
+function clone(value) {
+  if (value == null) return value;
+  try {
+    if (typeof structuredClone === 'function') {
+      return structuredClone(value);
+    }
+  } catch (_err) {
+    // Ignore and fallback to JSON clone
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (_err) {
+    return value;
+  }
+}
+
+function deepMerge(base = {}, extra = {}) {
+  if (base == null && extra == null) return null;
+  if (base == null) return clone(extra);
+  if (extra == null) return clone(base);
+  const result = Array.isArray(base) ? base.map((item) => clone(item)) : { ...base };
+  for (const [key, value] of Object.entries(extra)) {
+    if (value == null) {
+      result[key] = value;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      result[key] = value.map((item) => clone(item));
+      continue;
+    }
+    if (typeof value === 'object') {
+      const current = result[key];
+      if (current && typeof current === 'object' && !Array.isArray(current)) {
+        result[key] = deepMerge(current, value);
+      } else {
+        result[key] = clone(value);
+      }
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function normalizeWeightedEntries(entries = [], { defaultWeight = 1, valueKey } = {}) {
+  const normalized = [];
+  for (const entry of entries) {
+    if (entry == null) continue;
+    if (valueKey && entry && typeof entry === 'object' && !Array.isArray(entry) && valueKey in entry) {
+      const weight = Number.isFinite(entry.weight) ? Number(entry.weight) : defaultWeight;
+      normalized.push({ value: entry[valueKey], weight: Math.max(weight, 0) });
+      continue;
+    }
+    if (!valueKey && entry && typeof entry === 'object' && !Array.isArray(entry) && Object.prototype.hasOwnProperty.call(entry, 'value')) {
+      const weight = Number.isFinite(entry.weight) ? Number(entry.weight) : defaultWeight;
+      normalized.push({ value: entry.value, weight: Math.max(weight, 0) });
+      continue;
+    }
+    normalized.push({ value: entry, weight: defaultWeight });
+  }
+  return normalized;
+}
+
+function pickWeightedValue(entries = [], randomFn = Math.random) {
+  const normalized = normalizeWeightedEntries(entries);
+  if (!normalized.length) return null;
+  const total = normalized.reduce((sum, entry) => sum + (entry.weight > 0 ? entry.weight : 0), 0);
+  if (total <= 0) {
+    const index = Math.floor(randomFn() * normalized.length) % normalized.length;
+    return normalized[index].value;
+  }
+  let threshold = randomFn() * total;
+  for (const entry of normalized) {
+    if (entry.weight <= 0) continue;
+    if (threshold < entry.weight) return entry.value;
+    threshold -= entry.weight;
+  }
+  return normalized[normalized.length - 1].value;
+}
+
+function resolveRangeNode(node = {}, randomFn = Math.random) {
+  if (Array.isArray(node)) {
+    const [min = 0, max = min] = node;
+    return resolveRangeNode({ min, max }, randomFn);
+  }
+  const min = Number.isFinite(node.min) ? Number(node.min) : Number.isFinite(node.start) ? Number(node.start) : 0;
+  const max = Number.isFinite(node.max) ? Number(node.max) : Number.isFinite(node.end) ? Number(node.end) : min;
+  const t = randomFn();
+  let value = min + (max - min) * t;
+  if (node.integer || node.round) {
+    value = Math.round(value);
+  }
+  if (node.floor) value = Math.floor(value);
+  if (node.ceil) value = Math.ceil(value);
+  return value;
+}
+
+function pickRangeValue(entries = [], randomFn = Math.random) {
+  if (!Array.isArray(entries) || !entries.length) return 0;
+  const normalized = entries.map((entry) => {
+    if (Array.isArray(entry)) {
+      const [min = 0, max = min, weight = 1] = entry;
+      return { min, max, weight: Math.max(Number(weight) || 0, 0) };
+    }
+    if (entry && typeof entry === 'object') {
+      const min = Number.isFinite(entry.min) ? Number(entry.min) : Number.isFinite(entry.start) ? Number(entry.start) : 0;
+      const max = Number.isFinite(entry.max) ? Number(entry.max) : Number.isFinite(entry.end) ? Number(entry.end) : min;
+      const weight = Math.max(Number(entry.weight) || 0, 0);
+      return { ...entry, min, max, weight };
+    }
+    const value = Number(entry) || 0;
+    return { min: value, max: value, weight: 1 };
+  });
+  const total = normalized.reduce((sum, entry) => sum + (entry.weight > 0 ? entry.weight : 0), 0);
+  let pick;
+  if (total <= 0) {
+    const index = Math.floor(randomFn() * normalized.length) % normalized.length;
+    pick = normalized[index];
+  } else {
+    let threshold = randomFn() * total;
+    for (const entry of normalized) {
+      if (entry.weight <= 0) continue;
+      if (threshold < entry.weight) {
+        pick = entry;
+        break;
+      }
+      threshold -= entry.weight;
+    }
+    if (!pick) pick = normalized[normalized.length - 1];
+  }
+  return resolveRangeNode(pick, randomFn);
+}
+
+function getRefValue(path, context, fallback = null) {
+  if (!path) return fallback;
+  const parts = String(path).split('.');
+  let current = context;
+  for (const part of parts) {
+    if (!current || typeof current !== 'object') return fallback;
+    current = current[part];
+  }
+  if (current == null) return fallback;
+  return clone(current);
+}
+
+function resolvePlayerBodyColor(node = {}, context, resolve) {
+  const channel = node.channel || node.key || node.slot || 'A';
+  const playerColors = context?.player?.renderProfile?.bodyColors || {};
+  const baseCharacter = context?.baseCharacter || {};
+  const baseColors = baseCharacter.bodyColors || {};
+  const templateBase = context?.base || {};
+  const templateBaseColors = templateBase.bodyColors || {};
+  const source = playerColors[channel]
+    || templateBaseColors[channel]
+    || baseColors[channel]
+    || { h: 0, s: 0, v: 0 };
+  const color = clone(source) || { h: 0, s: 0, v: 0 };
+  const adjustments = node.adjustments || node.adjust || {};
+  for (const [component, adjustment] of Object.entries(adjustments)) {
+    const resolved = resolve(adjustment, context);
+    if (resolved == null) continue;
+    if (node.mode === 'add') {
+      const baseValue = Number(color[component]) || 0;
+      color[component] = baseValue + Number(resolved);
+    } else {
+      color[component] = resolved;
+    }
+  }
+  return color;
+}
+
+function resolveTemplateNode(node, context) {
+  const randomFn = typeof context?.random === 'function' ? context.random : Math.random;
+
+  if (node == null) return node;
+
+  if (Array.isArray(node)) {
+    return node.map((value) => resolveTemplateNode(value, context));
+  }
+
+  if (typeof node !== 'object') {
+    return node;
+  }
+
+  if (node.$kind === 'range') {
+    return resolveRangeNode(node, randomFn);
+  }
+
+  if (node.$kind === 'rangePool') {
+    return pickRangeValue(node.ranges || [], randomFn);
+  }
+
+  if (node.$kind === 'pool') {
+    return resolveTemplateNode(pickWeightedValue(node.items || [], randomFn), context);
+  }
+
+  if (node.$kind === 'pick') {
+    const pool = Array.isArray(node.pool) ? node.pool.slice() : [];
+    const count = Math.max(0, Number(node.count) || 0);
+    const unique = node.unique !== false;
+    const picks = [];
+    const indexPool = pool.map((entry, index) => ({
+      index,
+      value: entry && typeof entry === 'object' && !Array.isArray(entry) && Object.prototype.hasOwnProperty.call(entry, 'value')
+        ? entry.value
+        : entry,
+      weight: entry && typeof entry === 'object' && !Array.isArray(entry) && Number.isFinite(entry.weight)
+        ? Number(entry.weight)
+        : 1,
+    }));
+    for (let i = 0; i < count; i += 1) {
+      if (!indexPool.length) break;
+      const choice = pickWeightedValue(indexPool.map((entry) => ({ value: entry, weight: entry.weight })), randomFn);
+      if (!choice) break;
+      picks.push(resolveTemplateNode(choice.value, context));
+      if (unique) {
+        const removeIndex = indexPool.findIndex((entry) => entry.index === choice.index);
+        if (removeIndex >= 0) {
+          indexPool.splice(removeIndex, 1);
+        }
+      }
+    }
+    return picks;
+  }
+
+  if (node.$kind === 'ref') {
+    return getRefValue(node.path, context, node.fallback);
+  }
+
+  if (node.$kind === 'playerBodyColor') {
+    return resolvePlayerBodyColor(node, context, resolveTemplateNode);
+  }
+
+  const result = {};
+  for (const [key, value] of Object.entries(node)) {
+    result[key] = resolveTemplateNode(value, context);
+  }
+  return result;
+}
+
+export function instantiateCharacterTemplate(id, context = {}) {
+  if (!id) return null;
+  const C = context.config || ROOT.CONFIG || {};
+  const templates = C.characterTemplates || {};
+  const template = templates[id];
+  if (!template) return null;
+  const baseCharacterKey = template.baseCharacter || null;
+  const baseCharacter = baseCharacterKey && C.characters?.[baseCharacterKey]
+    ? clone(C.characters[baseCharacterKey])
+    : {};
+  const defaults = template.defaults ? clone(template.defaults) : {};
+  const base = deepMerge(baseCharacter, defaults);
+  const resolved = resolveTemplateNode(template.overrides || {}, {
+    ...context,
+    config: C,
+    template,
+    baseCharacter,
+    base,
+  }) || {};
+  const character = deepMerge(base, resolved) || {};
+  const characterKey = template.characterKey || `template:${id}`;
+  return {
+    id,
+    templateId: id,
+    characterKey,
+    baseCharacter: baseCharacterKey,
+    character,
+    meta: {
+      label: template.label || null,
+      description: template.description || null,
+    },
+  };
+}
+
+export function getRegisteredCharacterTemplates() {
+  const C = ROOT.CONFIG || {};
+  return clone(C.characterTemplates || {});
+}

--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -1,4 +1,4 @@
-import { initFighters } from './fighter.js?v=7';
+import { initFighters } from './fighter.js?v=8';
 import { renderAll } from './render.js?v=4';
 import { initSprites, renderSprites } from './sprites.js?v=8';
 import {

--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -3,6 +3,8 @@ import { degToRad } from './math-utils.js?v=1';
 import { pickFighterName } from './fighter-utils.js?v=1';
 import { getStatProfile } from './stat-hooks.js?v=1';
 
+import { instantiateCharacterTemplate } from './character-templates.js?v=1';
+
 function clone(value) {
   if (value == null) return value;
   try {
@@ -17,6 +19,29 @@ function clone(value) {
   } catch (_err) {
     return value;
   }
+}
+
+function normalizeStats(rawStats = {}) {
+  const baseline = Number.isFinite(rawStats.baseline) ? rawStats.baseline : 10;
+  const strength = Number.isFinite(rawStats.strength) ? rawStats.strength : baseline;
+  const agility = Number.isFinite(rawStats.agility) ? rawStats.agility : baseline;
+  const endurance = Number.isFinite(rawStats.endurance) ? rawStats.endurance : baseline;
+  const stats = {
+    baseline,
+    strength,
+    agility,
+    endurance,
+  };
+  if (Number.isFinite(rawStats.maxHealth)) {
+    stats.maxHealth = rawStats.maxHealth;
+  }
+  if (Number.isFinite(rawStats.maxStamina)) {
+    stats.maxStamina = rawStats.maxStamina;
+  }
+  if (Number.isFinite(rawStats.dashThreshold)) {
+    stats.dashThreshold = rawStats.dashThreshold;
+  }
+  return stats;
 }
 
 function resetRuntimeState(fighter, template, {
@@ -116,6 +141,101 @@ function resetRuntimeState(fighter, template, {
   return fighter;
 }
 
+function applyCharacterTemplateToFighter(fighter, templateResult, baseTemplate) {
+  if (!fighter || !templateResult) return fighter;
+  const fallbackProfile = baseTemplate?.renderProfile || fighter.renderProfile || {};
+  const fallbackCharacter = fallbackProfile.character || null;
+  const resolvedCharacter = templateResult.character
+    ? clone(templateResult.character)
+    : (fallbackCharacter ? clone(fallbackCharacter) : null);
+  const characterKey = templateResult.characterKey
+    || templateResult.templateId
+    || fallbackProfile.characterKey
+    || null;
+  const fighterName = resolvedCharacter?.fighter
+    || fallbackProfile.fighterName
+    || fighter.renderProfile?.fighterName
+    || null;
+  const bodyColors = resolvedCharacter?.bodyColors
+    ? clone(resolvedCharacter.bodyColors)
+    : (fallbackProfile.bodyColors ? clone(fallbackProfile.bodyColors) : null);
+  const cosmetics = resolvedCharacter?.cosmetics
+    ? clone(resolvedCharacter.cosmetics)
+    : (fallbackProfile.cosmetics ? clone(fallbackProfile.cosmetics) : null);
+  const appearance = resolvedCharacter?.appearance
+    ? clone(resolvedCharacter.appearance)
+    : (fallbackProfile.appearance ? clone(fallbackProfile.appearance) : null);
+  const slottedAbilities = Array.isArray(resolvedCharacter?.slottedAbilities)
+    ? resolvedCharacter.slottedAbilities.slice()
+    : (Array.isArray(fallbackProfile.slottedAbilities) ? fallbackProfile.slottedAbilities.slice() : []);
+  const stats = normalizeStats(resolvedCharacter?.stats || fallbackProfile.stats || {});
+  const statProfile = getStatProfile(stats);
+
+  fighter.renderProfile = {
+    ...fighter.renderProfile,
+    fighterName,
+    characterKey,
+    character: resolvedCharacter,
+    bodyColors,
+    cosmetics,
+    appearance,
+    weapon: resolvedCharacter?.weapon ?? fallbackProfile.weapon ?? null,
+    slottedAbilities,
+    stats,
+    statProfile,
+    templateId: templateResult.templateId || fighter.renderProfile?.templateId || null,
+  };
+
+  fighter.stats = stats;
+  fighter.statProfile = statProfile;
+
+  const baselineStat = stats.baseline ?? 10;
+  const enduranceStat = stats.endurance ?? baselineStat;
+  const staminaDrainRateMultiplier = Number.isFinite(statProfile?.staminaDrainRateMultiplier)
+    ? statProfile.staminaDrainRateMultiplier
+    : 1;
+  const staminaRegenRateMultiplier = Number.isFinite(statProfile?.staminaRegenRateMultiplier)
+    ? statProfile.staminaRegenRateMultiplier
+    : 1;
+  const dashThresholdMultiplier = Number.isFinite(statProfile?.dashStaminaThresholdMultiplier)
+    ? statProfile.dashStaminaThresholdMultiplier
+    : 1;
+  const healthRegenRate = Number.isFinite(statProfile?.healthRegenPerSecond)
+    ? statProfile.healthRegenPerSecond
+    : 0;
+  const maxHealth = Number.isFinite(stats.maxHealth)
+    ? stats.maxHealth
+    : Math.round(100 + (enduranceStat - baselineStat) * 6);
+  const maxStamina = Number.isFinite(stats.maxStamina)
+    ? stats.maxStamina
+    : Math.round(100 + (enduranceStat - baselineStat) * 5);
+  const staminaDrainRate = Math.max(15, Math.round(40 * staminaDrainRateMultiplier));
+  const staminaRegenRate = Math.max(12, Math.round(25 * staminaRegenRateMultiplier));
+  const staminaMinToDash = Number.isFinite(stats.dashThreshold)
+    ? stats.dashThreshold
+    : Math.max(6, Math.round(10 * dashThresholdMultiplier));
+
+  fighter.health = {
+    current: maxHealth,
+    max: maxHealth,
+    regenRate: healthRegenRate,
+  };
+
+  fighter.stamina = {
+    current: maxStamina,
+    max: maxStamina,
+    drainRate: staminaDrainRate,
+    regenRate: staminaRegenRate,
+    minToDash: staminaMinToDash,
+    isDashing: false,
+    reengageRatio: baseTemplate?.stamina?.reengageRatio ?? fighter.stamina?.reengageRatio ?? 0.6,
+  };
+
+  fighter.templateId = templateResult.templateId || fighter.templateId || null;
+
+  return fighter;
+}
+
 function randomHueDegrees() {
   const hue = Math.floor(Math.random() * 360);
   return hue > 180 ? hue - 360 : hue;
@@ -191,25 +311,7 @@ export function initFighters(cv, cx){
     return { x, y };
   }
 
-  function normalizeStats(rawStats) {
-    const baseline = Number.isFinite(rawStats?.baseline) ? rawStats.baseline : 10;
-    const strength = Number.isFinite(rawStats?.strength) ? rawStats.strength : baseline;
-    const agility = Number.isFinite(rawStats?.agility) ? rawStats.agility : baseline;
-    const endurance = Number.isFinite(rawStats?.endurance) ? rawStats.endurance : baseline;
-    const stats = {
-      baseline,
-      strength,
-      agility,
-      endurance,
-    };
-    if (Number.isFinite(rawStats?.maxHealth)) {
-      stats.maxHealth = rawStats.maxHealth;
-    }
-    if (Number.isFinite(rawStats?.maxStamina)) {
-      stats.maxStamina = rawStats.maxStamina;
-    }
-    return stats;
-  }
+
 
   function resolveActiveArea() {
     const registry = G.mapRegistry;
@@ -684,7 +786,19 @@ export function spawnAdditionalNpc(options = {}) {
     : (spawnMeta.facingSign ?? -1);
 
   const npc = clone(baseTemplate);
-  resetRuntimeState(npc, baseTemplate, {
+  const templateId = options.templateId || window.CONFIG?.bounty?.npcTemplateId || null;
+  let templateResult = null;
+  if (templateId) {
+    templateResult = instantiateCharacterTemplate(templateId, {
+      player: G.FIGHTERS?.player || null,
+      random: typeof options.random === 'function' ? options.random : undefined,
+    });
+    if (templateResult?.character) {
+      applyCharacterTemplateToFighter(npc, templateResult, baseTemplate);
+    }
+  }
+  const runtimeTemplate = templateResult ? npc : baseTemplate;
+  resetRuntimeState(npc, runtimeTemplate, {
     id,
     x: spawnX,
     y: spawnY,
@@ -694,7 +808,12 @@ export function spawnAdditionalNpc(options = {}) {
   npc.spawnMetadata = {
     waveId: options.waveId ?? null,
     spawnedAt: typeof performance !== 'undefined' ? performance.now() : Date.now(),
+    templateId: templateResult ? templateId : null,
   };
+  if (templateResult && npc.renderProfile) {
+    npc.renderProfile.templateId = templateResult.templateId || templateId;
+    npc.renderProfile.characterKey = npc.renderProfile.characterKey || templateResult.characterKey || templateId;
+  }
   if (!G.FIGHTERS) G.FIGHTERS = {};
   G.FIGHTERS[id] = npc;
   if (G.CHARACTER_STATE) {

--- a/docs/js/hitdetect.js
+++ b/docs/js/hitdetect.js
@@ -2,7 +2,7 @@
 import { applyHitReactionRagdoll, triggerFullRagdoll } from './physics.js?v=1';
 import { getFootingMitigation, getStatProfile } from './stat-hooks.js?v=1';
 import { getActiveNpcFighters } from './npc.js?v=2';
-import { markFighterDead } from './fighter.js?v=7';
+import { markFighterDead } from './fighter.js?v=8';
 import { reportPlayerAggression, reportNpcDefeated, reportPlayerDeath } from './bounty.js?v=1';
 
 function clamp(value, min, max) {


### PR DESCRIPTION
## Summary
- add a reusable character template module with weighted pools, range selection, and player color sampling for NPC generation
- register a city watch watchman template and configure bounty spawns to instantiate it for guard waves and idle patrols
- bump fighter module imports to v8 so callers pick up the new template-aware spawn logic

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917aaff911883269c11a02bd5c2d65d)