### PR TITLE
Restrict cosmetic transform overrides to allowed sources

### DIFF
--- a/docs/js/cosmetics.js
+++ b/docs/js/cosmetics.js
@@ -10,6 +10,8 @@ const STATE = (ROOT.COSMETIC_SYSTEM ||= {
   profiles: new Map()
 });
 
+const TRANSFORM_OVERRIDE_KEYS = new Set(['spriteStyle', 'warp', 'anchor', 'align', 'styleKey']);
+
 export function getRegisteredCosmeticLibrary(){
   const entries = Object.entries(STATE.library || {});
   const out = {};
@@ -52,6 +54,47 @@ function mergeConfig(baseValue, override){
     return deepMerge(baseValue, override);
   }
   return override;
+}
+
+function sanitizeOverrideObject(override, { allowTransforms = false } = {}){
+  if (!override || typeof override !== 'object'){
+    return null;
+  }
+  const cloned = deepMerge({}, override);
+  if (!allowTransforms){
+    for (const key of TRANSFORM_OVERRIDE_KEYS){
+      if (key in cloned){
+        delete cloned[key];
+      }
+    }
+  }
+  if (cloned.layers && typeof cloned.layers === 'object' && !Array.isArray(cloned.layers)){
+    for (const [layerKey, layerOverride] of Object.entries(cloned.layers)){
+      const sanitizedLayer = sanitizeOverrideObject(layerOverride, { allowTransforms });
+      if (sanitizedLayer){
+        cloned.layers[layerKey] = sanitizedLayer;
+      } else {
+        delete cloned.layers[layerKey];
+      }
+    }
+    if (!Object.keys(cloned.layers).length){
+      delete cloned.layers;
+    }
+  }
+  if (cloned.parts && typeof cloned.parts === 'object' && !Array.isArray(cloned.parts)){
+    for (const [partKey, partOverride] of Object.entries(cloned.parts)){
+      const sanitizedPart = sanitizeOverrideObject(partOverride, { allowTransforms });
+      if (sanitizedPart){
+        cloned.parts[partKey] = sanitizedPart;
+      } else {
+        delete cloned.parts[partKey];
+      }
+    }
+    if (!Object.keys(cloned.parts).length){
+      delete cloned.parts;
+    }
+  }
+  return Object.keys(cloned).length ? cloned : null;
 }
 
 export function registerFighterCosmeticProfile(fighterName, profile = {}){
@@ -823,6 +866,24 @@ export function ensureCosmeticLayers(config = {}, fighterName, baseStyle = {}, o
     if (!cosmetic) continue;
     const slotOverride = editorState?.slotOverrides?.[slot];
     const isAppearance = slot.startsWith(APPEARANCE_SLOT_PREFIX) || cosmetic?.type === 'appearance' || !!cosmetic?.appearance;
+    const sanitizedSlotOverride = sanitizeOverrideObject(slotOverride, { allowTransforms: false });
+    const slotBaseOverride = sanitizedSlotOverride
+      ? (() => {
+        const { layers: _ignoredLayers, parts: _ignoredParts, ...base } = sanitizedSlotOverride;
+        return Object.keys(base).length ? base : null;
+      })()
+      : null;
+    const slotLayerOverrides = sanitizedSlotOverride?.layers || {};
+    const slotPartOverrides = sanitizedSlotOverride?.parts || {};
+    const sanitizedFighterOverride = sanitizeOverrideObject(equipped.fighterOverrides, { allowTransforms: !isAppearance });
+    const fighterBaseOverride = sanitizedFighterOverride
+      ? (() => {
+        const { layers: _ignoredLayers, parts: _ignoredParts, ...base } = sanitizedFighterOverride;
+        return Object.keys(base).length ? base : null;
+      })()
+      : null;
+    const fighterLayerOverrides = sanitizedFighterOverride?.layers || {};
+    const fighterPartOverrides = sanitizedFighterOverride?.parts || {};
     const equippedTint = equipped.hsl ?? equipped.hsv;
     let slotHSL = isAppearance
       ? resolveAppearanceBaseHSL(equipped, cosmetic, bodyColors)
@@ -840,7 +901,8 @@ export function ensureCosmeticLayers(config = {}, fighterName, baseStyle = {}, o
     for (const [partKey, partConfig] of Object.entries(cosmetic.parts || {})){
       const partLayers = resolvePartLayers(partKey, partConfig, fighterName, cosmetic.id);
       if (!Array.isArray(partLayers) || partLayers.length === 0) continue;
-      const partOverride = slotOverride?.parts?.[partKey];
+      const fighterPartOverride = fighterPartOverrides?.[partKey];
+      const slotPartOverride = slotPartOverrides?.[partKey];
       for (const { position, config: baseLayerConfig } of partLayers){
         if (!baseLayerConfig) continue;
         const layerPosition = position || 'front';
@@ -853,8 +915,10 @@ export function ensureCosmeticLayers(config = {}, fighterName, baseStyle = {}, o
           align: baseLayerConfig.align ? deepMerge({}, baseLayerConfig.align) : baseLayerConfig.align,
           extra: baseLayerConfig.extra ? deepMerge({}, baseLayerConfig.extra) : {}
         };
-        const slotLayerOverride = slotOverride?.layers?.[layerPosition];
-        const partLayerOverride = partOverride?.layers?.[layerPosition];
+        const fighterLayerOverride = fighterLayerOverrides?.[layerPosition];
+        const slotLayerOverride = slotLayerOverrides?.[layerPosition];
+        const fighterPartLayerOverride = fighterPartOverride?.layers?.[layerPosition];
+        const slotPartLayerOverride = slotPartOverride?.layers?.[layerPosition];
 
         let styleOverride = resolved.spriteStyle;
         let warpOverride = resolved.warp;
@@ -900,10 +964,14 @@ export function ensureCosmeticLayers(config = {}, fighterName, baseStyle = {}, o
           }
         };
 
-        applyOverrides(slotOverride, { applyTint: false });
+        applyOverrides(fighterBaseOverride, { applyTint: true });
+        applyOverrides(fighterLayerOverride, { applyTint: true });
+        applyOverrides(fighterPartOverride, { applyTint: true });
+        applyOverrides(fighterPartLayerOverride, { applyTint: true });
+        applyOverrides(slotBaseOverride, { applyTint: false });
         applyOverrides(slotLayerOverride, { applyTint: false });
-        applyOverrides(partOverride, { applyTint: true });
-        applyOverrides(partLayerOverride, { applyTint: true });
+        applyOverrides(slotPartOverride, { applyTint: true });
+        applyOverrides(slotPartLayerOverride, { applyTint: true });
 
         if (!resolved?.image?.url) continue;
         const asset = ensureAsset(cosmetic.id, partKey, resolved.image, layerPosition);

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -4,6 +4,11 @@ import { COSMETIC_SLOTS, cosmeticTagFor, ensureCosmeticLayers, clearCosmeticCach
 import { clearPaletteCache } from '../docs/js/cosmetic-palettes.js';
 import { readFileSync } from 'node:fs';
 
+function readXform(layer, partKey, axis){
+  return layer?.styleOverride?.base?.xform?.[partKey]?.[axis]
+    ?? layer?.styleOverride?.xform?.[partKey]?.[axis];
+}
+
 const EXPECTED_SLOTS = [
   'hat',
   'hood',
@@ -219,6 +224,168 @@ test('appearance cosmetics inherit character body colors', () => {
   deepStrictEqual(layers[0].extra?.appearance?.bodyColors, ['A']);
   strictEqual(layers[0].styleKey, 'torso');
   strictEqual(layers[0].asset.alignRad, undefined);
+});
+
+test('runtime slot overrides cannot mutate cosmetic transforms', () => {
+  clearCosmeticCache();
+  clearPaletteCache();
+  const previousWindow = globalThis.window;
+  try {
+    globalThis.window = {
+      GAME: {
+        editorState: {
+          slotOverrides: {
+            hat: {
+              spriteStyle: { base: { xform: { head: { ax: 90 } } } },
+              layers: {
+                front: { spriteStyle: { base: { xform: { head: { ay: -12 } } } } }
+              },
+              hsl: { h: 45, s: 0.1, l: 0.2 }
+            }
+          }
+        }
+      }
+    };
+
+    const config = {
+      cosmeticLibrary: {
+        rigid_hat: {
+          slot: 'hat',
+          hsl: {
+            defaults: { h: 0, s: 0, l: 0 },
+            limits: { h: [-180, 180], s: [-1, 1], l: [-1, 1] }
+          },
+          parts: {
+            head: {
+              image: { url: 'https://example.com/hat.png' },
+              spriteStyle: { base: { xform: { head: { ax: 3 } } } }
+            }
+          }
+        }
+      },
+      fighters: {
+        hero: {
+          cosmetics: {
+            slots: {
+              hat: { id: 'rigid_hat', hsl: { h: 0, s: 0, l: 0 } }
+            }
+          }
+        }
+      }
+    };
+
+    const layers = ensureCosmeticLayers(config, 'hero', {});
+    strictEqual(layers.length, 1);
+    const layer = layers[0];
+    deepStrictEqual(layer.hsl, { h: 45, s: 0.1, l: 0.2 });
+    strictEqual(readXform(layer, 'head', 'ax'), 3);
+    strictEqual(readXform(layer, 'head', 'ay'), undefined);
+  } finally {
+    globalThis.window = previousWindow;
+  }
+});
+
+test('fighter-specific overrides may adjust non-appearance transforms', () => {
+  clearCosmeticCache();
+  clearPaletteCache();
+  const config = {
+    cosmeticLibrary: {
+      tilted_hat: {
+        slot: 'hat',
+        hsl: {
+          defaults: { h: 0, s: 0, l: 0 },
+          limits: { h: [-180, 180], s: [-1, 1], l: [-1, 1] }
+        },
+        parts: {
+          head: {
+            image: { url: 'https://example.com/tilted-hat.png' },
+            spriteStyle: { base: { xform: { head: { ax: 2 } } } }
+          }
+        }
+      }
+    },
+    fighters: {
+      hero: {
+        cosmetics: {
+          slots: {
+            hat: {
+              id: 'tilted_hat',
+              fighterOverrides: {
+                spriteStyle: { base: { xform: { head: { ax: 7 } } } },
+                parts: {
+                  head: {
+                    layers: {
+                      front: { spriteStyle: { base: { xform: { head: { ay: 5 } } } } }
+                    }
+                  }
+                },
+                hsl: { h: -30 }
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const layers = ensureCosmeticLayers(config, 'hero', {});
+  strictEqual(layers.length, 1);
+  const layer = layers[0];
+  strictEqual(readXform(layer, 'head', 'ax'), 7);
+  strictEqual(readXform(layer, 'head', 'ay'), 5);
+  deepStrictEqual(layer.hsl, { h: -30, s: 0, l: 0 });
+});
+
+test('appearance cosmetics ignore fighter transform overrides', () => {
+  clearCosmeticCache();
+  clearPaletteCache();
+  const config = {
+    cosmeticLibrary: {
+      marking: {
+        slot: 'appearance:torso',
+        appearance: { inheritSprite: 'torso' },
+        parts: {
+          torso: {
+            image: { url: 'https://example.com/marking.png' },
+            spriteStyle: { base: { xform: { torso: { ax: 2 } } } }
+          }
+        }
+      }
+    },
+    fighters: {
+      hero: {
+        bodyColors: {
+          A: { h: 10, s: 0.05, v: 0.1 }
+        },
+        cosmetics: {
+          slots: {
+            'appearance:torso': {
+              id: 'marking',
+              colors: ['A'],
+              fighterOverrides: {
+                spriteStyle: { base: { xform: { torso: { ax: 40 } } } },
+                parts: {
+                  torso: {
+                    layers: {
+                      front: { spriteStyle: { base: { xform: { torso: { ay: -6 } } } } }
+                    }
+                  }
+                },
+                hsl: { s: 0.2 }
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const layers = ensureCosmeticLayers(config, 'hero', {});
+  strictEqual(layers.length, 1);
+  const layer = layers[0];
+  strictEqual(readXform(layer, 'torso', 'ax'), 2);
+  strictEqual(readXform(layer, 'torso', 'ay'), undefined);
+  deepStrictEqual(layer.hsl, { h: 10, s: 0.25, l: 0.1 });
 });
 
 test('resolveFighterBodyColors ignores stale palette when fighter changes', () => {


### PR DESCRIPTION
## Summary
- restrict transform overrides from runtime/editor inputs by sanitizing cosmetic layer overrides
- allow fighter-specific overrides to adjust transforms on non-appearance cosmetics while enforcing global-only transforms for appearance slots
- add regression tests covering editor, fighter-specific, and appearance cosmetic override handling

## Testing
- `node --test tests/cosmetics-system.test.js`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918700e80cc8326b12c2fcf650dbd9b)