### PR TITLE
Protect collider samples from invalid limb positions

### DIFF
--- a/docs/js/colliders.js
+++ b/docs/js/colliders.js
@@ -16,11 +16,14 @@ function ensureStore() {
   return store;
 }
 
+function isFinitePoint(point) {
+  if (!point || typeof point !== 'object') return false;
+  return Number.isFinite(point.x) && Number.isFinite(point.y);
+}
+
 function clonePoint(point) {
-  if (!point || typeof point !== 'object') return null;
-  const x = Number.isFinite(point.x) ? point.x : 0;
-  const y = Number.isFinite(point.y) ? point.y : 0;
-  return { x, y };
+  if (!isFinitePoint(point)) return null;
+  return { x: point.x, y: point.y };
 }
 
 function resolveBoneEnd(bone) {
@@ -59,9 +62,9 @@ function resolveRadius(key, config = {}) {
 }
 
 function writeCollider(entry, key, point, radius) {
-  if (point) {
+  if (isFinitePoint(point)) {
     entry[key] = { x: point.x, y: point.y };
-    entry[`${key}Radius`] = radius;
+    entry[`${key}Radius`] = Number.isFinite(radius) ? radius : null;
   } else {
     entry[key] = null;
     entry[`${key}Radius`] = null;


### PR DESCRIPTION
## Summary
- add helper guards in `colliders.js` so limb collider samples are only recorded when both coordinates are finite, preventing them from snapping to the world origin when a bone momentarily yields invalid data
- normalize stored radii at the same time so attack-trail consumers never inherit bogus sizes
- considered alternatives (deferring sampling until render stabilizes, caching per-phase collider snapshots, and guarding the debug renderer) but opted for the store-level guard because it fixes every consumer

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f074747c8326840ca84923d922c3)