### PR TITLE
Mitigate resource exhaustion by serializing config fetches

### DIFF
--- a/docs/js/cosmetic-library.js
+++ b/docs/js/cosmetic-library.js
@@ -24,5 +24,9 @@ const loadEntries = Object.entries(sources)
 if (typeof fetch !== 'function'){
   console.warn('[cosmetics] Skipping cosmetic library loading: fetch is unavailable in this environment');
 } else if (loadEntries.length){
-  await Promise.all(loadEntries.map(([id, url]) => loadCosmetic(id, url)));
+  for (const [id, url] of loadEntries){
+    // Sequentialize loads to avoid exhausting limited browser fetch slots.
+    // eslint-disable-next-line no-await-in-loop
+    await loadCosmetic(id, url);
+  }
 }

--- a/docs/js/cosmetic-profiles.js
+++ b/docs/js/cosmetic-profiles.js
@@ -24,5 +24,9 @@ const loadEntries = Object.entries(sources)
 if (typeof fetch !== 'function'){
   console.warn('[cosmetics] Skipping fighter profile loading: fetch is unavailable in this environment');
 } else if (loadEntries.length){
-  await Promise.all(loadEntries.map(([fighterName, url]) => loadProfile(fighterName, url)));
+  for (const [fighterName, url] of loadEntries){
+    // Sequential load mirrors the cosmetic library to keep fetch pressure low.
+    // eslint-disable-next-line no-await-in-loop
+    await loadProfile(fighterName, url);
+  }
 }

--- a/docs/js/prefab-catalog.js
+++ b/docs/js/prefab-catalog.js
@@ -304,25 +304,25 @@ export async function loadPrefabsFromManifests(manifestUrls, options = {}) {
   const errors = [];
 
   const uniqueManifests = Array.from(new Set((manifestUrls || []).filter((url) => typeof url === 'string' && url.trim())));
-  await Promise.all(uniqueManifests.map(async (manifestUrl) => {
+  for (const manifestUrl of uniqueManifests) {
     try {
       const { catalog, normalizedEntries } = await loadManifest(manifestUrl, fetchImpl);
       catalogs.push(catalog);
-      await Promise.all(normalizedEntries.map(async ({ id, url }) => {
+      for (const { id, url } of normalizedEntries) {
+        if (prefabs.has(id)) {
+          continue;
+        }
         try {
-          if (prefabs.has(id)) {
-            return;
-          }
           const prefab = await loadPrefab(url, fetchImpl);
           prefabs.set(id, prefab);
         } catch (error) {
           errors.push({ type: 'prefab', id, url, error });
         }
-      }));
+      }
     } catch (error) {
       errors.push({ type: 'manifest', url: manifestUrl, error });
     }
-  }));
+  }
 
   return { prefabs, catalogs, errors };
 }


### PR DESCRIPTION
## Summary
- load prefab manifests sequentially so only one manifest and prefab entry are fetched at a time
- switch the cosmetic library and profile loaders to sequential fetches to reduce simultaneous network usage

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917b58f89408326b13b9772fcf0c644)