### PR TITLE
Add loadout setup stage before demo launch

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -131,6 +131,110 @@
     </div>
   </div>
 
+  <div class="loadout-overlay" id="loadoutOverlay" role="dialog" aria-modal="true" aria-labelledby="loadoutTitle" hidden>
+    <div class="loadout-card">
+      <header class="loadout-header">
+        <h2 id="loadoutTitle">Player Loadout Setup</h2>
+        <p class="loadout-subtitle">Configure your fighter before entering the demo.</p>
+      </header>
+      <form id="loadoutForm" class="loadout-form" novalidate>
+        <section class="loadout-section" aria-labelledby="loadoutGeneralHeading">
+          <h3 id="loadoutGeneralHeading">General</h3>
+          <div class="loadout-grid">
+            <label class="loadout-field">
+              <span class="loadout-label">Fighter</span>
+              <select id="loadoutFighter" class="loadout-select"></select>
+            </label>
+            <label class="loadout-field">
+              <span class="loadout-label">Weapon</span>
+              <select id="loadoutWeapon" class="loadout-select"></select>
+            </label>
+          </div>
+        </section>
+
+        <section class="loadout-section" aria-labelledby="loadoutBodyColorsHeading">
+          <h3 id="loadoutBodyColorsHeading">Body Colors (HSV Adjustments)</h3>
+          <div class="loadout-bodycolors">
+            <div class="loadout-bodycolor" data-channel="A">
+              <header>A</header>
+              <label>Hue<input type="number" step="1" id="bodyColorA_h" class="loadout-number"></label>
+              <label>Saturation<input type="number" step="0.01" id="bodyColorA_s" class="loadout-number"></label>
+              <label>Value<input type="number" step="0.01" id="bodyColorA_v" class="loadout-number"></label>
+            </div>
+            <div class="loadout-bodycolor" data-channel="B">
+              <header>B</header>
+              <label>Hue<input type="number" step="1" id="bodyColorB_h" class="loadout-number"></label>
+              <label>Saturation<input type="number" step="0.01" id="bodyColorB_s" class="loadout-number"></label>
+              <label>Value<input type="number" step="0.01" id="bodyColorB_v" class="loadout-number"></label>
+            </div>
+            <div class="loadout-bodycolor" data-channel="C">
+              <header>C</header>
+              <label>Hue<input type="number" step="1" id="bodyColorC_h" class="loadout-number"></label>
+              <label>Saturation<input type="number" step="0.01" id="bodyColorC_s" class="loadout-number"></label>
+              <label>Value<input type="number" step="0.01" id="bodyColorC_v" class="loadout-number"></label>
+            </div>
+          </div>
+        </section>
+
+        <section class="loadout-section" aria-labelledby="loadoutClothesHeading">
+          <h3 id="loadoutClothesHeading">Clothing</h3>
+          <div class="loadout-clothing">
+            <div class="loadout-slot" data-slot="hat">
+              <header>Hat</header>
+              <label>Cosmetic ID<input type="text" class="loadout-text" data-slot-input="id"></label>
+              <label>Hue<input type="number" step="1" class="loadout-number" data-slot-input="h"></label>
+              <label>Saturation<input type="number" step="0.01" class="loadout-number" data-slot-input="s"></label>
+              <label>Value<input type="number" step="0.01" class="loadout-number" data-slot-input="v"></label>
+              <button type="button" class="loadout-clear" data-slot-action="clear">Clear</button>
+            </div>
+            <div class="loadout-slot" data-slot="overwear">
+              <header>Overwear</header>
+              <label>Cosmetic ID<input type="text" class="loadout-text" data-slot-input="id"></label>
+              <label>Hue<input type="number" step="1" class="loadout-number" data-slot-input="h"></label>
+              <label>Saturation<input type="number" step="0.01" class="loadout-number" data-slot-input="s"></label>
+              <label>Value<input type="number" step="0.01" class="loadout-number" data-slot-input="v"></label>
+              <button type="button" class="loadout-clear" data-slot-action="clear">Clear</button>
+            </div>
+            <div class="loadout-slot" data-slot="torso">
+              <header>Torso</header>
+              <label>Cosmetic ID<input type="text" class="loadout-text" data-slot-input="id"></label>
+              <label>Hue<input type="number" step="1" class="loadout-number" data-slot-input="h"></label>
+              <label>Saturation<input type="number" step="0.01" class="loadout-number" data-slot-input="s"></label>
+              <label>Value<input type="number" step="0.01" class="loadout-number" data-slot-input="v"></label>
+              <button type="button" class="loadout-clear" data-slot-action="clear">Clear</button>
+            </div>
+            <div class="loadout-slot" data-slot="legs">
+              <header>Legs</header>
+              <label>Cosmetic ID<input type="text" class="loadout-text" data-slot-input="id"></label>
+              <label>Hue<input type="number" step="1" class="loadout-number" data-slot-input="h"></label>
+              <label>Saturation<input type="number" step="0.01" class="loadout-number" data-slot-input="s"></label>
+              <label>Value<input type="number" step="0.01" class="loadout-number" data-slot-input="v"></label>
+              <button type="button" class="loadout-clear" data-slot-action="clear">Clear</button>
+            </div>
+          </div>
+        </section>
+
+        <section class="loadout-section" aria-labelledby="loadoutEntryHeading">
+          <h3 id="loadoutEntryHeading">Character Entry</h3>
+          <p class="loadout-entry-hint">Copy this entry to save your loadout or paste an entry to load it.</p>
+          <textarea id="loadoutEntry" class="loadout-entry" rows="10"></textarea>
+          <div class="loadout-entry-actions">
+            <button type="button" class="loadout-secondary" data-action="copy-entry">Copy Entry</button>
+            <button type="button" class="loadout-secondary" data-action="apply-entry">Apply From Entry</button>
+          </div>
+        </section>
+
+        <div class="loadout-status" id="loadoutStatus" role="status" aria-live="polite"></div>
+
+        <footer class="loadout-footer">
+          <button type="button" class="loadout-secondary" data-action="reset-defaults">Reset to Defaults</button>
+          <span class="loadout-spacer" aria-hidden="true"></span>
+          <button type="button" class="loadout-primary" data-action="launch">Start Demo with Loadout</button>
+        </footer>
+      </form>
+    </div>
+  </div>
+
   <button type="button" id="editorReturnBtn" class="editor-preview-return" hidden>← Return to Editor</button>
 
   <main class="stack">
