### PR TITLE
Enable multi-bone cosmetic deformation for cosmetics

### DIFF
--- a/docs/combined-release-notes.md
+++ b/docs/combined-release-notes.md
@@ -12,7 +12,9 @@ This document summarises the features folded together for the consolidated merge
 - `docs/js/cosmetics.js` provides the normalized library/profile registry, HSV clamping, asset caching, and tag helpers used both in-game and inside the editor.
 - `docs/js/cosmetic-library.js` and `docs/js/cosmetic-profiles.js` fetch cosmetics and profile data and register them with the runtime.
 - `docs/js/sprites.js` integrates cosmetic layers into sprite assembly, including branch mirroring to keep limb cosmetics aligned.
-- `tests/cosmetics-system.test.js` locks behaviour for tag generation, layer expansion, and config wiring so the merge stays verifiable.
+- `docs/js/sprites.js` now blends cosmetic quad warps from multiple bones using per-layer falloff metadata so draped clothing can follow both torso and arms.
+- `docs/config/cosmetics/simple_poncho.json` showcases multi-bone deformation settings for torso and shoulder coverage, illustrating radius and weight tuning.
+- `tests/cosmetics-system.test.js` locks behaviour for tag generation, layer expansion, config wiring, and now guards cosmetic layer bone influence metadata.
 
 ## Combat, animation, and configuration updates
 - `docs/js/combat.js` merges weapon combo definitions with base abilities, adds queue management, and honours weapon-specific overrides.

--- a/docs/config/cosmetics/simple_poncho.json
+++ b/docs/config/cosmetics/simple_poncho.json
@@ -17,6 +17,13 @@
                 "torso": { "ax": 0, "ay": 0, "scaleX": 1, "scaleY": 1 }
               }
             }
+          },
+          "extra": {
+            "boneInfluences": [
+              { "bone": "torso", "radiusScale": 1.1, "innerWeight": 1, "outerWeight": 0.25 },
+              { "bone": "arm_L_upper", "radiusScale": 0.65, "innerWeight": 0.85, "outerWeight": 0.35 },
+              { "bone": "arm_R_upper", "radiusScale": 0.65, "innerWeight": 0.85, "outerWeight": 0.35 }
+            ]
           }
         },
         "front": {
@@ -29,6 +36,13 @@
                 "torso": { "ax": 0, "ay": 0, "scaleX": 1, "scaleY": 1 }
               }
             }
+          },
+          "extra": {
+            "boneInfluences": [
+              { "bone": "torso", "radiusScale": 1.1, "innerWeight": 1, "outerWeight": 0.25 },
+              { "bone": "arm_L_upper", "radiusScale": 0.65, "innerWeight": 0.85, "outerWeight": 0.35 },
+              { "bone": "arm_R_upper", "radiusScale": 0.65, "innerWeight": 0.85, "outerWeight": 0.35 }
+            ]
           }
         }
       }
@@ -45,6 +59,12 @@
                 "armUpper": { "ax": 0, "ay": 0, "scaleX": 1, "scaleY": 1 }
               }
             }
+          },
+          "extra": {
+            "boneInfluences": [
+              { "bone": "arm_L_upper", "radiusScale": 0.6, "innerWeight": 1, "outerWeight": 0.45 },
+              { "bone": "torso", "radiusScale": 0.8, "innerWeight": 0.7, "outerWeight": 0.25 }
+            ]
           }
         }
       }
@@ -61,6 +81,12 @@
                 "armUpper": { "ax": 0, "ay": 0, "scaleX": 1, "scaleY": 1 }
               }
             }
+          },
+          "extra": {
+            "boneInfluences": [
+              { "bone": "arm_R_upper", "radiusScale": 0.6, "innerWeight": 1, "outerWeight": 0.45 },
+              { "bone": "torso", "radiusScale": 0.8, "innerWeight": 0.7, "outerWeight": 0.25 }
+            ]
           }
         }
       }

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -495,11 +495,39 @@ test('default character pants tint to blue for player and red for enemy', () => 
     });
 });
 
+test('ensureCosmeticLayers exposes layer extra bone influence metadata', () => {
+  clearCosmeticCache();
+  clearPaletteCache();
+  const poncho = JSON.parse(readFileSync(new URL('../docs/config/cosmetics/simple_poncho.json', import.meta.url), 'utf8'));
+  const config = {
+    cosmeticLibrary: {
+      simple_poncho: poncho
+    },
+    fighters: {
+      drifter: {
+        cosmetics: {
+          slots: {
+            overwear: { id: 'simple_poncho' }
+          }
+        }
+      }
+    }
+  };
+
+  const layers = ensureCosmeticLayers(config, 'drifter', {});
+  const torsoFront = layers.find((layer) =>
+    layer.cosmeticId === 'simple_poncho' && layer.partKey === 'torso' && layer.position === 'front'
+  );
+  strictEqual(Array.isArray(torsoFront?.extra?.boneInfluences), true, 'torso layer should retain bone influence metadata');
+  strictEqual(torsoFront.extra.boneInfluences.length >= 3, true, 'torso layer should expose all configured influences');
+  strictEqual(torsoFront.extra.boneInfluences[0].bone, 'torso');
+});
+
 test('sprites.js integrates cosmetic layers and z-order expansion', () => {
   const spritesContent = readFileSync(new URL('../docs/js/sprites.js', import.meta.url), 'utf8');
   strictEqual(/expanded\.push\(cosmeticTagFor\(tag, slot\)\);/.test(spritesContent), true, 'buildZMap should add cosmetic tags');
   strictEqual(/const \{ assets, style, cosmetics(?:, bodyColors)?(?:, untintedOverlays: [^}]+)? } = ensureFighterSprites/.test(spritesContent), true, 'renderSprites should read cosmetics');
-  strictEqual(/withBranchMirror\(ctx,\s*originX,\s*mirror,\s*\(\)\s*=>\s*\{\s*drawBoneSprite\(ctx, layer\.asset, bone, styleKey/.test(spritesContent), true, 'cosmetic layers should mirror with their limbs');
+  strictEqual(/withBranchMirror\(ctx,\s*originX,\s*mirror,\s*\(\)\s*=>\s*\{[\s\S]*?drawBoneSprite\(ctx,\s*layer\.asset,\s*bone,\s*styleKey,\s*style,/.test(spritesContent), true, 'cosmetic layers should mirror with their limbs');
 });
 
 test('config references cosmetic library sources and fighter slot data', () => {


### PR DESCRIPTION
## Summary
- blend cosmetic quads from multiple bones in `docs/js/sprites.js`, including radius-weighted falloff helpers and runtime wiring for appearance and clothing layers
- document the new deformation metadata in the release notes and sample poncho cosmetic configuration
- add a regression test to ensure cosmetic layers retain their bone influence metadata

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918bb84a2c083269b56e167b4cea339)