### PR TITLE
Fix preview sandbox camera offset

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -2742,13 +2742,18 @@ function createEditorPreviewSandbox() {
     ctx.restore();
   };
 
-  const renderScene = ({ width, height, camX = 0, zoom = 1, groundY }) => {
+  const renderScene = ({ width, height, camX = 0, zoom = 1, groundY, camOrigin = 'left' }) => {
     if (!state.ready || !ctx) {
       return false;
     }
     const effectiveZoom = Math.max(Number.isFinite(zoom) ? zoom : 1, 0.05);
     const viewWidth = Math.max(1, Number(width) || state.canvas?.width || 1);
     const viewHeight = Math.max(1, Number(height) || state.canvas?.height || 1);
+    const viewportWorldWidth = viewWidth / effectiveZoom;
+    const normalizedCamX =
+      camOrigin === 'center'
+        ? camX - viewportWorldWidth * 0.5
+        : camX;
     const dpr = window.devicePixelRatio || 1;
     const pixelWidth = Math.round(viewWidth);
     const pixelHeight = Math.round(viewHeight);
@@ -2805,7 +2810,7 @@ function createEditorPreviewSandbox() {
       const parallax = Number.isFinite(layer.parallaxSpeed) ? layer.parallaxSpeed : 1;
       const layerScale = Number.isFinite(layer.scale) ? layer.scale : 1;
       const instRotRad = degToRad(inst.rotationDeg || 0);
-      const baseOffset = (pos.x - camX * parallax) * effectiveZoom;
+      const baseOffset = (pos.x - normalizedCamX * parallax) * effectiveZoom;
       const rootScreenX = baseOffset;
       const rootScreenY = groundLine + (layer.offsetY || 0) * effectiveZoom + pos.y * effectiveZoom;
       const dxScreen = baseOffset;


### PR DESCRIPTION
## Summary
- normalize the preview sandbox camera origin to treat `camX` as the viewport's left edge by default
- support center-based camera coordinates by normalizing them internally so prefab placement aligns with HUD overlays

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69194a07b8ac8326ab8c77b198563053)