### PR TITLE
Fix prefab slug propagation in editor and loader

### DIFF
--- a/docs/map-editor.html
+++ b/docs/map-editor.html
@@ -1347,7 +1347,13 @@ function loadImage(url){
 
 /*** Prefabs ***/
 async function registerPrefab(obj, options = {}){
-  const { select = true, autoPopulate = true, silent = false, deferRefresh = false } = options;
+  const {
+    select = true,
+    autoPopulate = true,
+    silent = false,
+    deferRefresh = false,
+    prefabId: explicitPrefabId = null,
+  } = options;
   const prefab = obj && typeof obj === 'object' ? JSON.parse(JSON.stringify(obj)) : null;
   if(!prefab || !prefab.structureId || !Array.isArray(prefab.parts)){
     const message = 'Invalid structure JSON';
@@ -1355,8 +1361,25 @@ async function registerPrefab(obj, options = {}){
     throw new Error(message);
   }
 
-  prefabs[prefab.structureId]=prefab;
-  if(select && !selectedPrefabId) selectedPrefabId=prefab.structureId;
+  const candidateIds = [
+    explicitPrefabId,
+    prefab.id,
+    prefab.prefabId,
+    prefab.slug,
+    prefab.structureId,
+  ];
+  const resolvedId = candidateIds
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .find((value) => !!value);
+  if(!resolvedId){
+    const message = 'Prefab missing identifier';
+    if(!silent) alert(message);
+    throw new Error(message);
+  }
+
+  prefab.id = resolvedId;
+  prefabs[resolvedId]=prefab;
+  if(select && !selectedPrefabId) selectedPrefabId=resolvedId;
 
   for(const part of prefab.parts){
     const t=part.propTemplate||{};
@@ -1369,11 +1392,11 @@ async function registerPrefab(obj, options = {}){
 
   if(autoPopulate && !instances.length && activeLayerId){
     pushHistory();
-    addRowOnLayer(activeLayerId,8,prefab.structureId);
+    addRowOnLayer(activeLayerId,8,resolvedId);
     refreshInstanceList();
   }
 
-  return prefab.structureId;
+  return resolvedId;
 }
 
 async function ensureConfiguredPrefabsLoaded(){
@@ -1391,6 +1414,7 @@ async function ensureConfiguredPrefabsLoaded(){
       for(const [id, prefab] of prefabMap.entries()){
         const already = !!prefabs[id];
         await registerPrefab(prefab, {
+          prefabId: id,
           select: !selectedPrefabId && !already,
           autoPopulate: false,
           silent: true,
@@ -1423,6 +1447,7 @@ function registerImagePrefab(file){
     let id=`img_${base}`, c=1;
     while(prefabs[id]) id=`img_${base}_${c++}`;
     prefabs[id]={
+      id,
       structureId:id,
       isImage:true,
       parts:[{

--- a/tests/prefabs/prefabCatalogFallback.test.js
+++ b/tests/prefabs/prefabCatalogFallback.test.js
@@ -78,6 +78,8 @@ test('loadPrefabsFromManifests falls back to JSON import when fetch fails for fi
     assert.equal(prefabs.size, 1);
     const prefab = prefabs.get('blocking_crate');
     assert.ok(prefab);
+    assert.equal(prefab.id, 'blocking_crate');
+    assert.equal(prefab.slug, 'blocking_crate');
     assert.equal(prefab.type, 'obstruction');
     assert.deepEqual(prefab.tags, ['grippable', 'obstruction']);
 
@@ -165,6 +167,8 @@ test('loadPrefabsFromManifests falls back to XMLHttpRequest when JSON import is 
     assert.equal(prefabs.size, 1);
     const prefab = prefabs.get('tower_commercial');
     assert.ok(prefab);
+    assert.equal(prefab.id, 'tower_commercial');
+    assert.equal(prefab.slug, 'tower_commercial');
     assert.equal(prefab.structureId, 'Commercial Tower');
     assert.equal(prefab.parts.length, 1);
   } finally {


### PR DESCRIPTION
## Summary
- ensure prefab loader preserves catalog slugs on returned prefabs and records catalog metadata
- register prefabs in the map editor by slug identifiers so prefab resolvers can find them
- extend prefab fallback tests to confirm slug propagation

## Testing
- npm test -- tests/prefabs/prefabCatalogFallback.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a855584483269a1a00656c59d240)