### PR TITLE
Fix absolute scale overrides in style composer

### DIFF
--- a/docs/js/style-xform.js
+++ b/docs/js/style-xform.js
@@ -18,8 +18,12 @@ export function composeStyleXformEntry(baseEntry, overrideSpec){
 
   const hasBaseScaleX = Number.isFinite(base.scaleX);
   const hasBaseScaleY = Number.isFinite(base.scaleY);
-  let nextScaleX = hasBaseScaleX ? base.scaleX : 1;
-  let nextScaleY = hasBaseScaleY ? base.scaleY : 1;
+  const baseScaleX = hasBaseScaleX ? base.scaleX : null;
+  const baseScaleY = hasBaseScaleY ? base.scaleY : null;
+  const overrideScaleX = toFiniteNumber(overrideSpec.scaleX);
+  const overrideScaleY = toFiniteNumber(overrideSpec.scaleY);
+  let nextScaleX = overrideScaleX ?? baseScaleX ?? 1;
+  let nextScaleY = overrideScaleY ?? baseScaleY ?? 1;
   let scaleChangedX = false;
   let scaleChangedY = false;
 
@@ -40,12 +44,10 @@ export function composeStyleXformEntry(baseEntry, overrideSpec){
   applyMultiplier(overrideSpec.scaleMulX ?? overrideSpec.scaleXMul ?? overrideSpec.scaleXMultiplier, 'x');
   applyMultiplier(overrideSpec.scaleMulY ?? overrideSpec.scaleYMul ?? overrideSpec.scaleYMultiplier, 'y');
 
-  const overrideScaleX = toFiniteNumber(overrideSpec.scaleX);
   if (overrideScaleX != null){
     nextScaleX = overrideScaleX;
     scaleChangedX = true;
   }
-  const overrideScaleY = toFiniteNumber(overrideSpec.scaleY);
   if (overrideScaleY != null){
     nextScaleY = overrideScaleY;
     scaleChangedY = true;

--- a/tests/cosmetics-system.test.js
+++ b/tests/cosmetics-system.test.js
@@ -126,6 +126,16 @@ test('breathing overrides preserve cosmetic spriteStyle transforms', () => {
   }
 });
 
+test('composeStyleXformEntry treats scale overrides as absolute values', () => {
+  const cosmeticXform = { scaleX: 0.75, scaleY: 0.6 };
+  const override = { scaleX: 1.2, scaleY: 1.05 };
+  const composed = composeStyleXformEntry(cosmeticXform, override);
+  strictEqual(composed.scaleX, 1.2);
+  strictEqual(composed.scaleY, 1.05);
+  strictEqual(cosmeticXform.scaleX, 0.75);
+  strictEqual(cosmeticXform.scaleY, 0.6);
+});
+
 test('ensureCosmeticLayers normalizes hsl arrays and string values', () => {
   clearCosmeticCache();
   clearPaletteCache();


### PR DESCRIPTION
## Summary
- ensure composeStyleXformEntry prefers absolute scale overrides instead of multiplying them with existing cosmetic scales
- add a regression test that proves scale overrides remain absolute and the base xform is left untouched

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69194b9b8b8483269f427c18b1efae44)