### PR TITLE
Implement sprite offset handling for fighter sprites

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -453,6 +453,14 @@ window.CONFIG = {
         leg: { upper:{ origin:{ax:0, ay:0}, knee:{ax:0, ay:0}  }, lower:{ origin:{ax:0, ay:0} } },
         head:{ origin:{ax:-1, ay:6} }
       },
+      spriteOffsets: {
+        torso:    { ax:-0.5,  ay:-0.2, units: 'percent' },
+        head:     { ax:-1.20, ay:-0.60, units: 'percent' },
+        armUpper: { ax:0,     ay:0,     units: 'percent' },
+        armLower: { ax:0,     ay:0,     units: 'percent' },
+        legUpper: { ax:-0.10, ay:0.10,  units: 'percent' },
+        legLower: { ax:-0.2,  ay:0.02,  units: 'percent' }
+      },
       sprites: {
         torso: { url: "./assets/fightersprites/tletingan/torso_mint.png", bodyColor: 'A' },
         head:  { url: "./assets/fightersprites/tletingan/head_mint.png", bodyColor: 'A' },
@@ -469,12 +477,12 @@ window.CONFIG = {
           widthFactor: { torso:0.9, armUpper:0.9, armLower:0.9, legUpper:0.9, legLower:0.9, head:0.9 },
           xformUnits: "percent",
           xform: {
-            torso:    { ax:-0.5,  ay:-0.2, scaleX:3.5, scaleY:4.50, rotDeg:180 },
-            head:     { ax:-1.20, ay:-0.60, scaleX:6, scaleY:6, rotDeg:180 },
-            armUpper: { ax:0.00,  ay:0.00,  scaleX:3.00, scaleY:3.00, rotDeg:0 },
-            armLower: { ax:0.00,  ay:0.00,  scaleX:2.00, scaleY:2.00, rotDeg:0 },
-            legUpper: { ax:-0.10, ay:0.10,  scaleX:2.0,  scaleY:2.0,  rotDeg:0 },
-            legLower: { ax:-0.2,  ay:0.02,  scaleX:2,    scaleY:2.00, rotDeg:-10 }
+            torso:    { scaleX:3.5, scaleY:4.50, rotDeg:180 },
+            head:     { scaleX:6,   scaleY:6,    rotDeg:180 },
+            armUpper: { scaleX:3.00, scaleY:3.00, rotDeg:0 },
+            armLower: { scaleX:2.00, scaleY:2.00, rotDeg:0 },
+            legUpper: { scaleX:2.0,  scaleY:2.0,  rotDeg:0 },
+            legLower: { scaleX:2,    scaleY:2.00, rotDeg:-10 }
           }
       },
       untintedOverlays: [
@@ -513,6 +521,14 @@ window.CONFIG = {
         leg: { upper:{ origin:{ax:0, ay:0}, knee:{ax:0, ay:0}  }, lower:{ origin:{ax:0, ay:0} } },
         head:{ origin:{ax:0, ay:0} }
       },
+      spriteOffsets: {
+        torso:    { ax:0,     ay:-0.2, units: 'percent' },
+        head:     { ax:-0.1, ay:-0.0, units: 'percent' },
+        armUpper: { ax:-0.2, ay:0.1,  units: 'percent' },
+        armLower: { ax:0.35, ay:0,    units: 'percent' },
+        legUpper: { ax:-0.10, ay:0,   units: 'percent' },
+        legLower: { ax:0,     ay:0.2, units: 'percent' }
+      },
       sprites: {
         torso: { url: "./assets/fightersprites/mao-ao-m/torso_mint.png", bodyColor: 'A' },
         head:  { url: "./assets/fightersprites/mao-ao-m/head_mint.png", bodyColor: 'A' },
@@ -529,12 +545,12 @@ window.CONFIG = {
           widthFactor: { torso:1.0, armUpper:1.0, armLower:1.0, legUpper:1.0, legLower:1.0, head:1.0 },
           xformUnits: "percent",
           xform: {
-            torso:    { ax:0,  ay:-0.2, scaleX:1.4, scaleY:1.6, rotDeg:180 },
-            head:     { ax:-0.1, ay:-0.0, scaleX:1, scaleY:1.2, rotDeg:180 },
-            armUpper: { ax:-0.2,  ay:0.1,  scaleX:1.6, scaleY:2.8, rotDeg:-10 },
-            armLower: { ax:0.35,  ay:0,  scaleX:1.7, scaleY:2.1, rotDeg:-3 },
-            legUpper: { ax:-0.10, ay:0,  scaleX:1.7, scaleY:2.75,  rotDeg:-15 },
-            legLower: { ax:-0.0,  ay:0.2,  scaleX:1.7, scaleY:2.1, rotDeg:-4 }
+            torso:    { scaleX:1.4, scaleY:1.6, rotDeg:180 },
+            head:     { scaleX:1,   scaleY:1.2, rotDeg:180 },
+            armUpper: { scaleX:1.6, scaleY:2.8, rotDeg:-10 },
+            armLower: { scaleX:1.7, scaleY:2.1, rotDeg:-3 },
+            legUpper: { scaleX:1.7, scaleY:2.75, rotDeg:-15 },
+            legLower: { scaleX:1.7, scaleY:2.1, rotDeg:-4 }
           }
       },
       untintedOverlays: [

--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -469,6 +469,65 @@ function drawWarpedImage(ctx, img, destPoints, w, h){
   }
 }
 
+function normalizeSpriteOffsetSpec(raw){
+  if (!raw) return null;
+  let spec = raw;
+  if (typeof raw === 'object' && raw !== null && raw.origin){
+    spec = raw.origin;
+  }
+  if (Array.isArray(spec)){
+    const [ax = 0, ay = 0, units] = spec;
+    return {
+      ax: Number(ax) || 0,
+      ay: Number(ay) || 0,
+      units: typeof units === 'string' ? units : undefined
+    };
+  }
+  if (typeof spec === 'number'){
+    return { ax: spec, ay: 0 };
+  }
+  if (!spec || typeof spec !== 'object') return null;
+  return {
+    ax: Number(spec.ax ?? spec.x ?? 0) || 0,
+    ay: Number(spec.ay ?? spec.y ?? 0) || 0,
+    units: typeof spec.units === 'string'
+      ? spec.units
+      : (typeof spec.unit === 'string' ? spec.unit : undefined)
+  };
+}
+
+function lookupSpriteOffset(offsets, styleKey){
+  if (!offsets || typeof offsets !== 'object') return null;
+  const normalizedKey = normalizeStyleKey(styleKey);
+  const tryCandidates = (...candidates)=>{
+    for (const candidate of candidates){
+      const spec = normalizeSpriteOffsetSpec(candidate);
+      if (spec) return spec;
+    }
+    return null;
+  };
+
+  const direct = tryCandidates(offsets[styleKey], offsets[normalizedKey]);
+  if (direct) return direct;
+
+  switch (normalizedKey){
+    case 'torso':
+      return tryCandidates(offsets.torso, offsets.torso?.sprite, offsets.torso?.origin, offsets.torso?.spriteOffset);
+    case 'head':
+      return tryCandidates(offsets.head, offsets.head?.sprite, offsets.head?.origin, offsets.head?.spriteOffset);
+    case 'armUpper':
+      return tryCandidates(offsets.armUpper, offsets.arm?.upper, offsets.arm?.upper?.sprite, offsets.arm?.upper?.spriteOffset);
+    case 'armLower':
+      return tryCandidates(offsets.armLower, offsets.arm?.lower, offsets.arm?.lower?.sprite, offsets.arm?.lower?.spriteOffset);
+    case 'legUpper':
+      return tryCandidates(offsets.legUpper, offsets.leg?.upper, offsets.leg?.upper?.sprite, offsets.leg?.upper?.spriteOffset);
+    case 'legLower':
+      return tryCandidates(offsets.legLower, offsets.leg?.lower, offsets.leg?.lower?.sprite, offsets.leg?.lower?.spriteOffset);
+    default:
+      return null;
+  }
+}
+
 function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
   const options = arguments[6] || {};
   const opts = options || {};
@@ -535,6 +594,21 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
   const offsetY = ax * bAxis.fy + ay * bAxis.ry;
   posX += offsetX;
   posY += offsetY;
+
+  const spriteOffset = lookupSpriteOffset(offsets, styleKey);
+  if (spriteOffset){
+    const units = (spriteOffset.units || '').toLowerCase();
+    let ox = spriteOffset.ax;
+    let oy = spriteOffset.ay;
+    const unitMode = units
+      || (xformUnits === 'percent' || xformUnits === '%' || xformUnits === 'pct' ? 'percent' : 'px');
+    if (unitMode === 'percent' || unitMode === '%' || unitMode === 'pct'){
+      ox *= bone.len;
+      oy *= bone.len;
+    }
+    posX += ox * bAxis.fx + oy * bAxis.rx;
+    posY += ox * bAxis.fy + oy * bAxis.ry;
+  }
 
   // Sizing
   const nh = sourceImage.naturalHeight || sourceImage.height || 1;


### PR DESCRIPTION
## Summary
- add rendering helpers so fighter spriteOffsets data is applied when positioning parts
- move Tletingan and Mao-ao translation tweaks into spriteOffsets alongside existing scale/rotation data

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917cb03e7248326bee932313fb19519)