### PR TITLE
Remove legacy sprite offset integration

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -479,14 +479,6 @@ window.CONFIG = {
         leg: { upper:{ origin:{ax:0, ay:0}, knee:{ax:0, ay:0}  }, lower:{ origin:{ax:0, ay:0} } },
         head:{ origin:{ax:-1, ay:6} }
       },
-      spriteOffsets: {
-        torso:    { ax:0,  ay:0, units: 'percent' },
-        head:     { ax:0, ay:0, units: 'percent' },
-        armUpper: { ax:0,     ay:0,     units: 'percent' },
-        armLower: { ax:0,     ay:0,     units: 'percent' },
-        legUpper: { ax:0, ay:0,  units: 'percent' },
-        legLower: { ax:0,  ay:0,  units: 'percent' }
-      },
       sprites: {
         torso: { url: "./assets/fightersprites/tletingan/torso_mint.png", bodyColor: 'A' },
         head:  { url: "./assets/fightersprites/tletingan/head_mint.png", bodyColor: 'A' },
@@ -546,14 +538,6 @@ window.CONFIG = {
         arm: { upper:{ origin:{ax:0, ay:0}, elbow:{ax:0, ay:0} }, lower:{ origin:{ax:0, ay:0} } },
         leg: { upper:{ origin:{ax:0, ay:0}, knee:{ax:0, ay:0}  }, lower:{ origin:{ax:0, ay:0} } },
         head:{ origin:{ax:0, ay:0} }
-      },
-      spriteOffsets: {
-        torso:    { ax:0,     ay:0, units: 'percent' },
-        head:     { ax:0, ay:0.0, units: 'percent' },
-        armUpper: { ax:0, ay:0,  units: 'percent' },
-        armLower: { ax:0, ay:0,    units: 'percent' },
-        legUpper: { ax:-0, ay:0,   units: 'percent' },
-        legLower: { ax:0,     ay:0, units: 'percent' }
       },
       sprites: {
         torso: { url: "./assets/fightersprites/mao-ao-m/torso_mint.png", bodyColor: 'A' },

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -331,7 +331,7 @@ test('default character pants tint to blue for player and red for enemy', () => 
 test('sprites.js integrates cosmetic layers and z-order expansion', () => {
   const spritesContent = readFileSync(new URL('../docs/js/sprites.js', import.meta.url), 'utf8');
   strictEqual(/expanded\.push\(cosmeticTagFor\(tag, slot\)\);/.test(spritesContent), true, 'buildZMap should add cosmetic tags');
-  strictEqual(/const \{ assets, style, offsets, cosmetics(?:, bodyColors)?(?:, untintedOverlays: [^}]+)? } = ensureFighterSprites/.test(spritesContent), true, 'renderSprites should read cosmetics');
+  strictEqual(/const \{ assets, style, cosmetics(?:, bodyColors)?(?:, untintedOverlays: [^}]+)? } = ensureFighterSprites/.test(spritesContent), true, 'renderSprites should read cosmetics');
   strictEqual(/withBranchMirror\(ctx,\s*originX,\s*mirror,\s*\(\)\s*=>\s*\{\s*drawBoneSprite\(ctx, layer\.asset, bone, styleKey/.test(spritesContent), true, 'cosmetic layers should mirror with their limbs');
 });
 

--- a/tests/sprite-style-location.test.js
+++ b/tests/sprite-style-location.test.js
@@ -73,13 +73,8 @@ describe('Sprite style configuration location', () => {
       'Should check f.spriteStyle before C.spriteStyle');
   });
 
-  it('ensureFighterSprites looks for offsets in fighter config first', () => {
-    // Check that ensureFighterSprites function looks for f.spriteOffsets
-    const hasFighterOffsetsLookup = /f\.spriteOffsets/.test(spritesContent);
-    strictEqual(hasFighterOffsetsLookup, true, 'ensureFighterSprites should check f.spriteOffsets');
-    
-    // Should fallback to C.spriteOffsets
-    const hasGlobalOffsetsFallback = /C\.spriteOffsets/.test(spritesContent);
-    strictEqual(hasGlobalOffsetsFallback, true, 'ensureFighterSprites should fallback to C.spriteOffsets');
+  it('ensureFighterSprites does not rely on legacy spriteOffsets config', () => {
+    const referencesSpriteOffsets = /spriteOffsets/.test(spritesContent);
+    strictEqual(referencesSpriteOffsets, false, 'ensureFighterSprites should not read spriteOffsets');
   });
 });

--- a/tests/v20-orientation.test.js
+++ b/tests/v20-orientation.test.js
@@ -117,7 +117,7 @@ test('sprites.js does not apply per-sprite facing flip', async () => {
   // Check that drawBoneSprite does not have facingFlip parameter
   assert.match(
     source,
-    /function drawBoneSprite\(ctx,\s*asset,\s*bone,\s*styleKey,\s*style,\s*offsets\)\s*{/,
+    /function drawBoneSprite\(ctx,\s*asset,\s*bone,\s*styleKey,\s*style\)\s*{/,
     'drawBoneSprite() should not have facingFlip parameter'
   );
   
@@ -156,7 +156,7 @@ test('sprites.js drawArmBranch does not have facingFlip parameter', async () => 
   
   assert.match(
     source,
-    /function drawArmBranch\(ctx,\s*rig,\s*side,\s*assets,\s*style,\s*offsets,\s*segment\s*=\s*['"]both['"]\)\s*{/,
+    /function drawArmBranch\(ctx,\s*rig,\s*side,\s*assets,\s*style,\s*segment\s*=\s*['"]both['"]\)\s*{/,
     'drawArmBranch() should not have facingFlip parameter'
   );
 });
@@ -166,7 +166,7 @@ test('sprites.js drawLegBranch does not have facingFlip parameter', async () => 
   
   assert.match(
     source,
-    /function drawLegBranch\(ctx,\s*rig,\s*side,\s*assets,\s*style,\s*offsets,\s*segment\s*=\s*['"]both['"]\)\s*{/,
+    /function drawLegBranch\(ctx,\s*rig,\s*side,\s*assets,\s*style,\s*segment\s*=\s*['"]both['"]\)\s*{/,
     'drawLegBranch() should not have facingFlip parameter'
   );
 });


### PR DESCRIPTION
## Summary
- remove legacy spriteOffsets lookups so spriteStyle ax/ay drive positioning
- delete spriteOffsets blocks from fighter configs and adapt tests
- refresh sprite-related tests to assert the pipeline no longer references offsets

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186f60a1b88326b6b6bb8ec0e6d420)