### PR TITLE
Add canvas preview to animation editor timeline

### DIFF
--- a/docs/animation-editor.css
+++ b/docs/animation-editor.css
@@ -62,6 +62,14 @@ main.animation-editor {
   display: none;
 }
 
+.preview-stage canvas.is-visible {
+  display: block;
+}
+
+.preview-placeholder.is-hidden {
+  display: none;
+}
+
 .preview-placeholder {
   text-align: center;
   font-size: 14px;
@@ -151,6 +159,11 @@ main.animation-editor {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.panel[aria-disabled="true"] {
+  opacity: 0.45;
+  pointer-events: none;
 }
 
 .panel h2 {


### PR DESCRIPTION
## Summary
- add a canvas-driven timeline preview that visualizes move durations and attack sequences
- toggle the preview placeholder/canvas state and add disabled styling for inactive panels
- normalize move durations before rendering and sync preview updates when editing JSON or tags

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918226bf1fc83269bc0f720cf625930)