### PR TITLE
Add conditional debugger for weapon collider origin

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -1104,6 +1104,23 @@ function buildWeaponBones({
       boneEntry.colliders.push(collider);
     });
 
+    if (
+      typeof window !== 'undefined'
+        ? window.__SOK_BREAK_ON_WEAPON_COLLIDER_ORIGIN !== false
+        : true
+    ) {
+      const originThreshold = 1e-3;
+      const hasOriginCollider = boneEntry.colliders.some((col) => {
+        const { x, y } = col?.center || {};
+        if (!Number.isFinite(x) || !Number.isFinite(y)) return false;
+        return Math.hypot(x, y) <= originThreshold;
+      });
+      if (hasOriginCollider) {
+        // eslint-disable-next-line no-debugger
+        debugger;
+      }
+    }
+
     bones.push(boneEntry);
   });
 


### PR DESCRIPTION
## Summary
- add a conditional debugger breakpoint that pauses when a weapon collider center collapses near the origin
- gate the breakpoint behind a window flag so it can be disabled when not needed

## Testing
- not run (debugging aid only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d3c79ff48326bd6bb91d5d7799f7)