### PR TITLE
Prevent weapon rig collisions from erasing arm bones

### DIFF
--- a/docs/js/render.js
+++ b/docs/js/render.js
@@ -222,16 +222,19 @@ function computeAnchorsForFighter(F, C, fallbackFighterName) {
     weaponState.bones.forEach((bone, index) => {
       if (!bone) return;
       const boneKey = bone.id || `weapon_${index}`;
+      const collidesWithBaseRig = boneKey && !String(boneKey).startsWith('weapon_') && Object.prototype.hasOwnProperty.call(B, boneKey);
+      const safeKey = collidesWithBaseRig ? `weapon_${boneKey}` : boneKey;
       const start = bone.start || { x: 0, y: 0 };
       const end = bone.end || { x: start.x, y: start.y };
-      B[boneKey] = {
+      B[safeKey] = {
         x: start.x,
         y: start.y,
         len: Number.isFinite(bone.length) ? bone.length : Math.hypot(end.x - start.x, end.y - start.y),
         ang: bone.angle ?? angleFromDelta(end.x - start.x, end.y - start.y),
         endX: end.x,
         endY: end.y,
-        weapon: weaponKey
+        weapon: weaponKey,
+        sourceId: bone.id || null
       };
     });
   }

--- a/tests/render-weapon-bone-conflict.test.js
+++ b/tests/render-weapon-bone-conflict.test.js
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('render.js weapon bone safety', () => {
+  const renderPath = join(__dirname, '..', 'docs', 'js', 'render.js');
+  const renderSrc = readFileSync(renderPath, 'utf-8');
+
+  it('guards against weapon bones overriding base rig entries', () => {
+    assert.ok(
+      renderSrc.includes('const collidesWithBaseRig') &&
+      renderSrc.includes('const safeKey = collidesWithBaseRig ? `weapon_${boneKey}` : boneKey;'),
+      'render.js should rename weapon bones that collide with base rig keys'
+    );
+  });
+
+  it('preserves original weapon bone ids via sourceId metadata', () => {
+    assert.ok(
+      renderSrc.includes('sourceId: bone.id || null'),
+      'render.js should retain the originating weapon bone id for diagnostics'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- guard computeAnchorsForFighter against weapon rig bones overwriting base limb anchors
- retain the original weapon bone identifier on renamed entries for easier debugging
- add a regression test that checks for the safeguard and metadata

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a7f8d3d88326810ab2dca5a214e9)