### PR TITLE
Fix cosmetic editor preview to use stance pose for single fighter

### DIFF
--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -1,4 +1,4 @@
-import { initFighters } from './fighter.js?v=8';
+import { initFighters, resetFighterStateForTesting } from './fighter.js?v=8';
 import { renderAll } from './render.js?v=4';
 import { initSprites, renderSprites } from './sprites.js?v=8';
 import {
@@ -1870,6 +1870,21 @@ class CosmeticEditorApp {
         }
       }
 
+      const spawnMeta = GAME.FIGHTER_SPAWNS?.player || {};
+      resetFighterStateForTesting(playerEntry, {
+        x: Number.isFinite(playerEntry?.pos?.x) ? playerEntry.pos.x : spawnMeta.x,
+        y: Number.isFinite(playerEntry?.pos?.y) ? playerEntry.pos.y : spawnMeta.y,
+        spawnY: spawnMeta.y,
+        facingSign: 1,
+      });
+      if (playerEntry.walk){
+        playerEntry.walk.phase = 0;
+        playerEntry.walk.amp = 0;
+      }
+      if (playerEntry.anim?.breath){
+        playerEntry.anim.breath.active = false;
+      }
+
       const renderProfile = (playerEntry.renderProfile ||= {});
       renderProfile.fighterName = fighterName;
       renderProfile.characterKey = characterKey || null;
@@ -2426,7 +2441,7 @@ class CosmeticEditorApp {
     this.assetLibrary.setSelectedAsset(null);
     this.modeManager.bootstrap();
     await initSprites();
-    initFighters(this.canvas, this.ctx);
+    initFighters(this.canvas, this.ctx, { spawnNpc: false, poseKey: 'Stance' });
     GAME.CAMERA = GAME.CAMERA || { x: 0, worldWidth: this.canvas.width };
     await this.loadAssetManifest();
     this.slotGrid.rebuild();


### PR DESCRIPTION
## Summary
- add optional configuration to `initFighters` so preview callers can skip spawning an NPC and request a specific pose
- ensure the cosmetic editor boots the fighter preview in stance, clears NPC entries, and reverts the player to a neutral pose when swapping fighters

## Testing
- `npm test --silent`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e2e17764832695732ac9c94b79c1)