### PR TITLE
Fix duplicate default export in map runtime module

### DIFF
--- a/docs/js/vendor/map-runtime.js
+++ b/docs/js/vendor/map-runtime.js
@@ -861,4 +861,3 @@ function safeClone(value) {
   }
 }
 
-export default convertLayoutToArea;


### PR DESCRIPTION
## Summary
- remove the redundant `export default convertLayoutToArea` statement from `docs/js/vendor/map-runtime.js` so the vendor bundle only exposes a single default export

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918fc622e04832680de14b647c5b88e)