### PR TITLE
Fix sandbox camera offset

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -2742,18 +2742,13 @@ function createEditorPreviewSandbox() {
     ctx.restore();
   };
 
-  const renderScene = ({ width, height, camX = 0, zoom = 1, groundY, camOrigin = 'left' }) => {
+  const renderScene = ({ width, height, camX = 0, zoom = 1, groundY }) => {
     if (!state.ready || !ctx) {
       return false;
     }
     const effectiveZoom = Math.max(Number.isFinite(zoom) ? zoom : 1, 0.05);
     const viewWidth = Math.max(1, Number(width) || state.canvas?.width || 1);
     const viewHeight = Math.max(1, Number(height) || state.canvas?.height || 1);
-    const viewportWorldWidth = viewWidth / effectiveZoom;
-    const normalizedCamX =
-      camOrigin === 'center'
-        ? camX - viewportWorldWidth * 0.5
-        : camX;
     const dpr = window.devicePixelRatio || 1;
     const pixelWidth = Math.round(viewWidth);
     const pixelHeight = Math.round(viewHeight);
@@ -2810,7 +2805,7 @@ function createEditorPreviewSandbox() {
       const parallax = Number.isFinite(layer.parallaxSpeed) ? layer.parallaxSpeed : 1;
       const layerScale = Number.isFinite(layer.scale) ? layer.scale : 1;
       const instRotRad = degToRad(inst.rotationDeg || 0);
-      const baseOffset = (pos.x - normalizedCamX * parallax) * effectiveZoom;
+      const baseOffset = (pos.x - camX * parallax) * effectiveZoom;
       const rootScreenX = baseOffset;
       const rootScreenY = groundLine + (layer.offsetY || 0) * effectiveZoom + pos.y * effectiveZoom;
       const dxScreen = baseOffset;


### PR DESCRIPTION
## Summary
- remove the centered-camera assumptions from the editor preview sandbox renderer so it aligns with the runtime camera (which provides left-edge coordinates)
- compute instance screen positions directly from the left-origin camera value to keep the sandbox imagery aligned with the HUD and player

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69194b86abe88326b9b08b1b0d60e1f9)