@@ -358,8 +462,11 @@
       }
 
       const hideOverlay = () => {
+        if (!overlay) return;
         overlay.classList.add('entry-overlay--hidden');
-        setTimeout(() => overlay.remove(), 400);
+        setTimeout(() => {
+          if (overlay) overlay.hidden = true;
+        }, 400);
       };
 
       if (previewToken) {
@@ -374,27 +481,38 @@
             }
           });
         }
+        window.__skipLoadoutStage = true;
         hideOverlay();
         return;
       }
 
       if (defaultMode === 'game') {
+        window.__skipLoadoutStage = true;
         hideOverlay();
         return;
       }
 
       if (defaultMode === 'editor') {
+        window.__skipLoadoutStage = true;
         window.location.href = './cosmetic-editor.html';
         return;
       }
 
       if (defaultMode === 'map-editor') {
+        window.__skipLoadoutStage = true;
         window.location.href = './map-editor.html';
         return;
       }
 
       const launchBtn = document.getElementById('entryLaunchGame');
-      launchBtn?.addEventListener('click', hideOverlay);
+      launchBtn?.addEventListener('click', () => {
+        hideOverlay();
+        if (typeof window.__showLoadoutOverlay === 'function') {
+          window.__showLoadoutOverlay();
+        } else if (typeof window.__resolveLoadoutStage === 'function') {
+          window.__resolveLoadoutStage();
+        }
+      });
 
       // No additional handling for the editor link is needed now that the remember option is removed.
     })();
@@ -402,6 +520,7 @@
 
   <!-- In-repo config served same-origin under /docs -->
   <script src="./config/config.js"></script>
