### PR TITLE
Scale attack sequence timings with attack multipliers

### DIFF
--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -649,7 +649,19 @@ export function makeCombat(G, C, options = {}){
         if (typeof onComplete === 'function') onComplete();
         return;
       }
-      const steps = Array.isArray(sequenceSteps) ? sequenceSteps.slice() : [];
+      const applySequenceDuration = typeof context?.applyDuration === 'function'
+        ? (value) => context.applyDuration(value)
+        : (value) => value;
+      const steps = Array.isArray(sequenceSteps)
+        ? sequenceSteps.map((step)=>{
+            if (!step || typeof step !== 'object') return step;
+            const baseStart = Number.isFinite(step.rawStartMs) ? step.rawStartMs : step.startMs;
+            if (!Number.isFinite(baseStart)) return step;
+            const scaledStart = applySequenceDuration(baseStart);
+            if (scaledStart === step.startMs) return step;
+            return { ...step, startMs: scaledStart };
+          })
+        : [];
       steps.sort((a,b)=> (a.startMs || 0) - (b.startMs || 0));
       const timelineState = {
         ordered,
@@ -706,7 +718,19 @@ export function makeCombat(G, C, options = {}){
       if (typeof onComplete === 'function') onComplete();
       return;
     }
-    const steps = Array.isArray(sequenceSteps) ? sequenceSteps.slice() : [];
+    const applySequenceDuration = typeof context?.applyDuration === 'function'
+      ? (value) => context.applyDuration(value)
+      : (value) => value;
+    const steps = Array.isArray(sequenceSteps)
+      ? sequenceSteps.map((step)=>{
+          if (!step || typeof step !== 'object') return step;
+          const baseStart = Number.isFinite(step.rawStartMs) ? step.rawStartMs : step.startMs;
+          if (!Number.isFinite(baseStart)) return step;
+          const scaledStart = applySequenceDuration(baseStart);
+          if (scaledStart === step.startMs) return step;
+          return { ...step, startMs: scaledStart };
+        })
+      : [];
     steps.sort((a,b)=> (a.startMs || 0) - (b.startMs || 0));
     let nextStepIndex = 0;
     let stanceReset = false;


### PR DESCRIPTION
## Summary
- ensure `runAttackTimeline` recalculates cached sequence step start times using the attack context's duration multipliers so they stay aligned with the attack timeline
- keep previously stored `rawStartMs` offsets intact while scaling so the cached data can be reused safely

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691954159b4c83269dd4f39938447f0e)