### PR TITLE
Add airborne knockback tuning and NPC obstruction jumps

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -625,8 +625,20 @@ window.CONFIG = {
     }
   },
 
+  npc: {
+    obstructionJump: {
+      initialDelay: 10,
+      blockedDuration: 0.9,
+      cooldown: 3.2,
+      minVelocity: 45,
+      minProgress: 4,
+      minDistance: 36
+    }
+  },
+
   knockback: {
     maxFooting: 100,
+    airborneMultiplier: 5,
     weaponTypes: {
       unarmed: { type: 'blunt', multiplier: 1.0 },
       blunt: { multiplier: 2.4 },


### PR DESCRIPTION
## Summary
- add config controls for airborne knockback scaling and obstruction jump behavior
- amplify airborne knockback with dramatic spin effects shared by players and NPCs
- detect stalled NPC approaches, enforce an initial delay, and trigger jump attempts over blockers

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918771e5adc8326ade1959c2250b013)