### PR TITLE
Fix weapon rotation to follow anchor orientation

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -895,11 +895,12 @@ function buildWeaponBones({
       anchorPos = withAX(anchorPos[0], anchorPos[1], anchor.ang, boneSpec.anchorOffset, null, length);
     }
 
-    const weaponBaseAngle = Number.isFinite(target?.weapon) ? target.weapon : anchor.ang;
+    const anchorAngle = Number.isFinite(anchor?.ang) ? anchor.ang : 0;
+    const weaponAngleOffset = Number.isFinite(target?.weapon) ? target.weapon : 0;
     const boneAngleOffset = Number.isFinite(boneSpec.angleOffsetRad)
       ? boneSpec.angleOffsetRad
       : (Number.isFinite(boneSpec.angleOffsetDeg) ? degToRad(boneSpec.angleOffsetDeg) : 0);
-    const boneAng = weaponBaseAngle + baseAngleOffset + boneAngleOffset;
+    const boneAng = anchorAngle + weaponAngleOffset + baseAngleOffset + boneAngleOffset;
 
     const jointDefault = jointDefaults?.[boneId]
       ?? clamp(Number(boneSpec.joint?.percent ?? boneSpec.jointPercent ?? 0.5), 0, 1);

--- a/tests/weapon-rotation.test.js
+++ b/tests/weapon-rotation.test.js
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('weapon rotation handling', () => {
+  it('treats pose weapon angles as offsets from the anchor orientation', async () => {
+    const animatorSrc = await readFile(new URL('../docs/js/animator.js', import.meta.url), 'utf8');
+    assert.match(
+      animatorSrc,
+      /const\s+weaponAngleOffset\s*=\s*Number\.isFinite\(target\?\.weapon\)\s*\?\s*target\.weapon\s*:\s*0;/
+    );
+    assert.match(
+      animatorSrc,
+      /const\s+anchorAngle\s*=\s*Number\.isFinite\(anchor\?\.ang\)\s*\?\s*anchor\.ang\s*:\s*0;/
+    );
+    assert.match(
+      animatorSrc,
+      /const\s+boneAng\s*=\s*anchorAngle\s*\+\s*weaponAngleOffset\s*\+\s*baseAngleOffset\s*\+\s*boneAngleOffset;/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- treat pose weapon pose angles as offsets from the resolved anchor orientation when building weapon bones
- add a regression test that asserts the animator applies the anchor-relative angle calculation

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691886c532f88326a3f127c583d3333a)