### PR TITLE
Show drape overlay while editing cosmetics

### DIFF
--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -2366,6 +2366,12 @@ class CosmeticEditorApp {
     stack.className = 'part-preview__stack';
     stage.appendChild(stack);
 
+    const drapeModeEnabled = !!this.modeManager?.getModeConfig(this.state.activeMode)?.enableDrapeEditor;
+    if (drapeModeEnabled){
+      const overlay = this.buildDrapeOverlay(resolvedLayers, library, partKey);
+      stage.appendChild(overlay);
+    }
+
     let hasImage = false;
     resolvedLayers.forEach((layer, index)=>{
       const url = layer?.asset?.url;


### PR DESCRIPTION
## Summary
- add the drape influence overlay to the part preview when the draping mode is active so poncho-style cosmetics can be rigged visually

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f52dc118832685fdf409aff106c0)