### PR TITLE
Add drape overlay preview to cosmetic editor

### DIFF
--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -2393,6 +2393,13 @@ class CosmeticEditorApp {
       stack.appendChild(img);
     });
 
+    if (this.modeManager.resolveModeKey(this.state.activeMode) === 'draping'){
+      const overlay = this.buildDrapeOverlay(resolvedLayers, library, partKey);
+      if (overlay){
+        stage.appendChild(overlay);
+      }
+    }
+
     if (!hasImage){
       section.dataset.empty = 'true';
     }

--- a/tests/cosmetic-editor-app.test.js
+++ b/tests/cosmetic-editor-app.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import { strictEqual } from 'node:assert';
+import { readFileSync } from 'node:fs';
+
+const editorContent = readFileSync(new URL('../docs/js/cosmetic-editor-app.js', import.meta.url), 'utf8');
+
+test('cosmetic editor renders drape overlay in draping mode', () => {
+  const drapeModeCheck = /buildPartPose[\s\S]+?modeManager\.resolveModeKey\(this\.state\.activeMode\) === 'draping'/.test(editorContent);
+  strictEqual(drapeModeCheck, true, 'buildPartPose should gate drape overlay on draping mode');
+
+  const overlayAppendCheck = /const\s+overlay\s*=\s*this\.buildDrapeOverlay\(resolvedLayers,\s*library,\s*partKey\);[\s\S]+?stage\.appendChild\(overlay\)/.test(editorContent);
+  strictEqual(overlayAppendCheck, true, 'part preview should append the drape overlay to the stage');
+});


### PR DESCRIPTION
## Summary
- render the drape influence overlay inside the part preview stage when the editor is in draping mode so poncho rigging data is visible
- add a regression test that ensures the cosmetic editor wires the drape overlay into the preview markup

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f52dc118832685fdf409aff106c0)