### PR TITLE
Add option to lock ground ratio

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -411,6 +411,8 @@ window.CONFIG = {
   },
   ground: {
     offset: 140,
+    // Set to true to keep the configured groundRatio instead of letting map layouts override it.
+    lockRatio: false,
   },
   groundY: 0,
   // Debug options are surfaced in the debug panel; freezeAngles lets animators hold joints for edits

--- a/docs/js-src/map-bootstrap.ts
+++ b/docs/js-src/map-bootstrap.ts
@@ -270,6 +270,13 @@ function normalizeAreaCollider(input: unknown, index: number): EditorCollider {
   };
 }
 
+function isGroundRatioLocked(config: any): boolean {
+  if (!config || typeof config !== 'object') return false;
+  const ground = config.ground;
+  if (!ground || typeof ground !== 'object') return false;
+  return ground.lockRatio === true;
+}
+
 function applyEditorPreviewSettings(
   area: MapArea,
   { token = null, createdAt = null }: { token?: string | null; createdAt?: number | string | null } = {}
@@ -298,14 +305,21 @@ function applyEditorPreviewSettings(
     : [];
   preview.platformColliders = normalizedColliders;
 
+  const ratioLocked = isGroundRatioLocked(CONFIG);
+
   if (Number.isFinite(groundOffset) && canvasHeight > 0) {
     const ratioRaw = 1 - groundOffset / canvasHeight;
     const ratio = Math.max(0.1, Math.min(0.95, ratioRaw));
-    preview.previousGroundRatio = CONFIG.groundRatio;
-    CONFIG.groundRatio = ratio;
+    const appliedRatio = ratioLocked
+      ? (Number.isFinite(CONFIG.groundRatio) ? CONFIG.groundRatio : ratio)
+      : ratio;
+    if (!ratioLocked) {
+      preview.previousGroundRatio = CONFIG.groundRatio;
+      CONFIG.groundRatio = ratio;
+    }
     preview.groundOffset = groundOffset;
 
-    const groundY = canvasHeight * ratio;
+    const groundY = canvasHeight * appliedRatio;
     const worldWidth = GAME?.CAMERA?.worldWidth || canvasWidth * 2;
     const colliderWidth = Math.max(worldWidth, canvasWidth * 2.5);
     const colliderHeight = Math.max(48, groundOffset + 32);
@@ -340,12 +354,18 @@ function syncConfigGround(area: MapArea): void {
   }
 
   const offset = Math.max(0, rawOffset);
+  const ratioLocked = isGroundRatioLocked(CONFIG);
 
   if (canvasHeight > 0) {
     const ratioRaw = 1 - offset / canvasHeight;
     const ratio = Math.max(0.1, Math.min(0.95, ratioRaw));
-    CONFIG.groundRatio = ratio;
-    CONFIG.groundY = Math.round(canvasHeight * ratio);
+    const appliedRatio = ratioLocked
+      ? (Number.isFinite(CONFIG.groundRatio) ? CONFIG.groundRatio : ratio)
+      : ratio;
+    if (!ratioLocked) {
+      CONFIG.groundRatio = ratio;
+    }
+    CONFIG.groundY = Math.round(canvasHeight * appliedRatio);
   }
 
   CONFIG.ground = {


### PR DESCRIPTION
## Summary
- add a helper that respects `CONFIG.ground.lockRatio` so map bootstrap no longer overwrites a manually centered ground ratio
- apply the helper when syncing map data and preview overlays so ground colliders continue to line up with the locked ratio
- document the new flag in the default config so it is easy to opt into player-centering behavior

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e663eb7c83269d4ff02a9171903c)