### PR TITLE
Add draping mode and bone influence editor

### DIFF
--- a/docs/cosmetic-editor.css
+++ b/docs/cosmetic-editor.css
@@ -201,6 +201,195 @@ main.editor-layout {
   text-transform: uppercase;
 }
 
+body[data-editor-mode="draping"] .part-preview__stage {
+  border-color: rgba(124, 222, 255, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.18);
+}
+
+.drape-overlay {
+  position: absolute;
+  inset: 8px;
+  pointer-events: none;
+  border-radius: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+  padding: 6px;
+}
+
+.drape-overlay[data-empty="true"] {
+  align-items: center;
+  justify-items: center;
+  color: rgba(148,163,184,0.85);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.drape-overlay__box {
+  position: relative;
+  border-radius: 12px;
+  border: 1px solid rgba(125, 211, 252, 0.35);
+  box-shadow: 0 0 12px rgba(14, 165, 233, 0.25);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  min-height: 96px;
+  overflow: hidden;
+  backdrop-filter: blur(2px);
+}
+
+.drape-overlay__box::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.25) 0%, rgba(14, 165, 233, 0) 70%);
+  mix-blend-mode: screen;
+}
+
+.drape-overlay__box[data-active="true"] {
+  border-color: rgba(56, 189, 248, 0.85);
+  box-shadow: 0 0 18px rgba(56, 189, 248, 0.55);
+}
+
+.drape-overlay__box-label {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  padding: 10px 8px;
+  background: rgba(2,6,23,0.72);
+  text-align: center;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #e0f2fe;
+  line-height: 1.4;
+}
+
+.drape-overlay__metric {
+  display: block;
+  font-size: 10px;
+  color: rgba(224, 242, 254, 0.82);
+}
+
+.drape-overlay__heat {
+  position: absolute;
+  inset: 0;
+  opacity: 0.9;
+}
+
+.drape-editor {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(148,163,184,0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.drape-editor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.drape-editor__header h3 {
+  margin: 0;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #bae6fd;
+}
+
+.drape-editor__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.drape-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr)) auto;
+  gap: 8px;
+  align-items: end;
+  padding: 10px;
+  border-radius: 10px;
+  background: rgba(8, 47, 73, 0.45);
+  border: 1px solid rgba(14, 165, 233, 0.2);
+}
+
+.drape-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(226,232,240,0.85);
+}
+
+.drape-row input {
+  font: inherit;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(148,163,184,0.35);
+  background: rgba(2,6,23,0.7);
+  color: #e2e8f0;
+}
+
+.drape-row__heat-swatch {
+  grid-column: span 2;
+  min-height: 44px;
+  border-radius: 8px;
+  border: 1px solid rgba(125, 211, 252, 0.35);
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.35) 0%, rgba(14, 165, 233, 0) 70%);
+}
+
+.drape-row__remove {
+  align-self: center;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(148,163,184,0.35);
+  background: rgba(2,6,23,0.7);
+  color: #e2e8f0;
+  cursor: pointer;
+}
+
+.drape-row__remove:hover,
+.drape-row__remove:focus-visible {
+  border-color: rgba(56, 189, 248, 0.7);
+  background: rgba(8,47,73,0.8);
+}
+
+.drape-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.drape-editor__add {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(56, 189, 248, 0.65);
+  background: rgba(8,47,73,0.7);
+  color: #bae6fd;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.drape-editor__add:hover,
+.drape-editor__add:focus-visible {
+  border-color: rgba(125, 211, 252, 0.8);
+  background: rgba(8,47,73,0.85);
+}
+
+.drape-editor__empty {
+  font-size: 12px;
+  color: rgba(148,163,184,0.85);
+}
+
 .part-preview__pose-header {
   display: flex;
   align-items: center;

--- a/docs/cosmetic-editor.html
+++ b/docs/cosmetic-editor.html
@@ -27,9 +27,10 @@
         <div class="mode-toggle" role="group" aria-label="Select editor mode">
           <button type="button" class="mode-toggle__btn" data-mode="appearance">Appearance</button>
           <button type="button" class="mode-toggle__btn" data-mode="clothing">Clothing</button>
+          <button type="button" class="mode-toggle__btn" data-mode="draping">Draping</button>
           <button type="button" class="mode-toggle__btn" data-mode="fighterSprites">Fighter Sprites</button>
         </div>
-        <p class="panel-hint">Switch modes to focus on appearance overlays, clothing items, or fighter sprite data.</p>
+        <p class="panel-hint">Switch modes to focus on appearance overlays, clothing items, draping influences, or fighter sprite data.</p>
       </div>
       <div class="panel">
         <h2>Cosmetic Slots</h2>


### PR DESCRIPTION
## Summary
- add a draping mode option to the cosmetic editor for stretchable clothing workflows
- draw heat-mapped bone influence previews and expose editing controls for each influence
- style the new mode with overlay cards, editable rows, and active state highlighting

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918cd1122d48326b66ddfcf0e8a88f7)