### PR TITLE
Improve cosmetic editor full-body stance preview

### DIFF
--- a/docs/cosmetic-editor.css
+++ b/docs/cosmetic-editor.css
@@ -56,7 +56,7 @@ main.editor-layout {
 }
 
 .part-preview__grid {
-  --preview-scale: 1;
+  --preview-scale: 0.1;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -165,14 +165,36 @@ main.editor-layout {
 .part-preview__stage {
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: 12px;
-  min-height: 140px;
+  padding: 16px;
+  min-height: 160px;
   border-radius: 12px;
   border: 1px solid rgba(148,163,184,0.2);
   background: rgba(2,6,23,0.65);
   overflow: visible;
+}
+
+.part-preview__stage--full-body {
+  align-items: center;
+  padding: 12px;
+}
+
+.full-body-preview__canvas {
+  width: min(260px, 100%);
+  height: 320px;
+  display: block;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 12px 24px rgba(2,6,23,0.45));
+}
+
+.part-preview__full-body-meta {
+  margin: 10px 0 0;
+  font-size: 12px;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148,163,184,0.85);
 }
 
 .part-preview__stage-group {
@@ -455,8 +477,18 @@ body[data-editor-mode="draping"] .part-preview__stage {
 .part-preview__stack {
   position: relative;
   transform: scale(var(--preview-scale));
-  transform-origin: top left;
+  transform-origin: top center;
   image-rendering: pixelated;
+}
+
+.part-preview__card--full-body {
+  border: 1px solid rgba(148,163,184,0.35);
+  box-shadow: 0 10px 30px rgba(15,23,42,0.4);
+}
+
+.part-preview__card--full-body .part-preview__stage {
+  min-height: 320px;
+  background: radial-gradient(circle at top, rgba(15,23,42,0.75), rgba(2,6,23,0.7));
 }
 
 .part-preview__layer {

--- a/docs/cosmetic-editor.html
+++ b/docs/cosmetic-editor.html
@@ -11,8 +11,8 @@
   <main class="editor-layout">
     <section class="editor-preview">
       <div class="editor-preview__intro">
-        <h2>Part Preview</h2>
-        <p>Inspect each body part with every equipped cosmetic layer stacked and scaled for clarity.</p>
+        <h2>Part & Stance Preview</h2>
+        <p>Inspect the full body stance alongside each body part with every equipped cosmetic layer stacked and scaled for clarity.</p>
       </div>
       <div id="partPreviewGrid" class="part-preview__grid" data-state="empty" aria-live="polite"></div>
     </section>
@@ -107,8 +107,9 @@
       </div>
       <div class="panel" id="overridePanel">
         <h2>Per-Fighter Overrides</h2>
-        <textarea id="overrideOutput" class="override-output" readonly spellcheck="false" aria-label="Generated override JSON"></textarea>
+        <textarea id="overrideOutput" class="override-output" spellcheck="false" aria-label="Generated override JSON"></textarea>
         <div class="override-actions">
+          <button type="button" id="loadOverrides">📥 Load JSON</button>
           <button type="button" id="applyOverrides">✅ Apply To Preview</button>
           <button type="button" id="copyOverrides">📋 Copy JSON</button>
           <button type="button" id="downloadOverrides">⬇ Download JSON</button>

--- a/docs/js/render.js
+++ b/docs/js/render.js
@@ -80,7 +80,7 @@ function withAX(x, y, ang, off, len, units) {
   return withAXUtil(x, y, ang, ax, ay, len || 1, unitStr);
 }
 
-function computeAnchorsForFighter(F, C, fallbackFighterName) {
+export function computeAnchorsForFighter(F, C, fallbackFighterName) {
   const profile = F?.renderProfile || {};
   const requestedName = profile.fighterName;
   const fighterName = (requestedName && C.fighters?.[requestedName]) ? requestedName : fallbackFighterName;


### PR DESCRIPTION
## Summary
- render the stance preview with the in-game sprite stack so cosmetics align exactly as they do in runtime
- dramatically reduce the layered part preview scale so individual sprites are easier to compare to the new stance preview
- expose the render math helper so the editor can build a preview rig without duplicating logic

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191c521d4c8326a529b853d74351dd)