### PR TITLE
Add citywatch helmet to cosmetic library manifest

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -173,6 +173,7 @@ const COSMETIC_PROFILE_SOURCES = {
 
 const COSMETIC_LIBRARY_SOURCES = {
   basic_headband: './config/cosmetics/basic_headband.json',
+  citywatch_helmet: './config/cosmetics/citywatch_helmet.json',
   layered_travel_cloak: './config/cosmetics/layered_travel_cloak.json',
   simple_poncho: './config/cosmetics/simple_poncho.json',
   basic_pants: './config/cosmetics/basic_pants.json',


### PR DESCRIPTION
## Summary
- register the citywatch helmet cosmetic in the library sources so it can be loaded

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186fc11654832696a972702c81fdf9)