### PR TITLE
Simplify dagger and sarrarru weapon colliders

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -907,8 +907,16 @@ window.CONFIG = {
               { id: 'primary', percent: 0.2, limb: 'right', offset: { ax: 0, ay: 0 } }
             ],
             colliders: [
-              { id: 'rightA', kind: 'box', width: 20, height: 60, from: 0.08, to: 1.0, activatesOn: ['SLASH', 'STRIKE'], offset: { ax: 0.45, ay: 0, units: 'percent' } },
-              { id: 'rightB', kind: 'box', width: 16, height: 44, from: 0.04, to: 0.75, activatesOn: ['STAB'], offset: { ax: 0.25, ay: -0.18, units: 'percent' } }
+              {
+                id: 'colliderA',
+                kind: 'box',
+                width: 20,
+                height: 60,
+                from: 0.08,
+                to: 1.0,
+                activatesOn: ['STRIKE'],
+                offset: { ax: 0.45, ay: 0, units: 'percent' }
+              }
             ]
           },
           {
@@ -923,17 +931,23 @@ window.CONFIG = {
               { id: 'secondary', percent: 0.2, limb: 'left', offset: { ax: 0, ay: 0 } }
             ],
             colliders: [
-              { id: 'leftA', kind: 'box', width: 20, height: 60, from: 0.08, to: 1.0, activatesOn: ['SLASH', 'STRIKE'], offset: { ax: 0.45, ay: 0, units: 'percent' } },
-              { id: 'leftB', kind: 'box', width: 16, height: 44, from: 0.04, to: 0.75, activatesOn: ['STAB'], offset: { ax: 0.25, ay: 0.18, units: 'percent' } }
+              {
+                id: 'colliderB',
+                kind: 'box',
+                width: 20,
+                height: 60,
+                from: 0.08,
+                to: 1.0,
+                activatesOn: ['STRIKE'],
+                offset: { ax: 0.45, ay: 0, units: 'percent' }
+              }
             ]
           }
         ]
       },
       colliders: {
-        rightA: { shape: 'rect', width: 20, height: 60, offset: { x: 20, y: 0 }, activatesOn: ['SLASH', 'STRIKE'] },
-        rightB: { shape: 'rect', width: 16, height: 44, offset: { x: 10, y: -8 }, activatesOn: ['STAB'] },
-        leftA: { shape: 'rect', width: 20, height: 60, offset: { x: 20, y: 0 }, activatesOn: ['SLASH', 'STRIKE'] },
-        leftB: { shape: 'rect', width: 16, height: 44, offset: { x: 10, y: 8 }, activatesOn: ['STAB'] }
+        colliderA: { shape: 'rect', width: 20, height: 60, offset: { x: 20, y: 0 }, activatesOn: ['STRIKE'] },
+        colliderB: { shape: 'rect', width: 20, height: 60, offset: { x: 20, y: 0 }, activatesOn: ['STRIKE'] }
       }
     },
 
@@ -952,16 +966,22 @@ window.CONFIG = {
               { id: 'secondary', percent: 0.76, limb: 'left', offset: { ax: 0, ay: 0 } }
             ],
             colliders: [
-              { id: 'thrust', kind: 'box', width: 18, height: 120, from: 0.05, to: 1.05, activatesOn: ['THRUST'], offset: { ax: 0.55, ay: 0, units: 'percent' } },
-              { id: 'sweep', kind: 'box', width: 26, height: 140, from: 0.08, to: 1.1, activatesOn: ['SWEEP'], offset: { ax: 0.42, ay: 0, units: 'percent' } }
+              {
+                id: 'colliderA',
+                kind: 'box',
+                width: 26,
+                height: 140,
+                from: 0.08,
+                to: 1.1,
+                activatesOn: ['STRIKE'],
+                offset: { ax: 0.42, ay: 0, units: 'percent' }
+              }
             ]
           }
         ]
       },
       colliders: {
-        rightA: { shape: 'rect', width: 18, height: 120, offset: { x: 50, y: 0 }, activatesOn: ['THRUST'] },
-        rightB: { shape: 'rect', width: 26, height: 140, offset: { x: 35, y: 0 }, activatesOn: ['SWEEP'] },
-        leftA: { shape: 'rect', width: 16, height: 40, offset: { x: -10, y: 0 }, activatesOn: ['SWEEP'] }
+        colliderA: { shape: 'rect', width: 26, height: 140, offset: { x: 35, y: 0 }, activatesOn: ['STRIKE'] }
       },
       sprite: {
         url: './assets/weapons/sarrarru/citywatch_sarrarru.png',

--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -208,6 +208,10 @@ export function makeCombat(G, C, options = {}){
       const str = String(value).trim();
       if (str) tagSet.add(str.toUpperCase());
     };
+    const defaultActivationTag = typeof options.defaultActivationTag === 'string'
+      ? options.defaultActivationTag.trim().toUpperCase()
+      : 'STRIKE';
+    if (defaultActivationTag) addTag(defaultActivationTag);
     if (options.preset) addTag(options.preset);
     const allowedTags = options.allowedTags;
     if (allowedTags instanceof Set) {
@@ -218,22 +222,28 @@ export function makeCombat(G, C, options = {}){
       Object.values(allowedTags).forEach(addTag);
     }
     const keys = [];
+    const seenKeys = new Set();
     for (const bone of state.bones) {
       for (const collider of bone?.colliders || []) {
         if (!collider || !collider.id) continue;
+        const id = String(collider.id).trim();
+        if (!id) continue;
         const activations = Array.isArray(collider.activatesOn) ? collider.activatesOn : [];
-        if (activations.length) {
-          if (!tagSet.size) {
-            continue;
+        const normalizedActivations = activations
+          .map((tag) => (typeof tag === 'string' ? tag.trim().toUpperCase() : ''))
+          .filter(Boolean);
+        if (normalizedActivations.length) {
+          const matches = normalizedActivations.some((tag) => tagSet.has(tag));
+          if (!matches) {
+            if (!defaultActivationTag || !tagSet.has(defaultActivationTag)) {
+              continue;
+            }
           }
-          const matches = activations.some((tag) => {
-            if (tag == null) return false;
-            const str = String(tag).trim();
-            return str && tagSet.has(str.toUpperCase());
-          });
-          if (!matches) continue;
         }
-        keys.push(`weapon:${collider.id}`);
+        const key = `weapon:${id}`;
+        if (seenKeys.has(key)) continue;
+        seenKeys.add(key);
+        keys.push(key);
       }
     }
     return keys;
@@ -1340,7 +1350,11 @@ export function makeCombat(G, C, options = {}){
         });
       }
       const weaponKeys = allowWeaponColliders
-        ? collectWeaponColliderKeys(fighter, { allowedTags, preset: attackState.preset || context?.preset })
+        ? collectWeaponColliderKeys(fighter, {
+            allowedTags,
+            preset: attackState.preset || context?.preset,
+            defaultActivationTag: 'STRIKE'
+          })
         : [];
       if (allowWeaponColliders && weaponKeys.length) {
         const merged = new Set(Array.isArray(explicitKeys) ? explicitKeys : []);


### PR DESCRIPTION
## Summary
- rename dagger-sword and sarrarru collider definitions to simple colliderA/colliderB entries and collapse redundant hitboxes
- retune combat weapon collider collection to default to STRIKE activations and avoid duplicate keys

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69188b2e7cac8326b8f9602882a99e9f)