### PR TITLE
Render map prefabs and add teleport debug control

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -170,6 +170,7 @@
             <button type="button" id="btnFullscreen" class="ui-btn">⤢ Full</button>
             <button type="button" id="btnReloadCfg" class="ui-btn">↻ Config</button>
             <button type="button" id="debugToggle" class="ui-btn">🔍 Debug</button>
+            <button type="button" id="btnTeleportSpawn" class="ui-btn">⟰ Teleport</button>
           </div>
 
           <div class="help-panel" id="helpPanel" role="dialog" aria-modal="false" aria-label="On-screen control help">


### PR DESCRIPTION
## Summary
- render actual prefab artwork in the map preview instead of tinted placeholders and retain ASCII fallbacks when assets are missing
- cache prefab images and reuse fallback logging to surface missing prefabs once
- add a controls overlay button that teleports the player 100 pixels above the spawn point for quick resets

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c22eca2c8326a921d9494ee24361)