### PR TITLE
Show single-part front/back preview in cosmetic editor

### DIFF
--- a/docs/cosmetic-editor.css
+++ b/docs/cosmetic-editor.css
@@ -32,19 +32,276 @@ main.editor-layout {
 
 .editor-preview {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
   background: linear-gradient(160deg, rgba(30,41,59,0.9), rgba(15,23,42,0.7));
   border-radius: 16px;
   padding: 16px;
   box-shadow: 0 18px 45px rgba(15,23,42,0.55);
 }
 
-.editor-preview canvas {
-  width: 100%;
-  height: auto;
+.editor-preview__intro h2 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #cbd5f5;
+}
+
+.editor-preview__intro p {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(226,232,240,0.75);
+}
+
+.part-preview__grid {
+  --preview-scale: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-height: 68vh;
+  overflow-y: auto;
+  padding: 4px;
+}
+
+.part-preview__grid.is-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 260px;
+  border: 1px dashed rgba(148,163,184,0.32);
   border-radius: 12px;
+  padding: 24px;
+}
+
+.part-preview__empty-note {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  text-align: center;
+  color: rgba(148,163,184,0.85);
+}
+
+.part-preview__card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(15,23,42,0.55);
+  border: 1px solid rgba(148,163,184,0.22);
+  border-radius: 14px;
+  padding: 12px;
+  box-shadow: inset 0 1px 0 rgba(148,163,184,0.12);
+}
+
+.part-preview__card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.part-preview__card-header--single {
+  flex-wrap: wrap;
+  row-gap: 6px;
+}
+
+.part-preview__part {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.part-preview__progress {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(37,99,235,0.2);
+  color: #cbd5f5;
+  font-weight: 600;
+}
+
+.part-preview__nav-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.part-preview__nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid rgba(148,163,184,0.35);
+  background: rgba(30,41,59,0.65);
+  color: #e2e8f0;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.part-preview__nav-btn:hover,
+.part-preview__nav-btn:focus-visible {
+  border-color: rgba(148,163,184,0.6);
+  background: rgba(51,65,85,0.7);
+}
+
+.part-preview__selector {
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 10px;
   border: 1px solid rgba(148,163,184,0.25);
-  background: #020617;
-  cursor: grab;
+  background: rgba(15,23,42,0.65);
+  color: #e2e8f0;
+  font: inherit;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.part-preview__stage {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  min-height: 140px;
+  border-radius: 12px;
+  border: 1px solid rgba(148,163,184,0.2);
+  background: rgba(2,6,23,0.65);
+  overflow: visible;
+}
+
+.part-preview__stage-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.part-preview__pose {
+  flex: 1 1 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.part-preview__pose[data-empty="true"] .part-preview__stage {
+  justify-content: center;
+}
+
+.part-preview__pose[data-empty="true"] .part-preview__stage::after {
+  content: 'No sprite available';
+  font-size: 12px;
+  color: rgba(148,163,184,0.75);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.part-preview__pose-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: rgba(148,163,184,0.9);
+  text-transform: uppercase;
+}
+
+.part-preview__pose-badge {
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(148,163,184,0.3);
+  background: rgba(30,41,59,0.6);
+  color: #e2e8f0;
+  font-weight: 600;
+}
+
+.part-preview__stack {
+  position: relative;
+  transform: scale(var(--preview-scale));
+  transform-origin: top left;
+  image-rendering: pixelated;
+}
+
+.part-preview__layer {
+  display: block;
+  max-width: none;
+  image-rendering: pixelated;
+  filter: none;
+}
+
+.part-preview__layer--base {
+  position: relative;
+}
+
+.part-preview__layer:not(.part-preview__layer--base) {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.part-preview__layers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.part-preview__layer-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: rgba(148,163,184,0.85);
+}
+
+.part-preview__layer-badges {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.part-preview__layer-slot {
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: #cbd5f5;
+}
+
+.part-preview__layer-id {
+  padding: 2px 6px;
+  border-radius: 8px;
+  background: rgba(30,41,59,0.65);
+  border: 1px solid rgba(148,163,184,0.3);
+  color: #e2e8f0;
+}
+
+.part-preview__layer-badge {
+  margin-left: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(37,99,235,0.45);
+  color: #e0f2fe;
+}
+
+.part-preview__layer-badge--appearance {
+  background: rgba(236,72,153,0.45);
+  color: #ffe4f1;
+}
+
+.part-preview__layer-badge--position {
+  border: 1px solid rgba(37,99,235,0.35);
+  background: rgba(37,99,235,0.2);
+  color: #bfdbfe;
 }
 
 .editor-controls {

--- a/docs/cosmetic-editor.html
+++ b/docs/cosmetic-editor.html
@@ -10,7 +10,11 @@
 <body>
   <main class="editor-layout">
     <section class="editor-preview">
-      <canvas id="cosmeticCanvas" width="720" height="460" aria-label="Cosmetic preview"></canvas>
+      <div class="editor-preview__intro">
+        <h2>Part Preview</h2>
+        <p>Inspect each body part with every equipped cosmetic layer stacked and scaled for clarity.</p>
+      </div>
+      <div id="partPreviewGrid" class="part-preview__grid" data-state="empty" aria-live="polite"></div>
     </section>
     <section class="editor-controls">
       <div class="panel">


### PR DESCRIPTION
## Summary
- shrink the cosmetic part preview scale and adjust styles for a single-card layout
- add navigation controls so only one part is shown at a time with front and back poses side by side
- refactor the preview renderer to build pose sections that reuse tint filters and expose layer metadata per position

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918875192508326ac3be3f388c01e09)