### PR TITLE
Scale sequence step timing with attack multipliers

### DIFF
--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -649,7 +649,7 @@ export function makeCombat(G, C, options = {}){
         if (typeof onComplete === 'function') onComplete();
         return;
       }
-      const steps = Array.isArray(sequenceSteps) ? sequenceSteps.slice() : [];
+      const steps = normalizeSequenceStepTimings(sequenceSteps, context);
       steps.sort((a,b)=> (a.startMs || 0) - (b.startMs || 0));
       const timelineState = {
         ordered,
@@ -706,7 +706,7 @@ export function makeCombat(G, C, options = {}){
       if (typeof onComplete === 'function') onComplete();
       return;
     }
-    const steps = Array.isArray(sequenceSteps) ? sequenceSteps.slice() : [];
+    const steps = normalizeSequenceStepTimings(sequenceSteps, context);
     steps.sort((a,b)=> (a.startMs || 0) - (b.startMs || 0));
     let nextStepIndex = 0;
     let stanceReset = false;
@@ -842,17 +842,43 @@ export function makeCombat(G, C, options = {}){
     normalized.forEach((step, index) => {
       const presetName = resolveSequenceStepPreset(step);
       if (!presetName) return;
-      const rawStartMs = Number.isFinite(step.startMs) ? step.startMs : 0;
+      const rawStartMs = Number.isFinite(step.rawStartMs)
+        ? step.rawStartMs
+        : Number.isFinite(step.startMs) ? step.startMs : 0;
       const startMs = applySequenceDuration(rawStartMs);
       if (index === 0 && (!startMs || startMs <= 0) && presetName === basePreset) return;
-      const preparedStep = { ...step, preset: presetName, startMs };
-      if (rawStartMs !== startMs && !Number.isFinite(step.rawStartMs)) {
-        preparedStep.rawStartMs = rawStartMs;
-      }
+      const preparedStep = {
+        ...step,
+        preset: presetName,
+        startMs,
+        rawStartMs
+      };
       prepared.push(preparedStep);
     });
     ATTACK.sequenceSteps = prepared;
     return prepared;
+  }
+
+  function normalizeSequenceStepTimings(sequenceSteps, context){
+    if (!Array.isArray(sequenceSteps) || !sequenceSteps.length) return [];
+    const applyStepDuration = typeof context?.applyDuration === 'function'
+      ? (value) => context.applyDuration(value)
+      : (value) => value;
+    return sequenceSteps
+      .map((step) => {
+        if (!step) return null;
+        const rawStart = Number.isFinite(step.rawStartMs)
+          ? step.rawStartMs
+          : Number.isFinite(step.startMs) ? step.startMs : 0;
+        const scaledStart = applyStepDuration(rawStart);
+        const hasRaw = Number.isFinite(step.rawStartMs);
+        if (hasRaw && scaledStart === step.startMs) return step;
+        const next = { ...step };
+        if (!hasRaw) next.rawStartMs = rawStart;
+        next.startMs = scaledStart;
+        return next;
+      })
+      .filter(Boolean);
   }
 
   function playAttackSequenceStep(step, context){


### PR DESCRIPTION
## Summary
- ensure attack sequence steps cache their raw offsets and apply the active duration multipliers when scheduled
- rescale sequence step timings right before running the attack timeline so buffs/debuffs keep the steps aligned with the segments

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195279775c832695cfc7a032e5712d)