### PR TITLE
Add synthetic weapon bone to animator

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -1127,6 +1127,42 @@ function buildWeaponBones({
   return { bones, gripLookup };
 }
 
+function createSyntheticWeaponBone(bones, { anchorBoneId } = {}) {
+  if (!Array.isArray(bones) || bones.length === 0) return null;
+  let source = null;
+  if (anchorBoneId) {
+    source = bones.find((bone) => bone && bone.id === anchorBoneId) || null;
+  }
+  if (!source) {
+    source = bones.find((bone) => bone && bone.id) || bones[0] || null;
+  }
+  if (!source) return null;
+  const startRaw = source.start || { x: 0, y: 0 };
+  const endRaw = source.end || startRaw;
+  const start = { x: Number(startRaw.x) || 0, y: Number(startRaw.y) || 0 };
+  const end = { x: Number(endRaw.x) || 0, y: Number(endRaw.y) || 0 };
+  const length = Number.isFinite(source.length)
+    ? source.length
+    : Math.hypot(end.x - start.x, end.y - start.y);
+  const angle = Number.isFinite(source.angle)
+    ? source.angle
+    : angleFromDelta(end.x - start.x, end.y - start.y);
+  const joint = source.joint ? { ...source.joint } : null;
+  const haft = source.haft ? { ...source.haft } : null;
+  return {
+    id: 'weapon',
+    start,
+    end,
+    length,
+    angle,
+    limb: source.limb || null,
+    anchor: source.anchor || null,
+    joint,
+    haft,
+    sourceId: source.id || null
+  };
+}
+
 function updateWeaponRig(F, target, finalDeg, C, fcfg) {
   if (!F?.anim?.weapon) return;
   const weaponKey = getActiveWeaponKey(F, C);
@@ -1267,14 +1303,23 @@ function updateWeaponRig(F, target, finalDeg, C, fcfg) {
     wristTransforms,
     lengthOverrides: F.anim?.length?.overrides
   });
+  const decoratedBones = Array.isArray(finalBuild.bones) ? [...finalBuild.bones] : [];
+  const syntheticWeaponBone = createSyntheticWeaponBone(
+    finalBuild.bones,
+    { anchorBoneId: weaponDef?.sprite?.anchorBone }
+  );
+  if (syntheticWeaponBone) {
+    decoratedBones.push(syntheticWeaponBone);
+  }
 
   F.anim.weapon.attachments = validAttachments;
   F.anim.weapon.state = {
     weaponKey,
-    bones: finalBuild.bones,
+    bones: decoratedBones,
     gripPercents: { ...gripPercents },
     jointPercents: { ...jointPercents },
-    attachments: validAttachments
+    attachments: validAttachments,
+    weaponBone: syntheticWeaponBone
   };
 }
 

--- a/tests/animator-weapon-bone.test.js
+++ b/tests/animator-weapon-bone.test.js
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const animatorSrc = readFileSync('docs/js/animator.js', 'utf8');
+
+describe('animator weapon bone synthesis', () => {
+  it('defines a helper that derives a synthetic weapon bone', () => {
+    assert.ok(
+      animatorSrc.includes('function createSyntheticWeaponBone'),
+      'animator.js should declare createSyntheticWeaponBone to generate derived bones'
+    );
+  });
+
+  it('appends the derived weapon bone to the computed rig output', () => {
+    assert.ok(
+      /decoratedBones\s*=\s*Array\.isArray\(finalBuild\.bones\)/.test(animatorSrc),
+      'animator.js should create a decoratedBones array before storing state'
+    );
+    assert.ok(
+      /decoratedBones\.push\(syntheticWeaponBone\)/.test(animatorSrc),
+      'animator.js should push the synthetic weapon bone into the decorated list'
+    );
+  });
+
+  it('stores the derived weapon bone alongside the rest of the state', () => {
+    assert.ok(
+      /weaponBone:\s*syntheticWeaponBone/.test(animatorSrc),
+      'animator.js should expose the derived bone on weapon state for downstream systems'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a helper that synthesizes a primary weapon bone from the resolved weapon rig
- include the derived bone in the stored weapon state so downstream systems can read it
- add a regression test that ensures the animator source contains the new logic

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f44ea41c8326b7a7c38a19fcdec5)