### PR TITLE
Fix duplicate ATTACK sequenceSteps property

### DIFF
--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -119,8 +119,7 @@ export function makeCombat(G, C, options = {}){
     pendingAbilityId: null,
     sequenceTimers: [],
     sequenceSteps: [],
-    timelineState: null
-    sequenceSteps: []
+    timelineState: null,
   };
 
   const CHARGE = {


### PR DESCRIPTION
## Summary
- fix a syntax error in docs/js/combat.js by removing the duplicate `sequenceSteps` field in the `ATTACK` state and restoring the missing comma

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69192d2e74c8832686d6195fa2e94174)