### PR TITLE
Ensure fighter and character selections refresh preview sprites

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -299,6 +299,7 @@ function initCharacterDropdown() {
     window.GAME ||= {};
     if (!selectedChar || !map[selectedChar]) {
       characterSelect.value = '';
+      currentSelectedFighter = null;
       window.GAME.selectedCharacter = null;
       window.GAME.selectedFighter = null;
       window.GAME.selectedWeapon = null;
@@ -325,12 +326,14 @@ function initCharacterDropdown() {
 
       const defaults = getDefaultAbilityAssignments();
       setAbilitySelection(defaults, { syncDropdowns: true });
+      requestFighterPreview(null);
       return;
     }
     const charData = map[selectedChar];
     // Sync fighter, weapon, cosmetics, and appearance
     window.GAME.selectedCharacter = selectedChar;
     window.GAME.selectedFighter = charData.fighter;
+    currentSelectedFighter = charData.fighter || null;
     window.GAME.selectedWeapon = charData.weapon || null;
     setConfigCurrentWeapon(window.GAME.selectedWeapon);
     window.GAME.selectedAppearance = {
@@ -369,6 +372,8 @@ function initCharacterDropdown() {
     // Also update fighter dropdown to match
     const fighterSelect = document.getElementById('fighterSelect');
     if (fighterSelect) fighterSelect.value = charData.fighter;
+
+    requestFighterPreview(charData.fighter);
 
     const weaponSelect = document.getElementById('weaponSelect');
     if (weaponSelect) {
@@ -568,7 +573,9 @@ if (reloadBtn){
       initFighters(cv, cx);
       initSelectionDropdowns();
       if (previousFighter) {
-        scheduleFighterPreview(previousFighter);
+        requestFighterPreview(previousFighter);
+      } else {
+        requestFighterPreview(null);
       }
       scheduleConfigUpdatedEvent();
       if (statusInfo) statusInfo.textContent = 'Config reloaded';
@@ -689,6 +696,39 @@ document.addEventListener('config:updated', ()=>{
 // Fighter selection and settings management
 let currentSelectedFighter = null;
 
+function determinePreviewFighter(preferredName) {
+  const C = window.CONFIG || {};
+  const fighters = C.fighters || {};
+
+  if (preferredName && fighters[preferredName]) {
+    return preferredName;
+  }
+
+  const selected = window.GAME?.selectedFighter;
+  if (selected && fighters[selected]) {
+    return selected;
+  }
+
+  const playerCharacterFighter = C.characters?.player?.fighter;
+  if (playerCharacterFighter && fighters[playerCharacterFighter]) {
+    return playerCharacterFighter;
+  }
+
+  if (fighters.TLETINGAN) {
+    return 'TLETINGAN';
+  }
+
+  const fighterKeys = Object.keys(fighters);
+  return fighterKeys.length ? fighterKeys[0] : null;
+}
+
+function requestFighterPreview(preferredName) {
+  const fighterName = determinePreviewFighter(preferredName);
+  if (fighterName) {
+    scheduleFighterPreview(fighterName);
+  }
+}
+
 // Debounced preview management so fighter settings immediately refresh the viewport
 let previewTimeoutId = null;
 let previewQueuedFighter = null;
@@ -781,18 +821,20 @@ function initFighterDropdown() {
     window.GAME ||= {};
     window.GAME.selectedFighter = previousSelection;
     showFighterSettings(previousSelection);
+    requestFighterPreview(previousSelection);
   } else {
     fighterSelect.value = '';
     if (!previousSelection) {
       hideFighterSettings();
     }
+    requestFighterPreview(null);
   }
 
   // Handle selection change
   if (!fighterSelect.dataset.initialized) {
     fighterSelect.addEventListener('change', (e) => {
       const selectedFighter = e.target.value;
-      currentSelectedFighter = selectedFighter;
+      currentSelectedFighter = selectedFighter || null;
       window.GAME ||= {};
       const previousPaletteFighter = window.GAME.selectedBodyColorsFighter;
       window.GAME.selectedFighter = selectedFighter;
@@ -802,6 +844,7 @@ function initFighterDropdown() {
         delete window.GAME.selectedCosmetics;
         delete window.GAME.selectedAppearance;
         hideFighterSettings();
+        requestFighterPreview(null);
         return;
       }
 
@@ -813,6 +856,7 @@ function initFighterDropdown() {
       delete window.GAME.selectedAppearance;
 
       showFighterSettings(selectedFighter);
+      requestFighterPreview(selectedFighter);
     });
     fighterSelect.dataset.initialized = 'true';
   }
@@ -1216,7 +1260,7 @@ function populateFighterSettings(fighterName, fighter, container) {
         setNestedValue(fighter, field.path, newValue);
         console.log(`[fighterSettings] Updated ${fighterName}.${field.path} = ${newValue}`);
         scheduleConfigUpdatedEvent();
-        scheduleFighterPreview(fighterName);
+        requestFighterPreview(fighterName);
       }
     });
 


### PR DESCRIPTION
## Summary
- ensure fighter and character dropdowns request a preview reload whenever selections change
- add a helper to choose a safe fallback fighter when no explicit selection is available
- trigger preview refreshes after config reloads and fighter setting edits

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917bed7f0c48326874906527cc86d3f)