### PR TITLE
Harden map conversion pipeline

### DIFF
--- a/tests/map/MapRegistry.test.js
+++ b/tests/map/MapRegistry.test.js
@@ -18,6 +18,15 @@ test('registers and retrieves areas', () => {
   assert.equal(registry.getArea('sample').name, 'Sample');
 });
 
+test('registerAreas validates entire batch before mutating registry', () => {
+  const registry = new MapRegistry();
+  assert.throws(() => registry.registerAreas({
+    good: SAMPLE_AREA,
+    bad: { name: 'Missing layers' },
+  }), MapRegistryError);
+  assert.equal(registry.hasArea('good'), false);
+});
+
 test('prevents invalid registrations', () => {
   const registry = new MapRegistry();
   assert.throws(() => registry.registerArea('', SAMPLE_AREA), MapRegistryError);


### PR DESCRIPTION
## Summary
- allow `convertLayoutToArea` to ingest `layout.props`, guard invalid prefab resolvers, preserve collider types, and teach `convertLayouts` to reject duplicate IDs
- make `MapRegistry.registerAreas` validate every descriptor before mutating internal state so batches stay atomic
- mirror the runtime/runtime-vendor updates in their docs build artifacts and extend the map tests to cover the new behaviors

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691930ac864c83268c6bc050825168f9)