+  <script type="module" src="./js/loadout-stage.js?v=1"></script>
   <script type="module" src="./js/map-bootstrap.js?v=1"></script>
   <script type="module" src="./js/cosmetic-library.js?v=1"></script>
   <script type="module" src="./js/cosmetic-profiles.js?v=1"></script>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -2077,5 +2077,12 @@ function boot(){
   try { if (window.reloadConfig) await window.reloadConfig(); } catch(_){ }
   applyRenderOrder();
   await initSprites();
+  try {
+    if (typeof window !== 'undefined' && typeof window.__waitForLoadoutReady === 'function') {
+      await window.__waitForLoadoutReady();
+    }
+  } catch (error) {
+    console.warn('[app] Loadout stage failed to resolve', error);
+  }
   boot();
 })();

--- a/docs/js/loadout-stage.js
+++ b/docs/js/loadout-stage.js
@@ -1,0 +1,447 @@
+const ROOT = typeof window !== 'undefined' ? window : globalThis;
+const CONFIG = ROOT.CONFIG || {};
+const overlay = typeof document !== 'undefined' ? document.getElementById('loadoutOverlay') : null;
+const statusEl = overlay ? overlay.querySelector('#loadoutStatus') : null;
+const entryTextarea = overlay ? overlay.querySelector('#loadoutEntry') : null;
+const fighterSelect = overlay ? overlay.querySelector('#loadoutFighter') : null;
+const weaponSelect = overlay ? overlay.querySelector('#loadoutWeapon') : null;
+const formEl = overlay ? overlay.querySelector('#loadoutForm') : null;
+const slotContainers = overlay ? Array.from(overlay.querySelectorAll('.loadout-slot')) : [];
+const bodyColorInputs = overlay ? Array.from(overlay.querySelectorAll('.loadout-bodycolor')) : [];
+const DEFAULT_CHARACTER = cloneCharacter(CONFIG.characters?.player || {});
+
+let loadout = cloneCharacter(DEFAULT_CHARACTER);
+let resolveReady;
+let isResolved = false;
+
+const readyPromise = new Promise((resolve) => {
+  resolveReady = resolve;
+});
+
+function resolveStage() {
+  if (isResolved) return readyPromise;
+  isResolved = true;
+  if (typeof resolveReady === 'function') {
+    resolveReady();
+  }
+  return readyPromise;
+}
+
+function cloneCharacter(value) {
+  if (value === null || value === undefined) return value;
+  if (typeof value !== 'object') return value;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (_err) {
+    const copy = Array.isArray(value) ? [] : {};
+    for (const [key, val] of Object.entries(value)) {
+      if (val && typeof val === 'object') {
+        copy[key] = cloneCharacter(val);
+      } else {
+        copy[key] = val;
+      }
+    }
+    return copy;
+  }
+}
+
+function ensureSlots(target) {
+  if (!target || typeof target !== 'object') {
+    return {};
+  }
+  target.cosmetics ||= {};
+  target.cosmetics.slots ||= {};
+  return target.cosmetics.slots;
+}
+
+function ensureBodyColors(target) {
+  if (!target || typeof target !== 'object') {
+    return {};
+  }
+  target.bodyColors ||= {};
+  return target.bodyColors;
+}
+
+function setStatus(message, { tone = 'info' } = {}) {
+  if (!statusEl) return;
+  statusEl.textContent = message || '';
+  statusEl.dataset.tone = tone;
+}
+
+function formatNumber(value, { precision = 2 } = {}) {
+  if (!Number.isFinite(value)) return '';
+  const factor = 10 ** precision;
+  return String(Math.round(value * factor) / factor);
+}
+
+function updateEntryPreview() {
+  if (!entryTextarea) return;
+  try {
+    entryTextarea.value = JSON.stringify(loadout, null, 2);
+  } catch (error) {
+    console.warn('[loadout-stage] Failed to serialize loadout', error);
+  }
+}
+
+function populateFighterSelect() {
+  if (!fighterSelect) return;
+  fighterSelect.innerHTML = '';
+  const fighters = CONFIG.fighters || {};
+  const fighterKeys = Object.keys(fighters);
+  if (!fighterKeys.includes(loadout.fighter || '') && loadout.fighter) {
+    fighterKeys.push(loadout.fighter);
+  }
+  fighterKeys.sort();
+  const fragment = document.createDocumentFragment();
+  fighterKeys.forEach((key) => {
+    const option = document.createElement('option');
+    option.value = key;
+    option.textContent = key;
+    fragment.appendChild(option);
+  });
+  fighterSelect.appendChild(fragment);
+  const selected = loadout.fighter || fighterSelect.options[0]?.value || '';
+  fighterSelect.value = selected;
+  loadout.fighter = fighterSelect.value || selected || null;
+}
+
+function populateWeaponSelect() {
+  if (!weaponSelect) return;
+  weaponSelect.innerHTML = '';
+  const weapons = CONFIG.weapons || {};
+  const weaponKeys = Object.keys(weapons);
+  if (!weaponKeys.includes(loadout.weapon || '') && loadout.weapon) {
+    weaponKeys.push(loadout.weapon);
+  }
+  weaponKeys.sort();
+  const fragment = document.createDocumentFragment();
+  weaponKeys.forEach((key) => {
+    const option = document.createElement('option');
+    option.value = key;
+    option.textContent = key;
+    fragment.appendChild(option);
+  });
+  weaponSelect.appendChild(fragment);
+  const preferred = loadout.weapon || 'unarmed';
+  const hasPreferred = preferred
+    && Array.from(weaponSelect.options).some((option) => option.value === preferred);
+  const selected = hasPreferred ? preferred : (weaponSelect.options[0]?.value || '');
+  weaponSelect.value = selected;
+  loadout.weapon = weaponSelect.value || selected || null;
+}
+
+function hydrateBodyColorInputs() {
+  if (!bodyColorInputs.length) return;
+  const colors = loadout.bodyColors || {};
+  bodyColorInputs.forEach((container) => {
+    const channel = container.dataset.channel;
+    const values = (channel && colors[channel]) || {};
+    const inputH = container.querySelector('input[id$="_h"]');
+    const inputS = container.querySelector('input[id$="_s"]');
+    const inputV = container.querySelector('input[id$="_v"]');
+    if (inputH) inputH.value = values.h != null ? formatNumber(values.h, { precision: 2 }) : '';
+    if (inputS) inputS.value = values.s != null ? formatNumber(values.s, { precision: 3 }) : '';
+    if (inputV) inputV.value = values.v != null ? formatNumber(values.v, { precision: 3 }) : '';
+  });
+}
+
+function hydrateSlotInputs() {
+  if (!slotContainers.length) return;
+  const slots = (loadout.cosmetics && loadout.cosmetics.slots) || {};
+  slotContainers.forEach((container) => {
+    const slotKey = container.dataset.slot;
+    const slotData = slotKey ? slots[slotKey] : null;
+    const idInput = container.querySelector('[data-slot-input="id"]');
+    const hInput = container.querySelector('[data-slot-input="h"]');
+    const sInput = container.querySelector('[data-slot-input="s"]');
+    const vInput = container.querySelector('[data-slot-input="v"]');
+    const hsv = slotData && slotData.hsv ? slotData.hsv : {};
+    if (idInput) idInput.value = slotData?.id || '';
+    if (hInput) hInput.value = hsv.h != null ? formatNumber(hsv.h, { precision: 2 }) : '';
+    if (sInput) sInput.value = hsv.s != null ? formatNumber(hsv.s, { precision: 3 }) : '';
+    if (vInput) vInput.value = hsv.v != null ? formatNumber(hsv.v, { precision: 3 }) : '';
+  });
+}
+
+function hydrateForm() {
+  populateFighterSelect();
+  populateWeaponSelect();
+  hydrateBodyColorInputs();
+  hydrateSlotInputs();
+  updateEntryPreview();
+}
+
+function parseNumberInput(value) {
+  if (value === '' || value == null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function onBodyColorChange(channel, component, inputEl) {
+  if (!channel || !component) return;
+  const value = parseNumberInput(inputEl.value);
+  const colors = ensureBodyColors(loadout);
+  if (value === null || Number.isNaN(value)) {
+    if (colors[channel]) {
+      delete colors[channel][component];
+      if (!Object.keys(colors[channel]).length) {
+        delete colors[channel];
+      }
+    }
+  } else {
+    colors[channel] ||= {};
+    colors[channel][component] = value;
+  }
+  if (!Object.keys(colors).length) {
+    delete loadout.bodyColors;
+  }
+  updateEntryPreview();
+}
+
+function onSlotInputChange(slotKey, part, inputEl) {
+  if (!slotKey || !part) return;
+  const slots = ensureSlots(loadout);
+  const current = slots[slotKey] ||= { id: '' };
+  if (part === 'id') {
+    const id = inputEl.value.trim();
+    if (!id) {
+      delete slots[slotKey];
+      if (!Object.keys(slots).length) {
+        delete loadout.cosmetics;
+      }
+    } else {
+      current.id = id;
+    }
+  } else {
+    current.id ||= '';
+    current.hsv ||= {};
+    const value = parseNumberInput(inputEl.value);
+    if (value === null) {
+      delete current.hsv[part];
+    } else {
+      current.hsv[part] = value;
+    }
+    if (current.hsv && !Object.keys(current.hsv).length) {
+      delete current.hsv;
+    }
+  }
+  updateEntryPreview();
+}
+
+function clearSlot(slotKey) {
+  const slots = ensureSlots(loadout);
+  delete slots[slotKey];
+  if (!Object.keys(slots).length) {
+    delete loadout.cosmetics;
+  }
+  hydrateSlotInputs();
+  updateEntryPreview();
+}
+
+function bindEvents() {
+  if (fighterSelect) {
+    fighterSelect.addEventListener('change', (event) => {
+      loadout.fighter = event.target.value || null;
+      updateEntryPreview();
+    });
+  }
+
+  if (weaponSelect) {
+    weaponSelect.addEventListener('change', (event) => {
+      loadout.weapon = event.target.value || null;
+      updateEntryPreview();
+    });
+  }
+
+  bodyColorInputs.forEach((container) => {
+    const channel = container.dataset.channel;
+    const inputH = container.querySelector('input[id$="_h"]');
+    const inputS = container.querySelector('input[id$="_s"]');
+    const inputV = container.querySelector('input[id$="_v"]');
+    if (inputH) {
+      inputH.addEventListener('input', () => onBodyColorChange(channel, 'h', inputH));
+    }
+    if (inputS) {
+      inputS.addEventListener('input', () => onBodyColorChange(channel, 's', inputS));
+    }
+    if (inputV) {
+      inputV.addEventListener('input', () => onBodyColorChange(channel, 'v', inputV));
+    }
+  });
+
+  slotContainers.forEach((container) => {
+    const slotKey = container.dataset.slot;
+    const idInput = container.querySelector('[data-slot-input="id"]');
+    const hInput = container.querySelector('[data-slot-input="h"]');
+    const sInput = container.querySelector('[data-slot-input="s"]');
+    const vInput = container.querySelector('[data-slot-input="v"]');
+    const clearBtn = container.querySelector('[data-slot-action="clear"]');
+    if (idInput) {
+      idInput.addEventListener('input', () => onSlotInputChange(slotKey, 'id', idInput));
+    }
+    if (hInput) {
+      hInput.addEventListener('input', () => onSlotInputChange(slotKey, 'h', hInput));
+    }
+    if (sInput) {
+      sInput.addEventListener('input', () => onSlotInputChange(slotKey, 's', sInput));
+    }
+    if (vInput) {
+      vInput.addEventListener('input', () => onSlotInputChange(slotKey, 'v', vInput));
+    }
+    if (clearBtn) {
+      clearBtn.addEventListener('click', () => clearSlot(slotKey));
+    }
+  });
+
+  if (formEl) {
+    formEl.addEventListener('submit', (event) => {
+      event.preventDefault();
+    });
+  }
+
+  if (overlay) {
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) {
+        setStatus('Click "Start Demo" to continue into the game.', { tone: 'info' });
+      }
+    });
+  }
+
+  if (entryTextarea) {
+    entryTextarea.addEventListener('input', () => {
+      setStatus('Entry changed – click "Apply From Entry" to load it.', { tone: 'info' });
+    });
+  }
+
+  if (overlay) {
+    overlay.querySelector('[data-action="copy-entry"]')?.addEventListener('click', async () => {
+      if (!entryTextarea) return;
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(entryTextarea.value);
+        } else {
+          entryTextarea.select();
+          document.execCommand('copy');
+          entryTextarea.setSelectionRange(entryTextarea.value.length, entryTextarea.value.length);
+        }
+        setStatus('Character entry copied to clipboard.', { tone: 'success' });
+      } catch (error) {
+        console.warn('[loadout-stage] Clipboard copy failed', error);
+        setStatus('Unable to copy to clipboard. Select the text manually.', { tone: 'warning' });
+      }
+    });
+
+    overlay.querySelector('[data-action="apply-entry"]')?.addEventListener('click', () => {
+      if (!entryTextarea) return;
+      try {
+        const parsed = JSON.parse(entryTextarea.value);
+        if (!parsed || typeof parsed !== 'object') {
+          throw new Error('Entry must be an object');
+        }
+        loadout = cloneCharacter(parsed);
+        hydrateForm();
+        setStatus('Entry applied successfully.', { tone: 'success' });
+      } catch (error) {
+        console.warn('[loadout-stage] Failed to apply entry', error);
+        setStatus('Unable to parse entry. Ensure it is valid JSON.', { tone: 'error' });
+      }
+    });
+
+    overlay.querySelector('[data-action="reset-defaults"]')?.addEventListener('click', () => {
+      loadout = cloneCharacter(DEFAULT_CHARACTER);
+      hydrateForm();
+      setStatus('Reset to default player configuration.', { tone: 'info' });
+    });
+
+    overlay.querySelector('[data-action="launch"]')?.addEventListener('click', () => {
+      applyLoadoutToConfig();
+      hideOverlay();
+      setStatus('Starting demo with configured loadout…', { tone: 'success' });
+      resolveStage();
+    });
+  }
+}
+
+function applyLoadoutToConfig() {
+  ROOT.CONFIG ||= {};
+  ROOT.CONFIG.characters ||= {};
+  ROOT.CONFIG.characters.player = cloneCharacter(loadout);
+  ROOT.GAME ||= {};
+  ROOT.GAME.selectedCharacter = 'player';
+  ROOT.GAME.selectedFighter = loadout.fighter || null;
+  if (loadout.bodyColors) {
+    try {
+      ROOT.GAME.selectedBodyColors = JSON.parse(JSON.stringify(loadout.bodyColors));
+    } catch (_err) {
+      ROOT.GAME.selectedBodyColors = cloneCharacter(loadout.bodyColors);
+    }
+    ROOT.GAME.selectedBodyColorsFighter = loadout.fighter || null;
+  } else {
+    delete ROOT.GAME.selectedBodyColors;
+    delete ROOT.GAME.selectedBodyColorsFighter;
+  }
+  if (loadout.cosmetics) {
+    try {
+      ROOT.GAME.selectedCosmetics = JSON.parse(JSON.stringify(loadout.cosmetics));
+    } catch (_err) {
+      ROOT.GAME.selectedCosmetics = cloneCharacter(loadout.cosmetics);
+    }
+  } else {
+    delete ROOT.GAME.selectedCosmetics;
+  }
+  ROOT.GAME.selectedWeapon = loadout.weapon || null;
+}
+
+function hideOverlay() {
+  if (!overlay) return;
+  overlay.classList.remove('loadout-overlay--visible');
+  overlay.hidden = true;
+}
+
+function showOverlay() {
+  if (!overlay) {
+    resolveStage();
+    return;
+  }
+  hydrateForm();
+  overlay.hidden = false;
+  overlay.classList.add('loadout-overlay--visible');
+  setStatus('Configure your fighter and click "Start Demo".', { tone: 'info' });
+  if (fighterSelect) {
+    requestAnimationFrame(() => {
+      try {
+        fighterSelect.focus();
+      } catch (_err) {
+        // ignore focus errors
+      }
+    });
+  }
+}
+
+function init() {
+  if (!overlay || ROOT.__skipLoadoutStage) {
+    resolveStage();
+    return;
+  }
+  bindEvents();
+  hydrateForm();
+  hideOverlay();
+  setStatus('');
+}
+
+if (!ROOT.__waitForLoadoutReady) {
+  ROOT.__waitForLoadoutReady = () => readyPromise;
+} else {
+  const previous = ROOT.__waitForLoadoutReady;
+  ROOT.__waitForLoadoutReady = async () => {
+    await previous();
+    await readyPromise;
+  };
+}
+
+ROOT.__resolveLoadoutStage = resolveStage;
+ROOT.__showLoadoutOverlay = showOverlay;
+
+init();
+
+export {};

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -46,6 +46,252 @@ body{
   pointer-events:none;
 }
 
