### PR TITLE
Remove duplicate xform axis declarations in sprites

### DIFF
--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -592,8 +592,6 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
     ax *= bone.len;
     ay *= bone.len;
   }
-  const hasXformAx = Math.abs(ax) > 1e-6;
-  const hasXformAy = Math.abs(ay) > 1e-6;
   // Offsets in bone-local space
   const offsetX = ax * bAxis.fx + ay * bAxis.rx;
   const offsetY = ax * bAxis.fy + ay * bAxis.ry;


### PR DESCRIPTION
## Summary
- remove the second const declarations for the xform axis flags in docs/js/sprites.js to avoid duplicate identifier errors

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917f18c22488326acb7ed4d57cb2b51)