### PR TITLE
Remove redundant sprite offset block

### DIFF
--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -592,28 +592,11 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style, offsets){
     ax *= bone.len;
     ay *= bone.len;
   }
-  const hasXformAx = Math.abs(ax) > 1e-6;
-  const hasXformAy = Math.abs(ay) > 1e-6;
   // Offsets in bone-local space
   const offsetX = ax * bAxis.fx + ay * bAxis.rx;
   const offsetY = ax * bAxis.fy + ay * bAxis.ry;
   posX += offsetX;
   posY += offsetY;
-
-  const spriteOffset = lookupSpriteOffset(offsets, styleKey);
-  if (spriteOffset){
-    const units = (spriteOffset.units || '').toLowerCase();
-    let ox = spriteOffset.ax;
-    let oy = spriteOffset.ay;
-    const unitMode = units
-      || (xformUnits === 'percent' || xformUnits === '%' || xformUnits === 'pct' ? 'percent' : 'px');
-    if (unitMode === 'percent' || unitMode === '%' || unitMode === 'pct'){
-      ox *= bone.len;
-      oy *= bone.len;
-    }
-    posX += ox * bAxis.fx + oy * bAxis.rx;
-    posY += ox * bAxis.fy + oy * bAxis.ry;
-  }
 
   // Sizing
   const nh = sourceImage.naturalHeight || sourceImage.height || 1;


### PR DESCRIPTION
## Summary
- remove the earlier spriteOffset lookup block so the sprite renderer only declares the variable once

## Testing
- npm test *(fails: gates weapon collider activation on preset opt-in; Sarrarru weapon integration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917f18c22488326acb7ed4d57cb2b51)