+.loadout-overlay{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:32px clamp(12px,4vw,40px);
+  background:radial-gradient(circle at center, rgba(2,6,14,0.92) 0%, rgba(5,7,13,0.98) 70%);
+  backdrop-filter:blur(6px);
+  z-index:998;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity 0.25s ease;
+}
+
+.loadout-overlay--visible{
+  opacity:1;
+  pointer-events:auto;
+}
+
+.loadout-card{
+  width:min(860px, calc(100% - 24px));
+  max-height:calc(100vh - 64px);
+  border-radius:22px;
+  border:1px solid rgba(148,163,184,0.28);
+  background:linear-gradient(165deg, rgba(15,23,42,0.96), rgba(9,9,11,0.94));
+  box-shadow:0 30px 90px rgba(0,0,0,0.65);
+  display:flex;
+  flex-direction:column;
+}
+
+.loadout-header{
+  padding:28px clamp(20px,5vw,36px) 16px;
+  border-bottom:1px solid rgba(71,85,105,0.35);
+}
+
+.loadout-header h2{
+  margin:0 0 6px;
+  font-size:clamp(22px, 3vw, 28px);
+}
+
+.loadout-subtitle{
+  margin:0;
+  color:var(--muted);
+  font-size:14px;
+}
+
+.loadout-form{
+  overflow-y:auto;
+  padding:0 clamp(20px, 5vw, 36px) 28px;
+  display:flex;
+  flex-direction:column;
+  gap:24px;
+}
+
+.loadout-section h3{
+  margin:0 0 12px;
+  font-size:16px;
+  letter-spacing:0.2px;
+}
+
+.loadout-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(200px, 1fr));
+  gap:16px;
+}
+
+.loadout-field{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  font-size:14px;
+  color:var(--muted);
+}
+
+.loadout-label{font-weight:600;color:var(--fg);font-size:14px;}
+
+.loadout-select,
+.loadout-number,
+.loadout-text,
+.loadout-entry{
+  width:100%;
+  border-radius:10px;
+  border:1px solid rgba(148,163,184,0.35);
+  background:rgba(15,23,42,0.6);
+  color:var(--fg);
+  font:14px/1.35 inherit;
+  padding:10px 12px;
+  transition:border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.loadout-select:focus,
+.loadout-number:focus,
+.loadout-text:focus,
+.loadout-entry:focus{
+  outline:none;
+  border-color:rgba(96,165,250,0.75);
+  box-shadow:0 0 0 3px rgba(96,165,250,0.25);
+}
+
+.loadout-number{appearance:textfield;}
+.loadout-number::-webkit-outer-spin-button,
+.loadout-number::-webkit-inner-spin-button{appearance:none;margin:0;}
+
+.loadout-bodycolors{
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(160px,1fr));
+  gap:16px;
+}
+
+.loadout-bodycolor{
+  border:1px solid rgba(148,163,184,0.25);
+  border-radius:14px;
+  padding:16px;
+  display:grid;
+  gap:10px;
+  background:rgba(30,41,59,0.45);
+}
+
+.loadout-bodycolor header{
+  font-weight:700;
+  font-size:14px;
+  color:var(--fg);
+}
+
+.loadout-bodycolor label{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:13px;
+  color:var(--muted);
+}
+
+.loadout-clothing{
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(180px,1fr));
+  gap:18px;
+}
+
+.loadout-slot{
+  border:1px solid rgba(148,163,184,0.25);
+  border-radius:14px;
+  padding:16px;
+  display:grid;
+  gap:10px;
+  background:rgba(30,41,59,0.45);
+}
+
+.loadout-slot header{
+  font-weight:700;
+  font-size:14px;
+  color:var(--fg);
+}
+
+.loadout-slot label{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:13px;
+  color:var(--muted);
+}
+
+.loadout-clear{
+  justify-self:flex-start;
+  padding:6px 10px;
+  border-radius:8px;
+  border:1px solid rgba(248,113,113,0.45);
+  background:rgba(127,29,29,0.25);
+  color:#fecaca;
+  font-size:12px;
+  font-weight:600;
+  cursor:pointer;
+  transition:background 0.2s ease, border-color 0.2s ease;
+}
+
+.loadout-clear:hover{background:rgba(127,29,29,0.35);border-color:rgba(248,113,113,0.65);}
+
+.loadout-entry{min-height:180px;resize:vertical;}
+
+.loadout-entry-hint{
+  margin:0 0 10px;
+  color:var(--muted);
+  font-size:13px;
+}
+
+.loadout-entry-actions{
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+}
+
+.loadout-primary,
+.loadout-secondary{
+  border-radius:12px;
+  padding:10px 18px;
+  font-size:14px;
+  font-weight:600;
+  cursor:pointer;
+  border:1px solid transparent;
+  transition:transform 0.12s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.loadout-primary{
+  background:linear-gradient(135deg,#2563eb,#60a5fa);
+  border-color:rgba(59,130,246,0.65);
+  color:#f8fafc;
+  box-shadow:0 16px 48px rgba(37,99,235,0.35);
+}
+
+.loadout-primary:hover{background:linear-gradient(135deg,#1d4ed8,#3b82f6);}
+
+.loadout-secondary{
+  background:rgba(15,23,42,0.45);
+  border-color:rgba(148,163,184,0.4);
+  color:var(--fg);
+}
+
+.loadout-secondary:hover{background:rgba(15,23,42,0.6);}
+
+.loadout-primary:active,
+.loadout-secondary:active{transform:translateY(1px);}
+
+.loadout-footer{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  margin-top:4px;
+}
+
+.loadout-spacer{flex:1 1 auto;}
+
+.loadout-status{
+  min-height:24px;
+  font-size:13px;
+  color:var(--muted);
+}
+
+.loadout-status[data-tone="success"]{color:#bbf7d0;}
+.loadout-status[data-tone="error"]{color:#fecaca;}
+.loadout-status[data-tone="warning"]{color:#fde68a;}
+
+@media (max-width:720px){
+  .loadout-card{width:100%;max-height:100vh;border-radius:0;}
+  .loadout-form{padding-inline:20px;padding-bottom:24px;}
+}
+
 .editor-preview-return{
   position:fixed;
   top:18px;


### PR DESCRIPTION
## Summary
- add a pre-game loadout overlay that lets players edit fighter, body colors, and clothing before launching the demo
- introduce a dedicated loadout-stage module that serializes loadouts to JSON, handles imports, and updates the runtime/config state before boot
- extend the game bootstrap to wait on the loadout stage and style the new overlay

## Testing
- npm test *(fails: existing sarrarru weapon integration test expects weapon collider opt-in wiring)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917eb19dc9c8326b9a52e47574416f4)