### PR TITLE
Enforce instance identifiers across map registry

### DIFF
--- a/src/config/maps/defaultdistrict.layout.json
+++ b/src/config/maps/defaultdistrict.layout.json
@@ -128,7 +128,8 @@
       "tags": [
         "spawn:player"
       ],
-      "meta": {}
+      "meta": {},
+      "instanceId": "player_spawn"
     },
     {
       "id": 9002,
@@ -147,7 +148,8 @@
       "tags": [
         "spawn:npc"
       ],
-      "meta": {}
+      "meta": {},
+      "instanceId": "npc_spawn"
     },
     {
       "id": 8,
@@ -164,7 +166,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "8"
     },
     {
       "id": 9,
@@ -181,7 +184,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "9"
     },
     {
       "id": 10,
@@ -198,7 +202,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "10"
     },
     {
       "id": 11,
@@ -215,7 +220,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "11"
     },
     {
       "id": 12,
@@ -232,7 +238,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "12"
     },
     {
       "id": 13,
@@ -249,7 +256,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "13"
     },
     {
       "id": 14,
@@ -266,7 +274,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "14"
     },
     {
       "id": 15,
@@ -283,7 +292,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "15"
     },
     {
       "id": 16,
@@ -300,7 +310,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "16"
     },
     {
       "id": 17,
@@ -317,7 +328,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "17"
     },
     {
       "id": 18,
@@ -334,7 +346,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "18"
     },
     {
       "id": 19,
@@ -351,7 +364,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "19"
     },
     {
       "id": 20,
@@ -368,7 +382,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "20"
     },
     {
       "id": 21,
@@ -385,7 +400,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "21"
     },
     {
       "id": 22,
@@ -402,7 +418,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "22"
     },
     {
       "id": 23,
@@ -419,7 +436,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "23"
     },
     {
       "id": 24,
@@ -436,7 +454,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "24"
     },
     {
       "id": 25,
@@ -453,7 +472,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "25"
     },
     {
       "id": 27,
@@ -470,7 +490,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "27"
     },
     {
       "id": 28,
@@ -487,7 +508,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "28"
     },
     {
       "id": 29,
@@ -504,7 +526,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "29"
     },
     {
       "id": 30,
@@ -521,7 +544,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "30"
     },
     {
       "id": 31,
@@ -538,7 +562,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "31"
     },
     {
       "id": 32,
@@ -555,7 +580,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "32"
     },
     {
       "id": 33,
@@ -572,7 +598,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "33"
     },
     {
       "id": 34,
@@ -589,7 +616,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "34"
     },
     {
       "id": 35,
@@ -606,7 +634,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "35"
     },
     {
       "id": 36,
@@ -623,7 +652,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "36"
     },
     {
       "id": 37,
@@ -640,7 +670,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "37"
     },
     {
       "id": 38,
@@ -657,7 +688,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "38"
     },
     {
       "id": 39,
@@ -674,7 +706,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "39"
     },
     {
       "id": 40,
@@ -691,7 +724,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "40"
     },
     {
       "id": 41,
@@ -708,7 +742,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "41"
     },
     {
       "id": 42,
@@ -725,7 +760,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "42"
     },
     {
       "id": 43,
@@ -742,7 +778,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "43"
     },
     {
       "id": 44,
@@ -759,7 +796,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "44"
     },
     {
       "id": 45,
@@ -776,7 +814,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "45"
     },
     {
       "id": 46,
@@ -793,7 +832,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "46"
     },
     {
       "id": 47,
@@ -810,7 +850,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "47"
     },
     {
       "id": 48,
@@ -827,7 +868,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "48"
     },
     {
       "id": 49,
@@ -844,7 +886,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "49"
     },
     {
       "id": 50,
@@ -861,7 +904,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "50"
     },
     {
       "id": 51,
@@ -878,7 +922,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "51"
     },
     {
       "id": 52,
@@ -895,7 +940,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "52"
     },
     {
       "id": 53,
@@ -912,7 +958,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "53"
     },
     {
       "id": 54,
@@ -929,7 +976,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "54"
     },
     {
       "id": 55,
@@ -946,7 +994,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "55"
     },
     {
       "id": 56,
@@ -963,7 +1012,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "56"
     },
     {
       "id": 57,
@@ -980,7 +1030,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "57"
     },
     {
       "id": 58,
@@ -997,7 +1048,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "58"
     },
     {
       "id": 59,
@@ -1014,7 +1066,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "59"
     },
     {
       "id": 60,
@@ -1031,7 +1084,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "60"
     },
     {
       "id": 61,
@@ -1048,7 +1102,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "61"
     },
     {
       "id": 62,
@@ -1065,7 +1120,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "62"
     },
     {
       "id": 63,
@@ -1082,7 +1138,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "63"
     },
     {
       "id": 64,
@@ -1099,7 +1156,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "64"
     },
     {
       "id": 65,
@@ -1116,7 +1174,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "65"
     },
     {
       "id": 66,
@@ -1133,7 +1192,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "66"
     },
     {
       "id": 67,
@@ -1150,7 +1210,8 @@
       "rotationDeg": 0,
       "locked": false,
       "tags": [],
-      "meta": {}
+      "meta": {},
+      "instanceId": "67"
     }
   ],
   "colliders": [

--- a/tests/map/builderConversion.test.js
+++ b/tests/map/builderConversion.test.js
@@ -34,6 +34,13 @@ test('convertLayoutToArea produces modular descriptor', () => {
   assert.equal(area.instances[0].position.y, -15);
   assert.equal(area.instances[1].scale.x, 0.9);
   assert.deepEqual(area.instances[1].tags, ['spawn:player']);
+  assert.equal(area.instances[0].instanceId, '1');
+  assert.equal(area.instances[1].instanceId, 'player_spawn');
+  assert.equal(area.instances[1].meta.identity.instanceId, 'player_spawn');
+  assert.equal(area.instances[1].meta.identity.source, 'tag:spawn:player');
+  assert.ok(area.instancesById);
+  assert.strictEqual(area.instancesById['1'], area.instances[0]);
+  assert.strictEqual(area.instancesById.player_spawn, area.instances[1]);
 });
 
 test('convertLayoutToArea tolerates missing arrays', () => {
@@ -74,6 +81,10 @@ test('convertLayoutToArea normalizes area descriptors', () => {
   assert.equal(area.layers[0].parallaxSpeed, 0.5);
   assert.equal(area.instances[0].position.x, 120);
   assert.deepEqual(area.instances[0].tags, ['spawn:player']);
+  assert.equal(area.instances[0].instanceId, 'player_spawn');
+  assert.equal(area.instances[0].meta.identity.instanceId, 'player_spawn');
+  assert.equal(area.instances[0].meta.identity.source, 'tag:spawn:player');
+  assert.strictEqual(area.instancesById.player_spawn, area.instances[0]);
   assert.deepEqual(area.meta, { revision: 2 });
   assert.equal(area.warnings.length, 0);
 });
@@ -98,6 +109,9 @@ test('convertLayoutToArea generates fallback prefab art when prefab is missing',
 
   assert.equal(area.instances.length, 1);
   const inst = area.instances[0];
+  assert.equal(inst.instanceId, '42');
+  assert.strictEqual(area.instancesById['42'], inst);
+  assert.equal(inst.meta.identity.instanceId, '42');
   assert.equal(inst.prefabId, 'missing_prefab');
   assert.ok(inst.prefab);
   assert.equal(inst.prefab.id, 'missing_prefab');


### PR DESCRIPTION
## Summary
- add canonical instance ID resolution and lookup helpers to map conversion utilities
- ensure area descriptors expose `instancesById` and validate duplicate IDs in the map registry
- surface instance IDs throughout configuration and tests, including the default district layout

## Testing
- npm test *(fails: gates weapon collider activation on preset opt-in)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ecebd7cc8326abfd4f1bfd9fce4a)