### PR TITLE
Add dedicated footstep types and audio folders

### DIFF
--- a/docs/assets/audio/sfx/steps/grass/.gitkeep
+++ b/docs/assets/audio/sfx/steps/grass/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for grass footstep samples

--- a/docs/assets/audio/sfx/steps/tile/.gitkeep
+++ b/docs/assets/audio/sfx/steps/tile/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for tile footstep samples

--- a/docs/assets/audio/sfx/steps/wood/.gitkeep
+++ b/docs/assets/audio/sfx/steps/wood/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for wood footstep samples

--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -497,6 +497,10 @@ window.CONFIG = {
           head: { neck:10, radius:12 }
         },
         hierarchy: { legsFollowTorsoRotation: false },
+        footsteps: {
+          type: 'cat-foot',
+          strideScale: 1,
+        },
         ik: { calvesOnly: true },
         limits: {
           torso: { absMin:-45, absMax:90 },
@@ -564,6 +568,10 @@ window.CONFIG = {
       actor: { scale: 1 },
       parts: { hitbox:{ w:80, h:110, r:60, torsoAttach:{ nx:0.4, ny:0.6 } }, torso:{ len:55 }, arm:{ upper:35, lower:50 }, leg:{ upper:40, lower:40 }, head:{ neck:10, radius:12 } },
       hierarchy: { legsFollowTorsoRotation: false },
+      footsteps: {
+        type: 'bird-foot',
+        strideScale: 1.1,
+      },
       ik: { calvesOnly: true },
       limits: { torso:{ absMin:-45, absMax:90 }, shoulder:{ relMin:-360, relMax:-90 }, elbow:{ relMin:-170, relMax:0 }, hip:{ absMin:90, absMax:210 }, knee:{ relMin:0, relMax:170 }, head:{ relMin:75, relMax:100 } },
       headTracking: {

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -2589,6 +2589,11 @@ function createEditorPreviewSandbox() {
     if (!Number.isFinite(left) || !Number.isFinite(width) || width <= 0) return null;
     if (!Number.isFinite(height) || height <= 0) return null;
     const topOffset = Number(collider.topOffset);
+    const materialTypeRaw = typeof collider.materialType === 'string' ? collider.materialType.trim() : '';
+    const metaMaterialType = typeof collider.meta?.materialType === 'string' ? collider.meta.materialType.trim() : '';
+    const legacyStepSoundRaw = typeof collider.stepSound === 'string' ? collider.stepSound.trim() : '';
+    const legacyMetaStepSound = typeof collider.meta?.stepSound === 'string' ? collider.meta.stepSound.trim() : '';
+    const materialType = materialTypeRaw || metaMaterialType || legacyStepSoundRaw || legacyMetaStepSound || '';
     return {
       id: typeof collider.id === 'string' && collider.id.trim() ? collider.id.trim() : `col_${index}`,
       left,
@@ -2596,6 +2601,7 @@ function createEditorPreviewSandbox() {
       height,
       topOffset: Number.isFinite(topOffset) ? topOffset : 0,
       label: typeof collider.label === 'string' ? collider.label : '',
+      materialType: materialType || null,
     };
   };
 

--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -2,6 +2,7 @@
 import { pushPoseOverride, pushPoseLayerOverride } from './animator.js?v=5';
 import { resetMirror, setMirrorForPart } from './sprites.js?v=8';
 import { ensureFighterPhysics, updateFighterPhysics } from './physics.js?v=1';
+import { updateFighterFootsteps } from './footstep-audio.js?v=1';
 import {
   applyHealthRegenFromStats,
   applyStaminaTick,
@@ -2256,6 +2257,7 @@ export function makeCombat(G, C, options = {}){
       input: effectiveInput,
       attackActive: attackBlocksMovement,
     });
+    updateFighterFootsteps(p, C, dt);
   }
 
   function isFighterAttacking(){

--- a/docs/js/footstep-audio.js
+++ b/docs/js/footstep-audio.js
@@ -1,0 +1,199 @@
+// footstep-audio.js — synthesize fighter-specific footstep sounds per surface material
+
+const MATERIAL_PROFILES = {
+  default: { lowpass: 1800, pitch: 240, gain: 0.16, decay: 0.18 },
+  stone: { lowpass: 1500, pitch: 190, gain: 0.2, decay: 0.22 },
+  concrete: { lowpass: 1400, pitch: 180, gain: 0.22, decay: 0.24 },
+  wood: { lowpass: 1600, pitch: 220, gain: 0.18, decay: 0.28 },
+  metal: { lowpass: 2200, pitch: 320, gain: 0.24, decay: 0.18 },
+  glass: { lowpass: 2500, pitch: 360, gain: 0.15, decay: 0.14 },
+  ceramic: { lowpass: 2100, pitch: 280, gain: 0.18, decay: 0.18 },
+  dirt: { lowpass: 900, pitch: 140, gain: 0.2, decay: 0.32 },
+  grass: { lowpass: 1100, pitch: 150, gain: 0.18, decay: 0.3 },
+  sand: { lowpass: 700, pitch: 120, gain: 0.18, decay: 0.36 },
+  snow: { lowpass: 600, pitch: 110, gain: 0.15, decay: 0.34 },
+  ice: { lowpass: 2600, pitch: 340, gain: 0.16, decay: 0.2 },
+  water: { lowpass: 1200, pitch: 130, gain: 0.2, decay: 0.4 },
+};
+
+const FOOT_PROFILES = {
+  'cat-foot': { gain: 0.17, pitch: 1.28, strideScale: 0.92 },
+  'bird-foot': { gain: 0.22, pitch: 1.05, strideScale: 1 },
+  'sloth-foot': { gain: 0.3, pitch: 0.78, strideScale: 1.18 },
+};
+
+const FOOT_PROFILE_ALIASES = {
+  light: 'cat-foot',
+  claw: 'cat-foot',
+  boot: 'bird-foot',
+  hoof: 'bird-foot',
+  heavy: 'sloth-foot',
+};
+
+const DEFAULT_FOOT_TYPE = 'cat-foot';
+
+const MIN_STEP_SPEED = 65;
+const BASE_STRIDE_LENGTH = 52;
+const LANDING_IMPULSE_REF = 900;
+
+let audioCtx = null;
+
+function clamp(value, min, max) {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function resolveAudioContext() {
+  if (audioCtx) return audioCtx;
+  if (typeof window === 'undefined') return null;
+  const AudioCtor = window.AudioContext || window.webkitAudioContext;
+  if (typeof AudioCtor !== 'function') return null;
+  try {
+    audioCtx = new AudioCtor();
+    if (typeof audioCtx.resume === 'function') {
+      audioCtx.resume().catch(() => {});
+    }
+  } catch (error) {
+    console.warn('[footstep-audio] Unable to initialize AudioContext', error);
+    audioCtx = null;
+  }
+  return audioCtx;
+}
+
+function createNoiseBuffer(duration) {
+  const ctx = audioCtx;
+  if (!ctx) return null;
+  const sampleCount = Math.max(1, Math.floor(ctx.sampleRate * duration));
+  const buffer = ctx.createBuffer(1, sampleCount, ctx.sampleRate);
+  const channel = buffer.getChannelData(0);
+  for (let i = 0; i < channel.length; i += 1) {
+    channel[i] = (Math.random() * 2 - 1) * 0.6;
+  }
+  return buffer;
+}
+
+function resolveMaterialProfile(material, config) {
+  const cfg = config?.audio?.footsteps?.materials || {};
+  const key = (material || '').toLowerCase();
+  const base = MATERIAL_PROFILES[key] || MATERIAL_PROFILES.default;
+  const overrides = key && cfg[key]
+    ? cfg[key]
+    : cfg.default;
+  return overrides ? { ...base, ...overrides } : base;
+}
+
+function resolveFootProfile(fighter, config) {
+  const fighters = config?.fighters || {};
+  const fighterName = fighter?.renderProfile?.fighterName;
+  const fighterConfig = fighterName && fighters[fighterName] ? fighters[fighterName] : null;
+  const configProfile = fighterConfig?.footsteps || {};
+  const rawType = (configProfile.type || configProfile.footType || '').toLowerCase();
+  const type = FOOT_PROFILE_ALIASES[rawType] || rawType;
+  const base = FOOT_PROFILES[type] || FOOT_PROFILES[DEFAULT_FOOT_TYPE];
+  const overrides = config?.audio?.footsteps?.fighters?.[fighterName] || {};
+  return {
+    ...base,
+    ...overrides,
+    ...configProfile,
+  };
+}
+
+function ensureFootstepState(fighter) {
+  fighter._footstepState ||= {
+    prevOnGround: !!fighter.onGround,
+    strideProgress: 0,
+    lastMaterial: null,
+  };
+  return fighter._footstepState;
+}
+
+function computeStrideLength(config, profile) {
+  const scale = Number.isFinite(config?.actor?.scale) ? config.actor.scale : 1;
+  const strideScale = Number.isFinite(profile?.strideScale) ? profile.strideScale : 1;
+  return BASE_STRIDE_LENGTH * scale * strideScale;
+}
+
+function playFootstepSample(materialProfile, footProfile, intensity) {
+  const ctx = resolveAudioContext();
+  if (!ctx) return;
+  const now = ctx.currentTime;
+  const duration = Math.max(0.05, (materialProfile.decay || 0.2) * clamp(intensity, 0.2, 1.5));
+  const gainNode = ctx.createGain();
+  const baseGain = (materialProfile.gain ?? 0.2) * (footProfile?.gain ?? 0.2) * clamp(intensity, 0.2, 1.5);
+  gainNode.gain.setValueAtTime(baseGain, now);
+  gainNode.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+  const filter = ctx.createBiquadFilter();
+  filter.type = 'lowpass';
+  filter.frequency.setValueAtTime(materialProfile.lowpass ?? 1800, now);
+  filter.Q.setValueAtTime(1.1, now);
+
+  const noise = ctx.createBufferSource();
+  const buffer = createNoiseBuffer(duration);
+  if (buffer) noise.buffer = buffer;
+
+  const osc = ctx.createOscillator();
+  osc.type = 'triangle';
+  const footPitch = footProfile?.pitch ?? 1;
+  const basePitch = materialProfile.pitch ?? 220;
+  const jitter = basePitch * 0.08 * (Math.random() - 0.5);
+  osc.frequency.setValueAtTime((basePitch + jitter) * footPitch, now);
+  osc.frequency.exponentialRampToValueAtTime(basePitch * footPitch * 0.6, now + duration);
+
+  noise.connect(filter);
+  filter.connect(gainNode);
+  osc.connect(gainNode);
+  gainNode.connect(ctx.destination);
+
+  noise.start(now);
+  noise.stop(now + duration);
+  osc.start(now);
+  osc.stop(now + duration);
+}
+
+function resolveSurfaceMaterial(fighter, config) {
+  const raw = typeof fighter?.surfaceMaterial === 'string' ? fighter.surfaceMaterial : '';
+  if (raw) return raw;
+  const groundMaterial = typeof config?.ground?.materialType === 'string' ? config.ground.materialType : '';
+  return groundMaterial || 'default';
+}
+
+export function updateFighterFootsteps(fighter, config, dt) {
+  if (!fighter || !Number.isFinite(dt) || dt <= 0) return;
+  if (fighter.isDead || fighter.destroyed) return;
+  const state = ensureFootstepState(fighter);
+  const onGround = !!(fighter.onGround && !fighter.ragdoll);
+  const material = resolveSurfaceMaterial(fighter, config);
+  const profile = resolveFootProfile(fighter, config);
+  const materialProfile = resolveMaterialProfile(material, config);
+  const velX = Number.isFinite(fighter.vel?.x) ? fighter.vel.x : 0;
+  const speed = Math.abs(velX);
+  const strideLength = computeStrideLength(config, profile);
+  const events = [];
+
+  if (onGround && !state.prevOnGround) {
+    const impulse = Math.abs(Number(fighter.landedImpulse) || 0);
+    const normalized = clamp(impulse / LANDING_IMPULSE_REF, 0.25, 1.4);
+    events.push(normalized);
+    state.strideProgress = 0;
+  } else if (onGround && speed >= MIN_STEP_SPEED && !fighter.recovering) {
+    state.strideProgress += speed * dt;
+    const stride = Math.max(20, strideLength);
+    if (state.strideProgress >= stride) {
+      state.strideProgress -= stride;
+      const normalized = clamp(speed / 420, 0.2, 1);
+      events.push(normalized);
+    }
+  } else {
+    state.strideProgress = 0;
+  }
+
+  state.prevOnGround = onGround;
+  state.lastMaterial = material;
+
+  if (!events.length) return;
+  for (const intensity of events) {
+    playFootstepSample(materialProfile, profile, intensity);
+  }
+}

--- a/docs/js/map-bootstrap.js
+++ b/docs/js/map-bootstrap.js
@@ -210,6 +210,15 @@ function normalizeAreaCollider(input, index) {
   }
 
   const meta = safe.meta && typeof safe.meta === 'object' ? { ...safe.meta } : undefined;
+  const materialTypeRaw = typeof safe.materialType === 'string' ? safe.materialType.trim() : '';
+  const metaMaterialType = typeof meta?.materialType === 'string' ? meta.materialType.trim() : '';
+  const legacyStepSoundRaw = typeof safe.stepSound === 'string' ? safe.stepSound.trim() : '';
+  const legacyMetaStepSound = typeof meta?.stepSound === 'string' ? meta.stepSound.trim() : '';
+  const materialType = materialTypeRaw
+    || metaMaterialType
+    || legacyStepSoundRaw
+    || legacyMetaStepSound
+    || '';
 
   return {
     id,
@@ -219,6 +228,7 @@ function normalizeAreaCollider(input, index) {
     width: Math.max(1, width),
     topOffset,
     height: Math.max(1, height),
+    materialType: materialType || null,
     meta: meta ?? undefined,
   };
 }

--- a/docs/js/npc.js
+++ b/docs/js/npc.js
@@ -2,6 +2,7 @@
 
 import { initCombatForFighter } from './combat.js?v=19';
 import { ensureFighterPhysics, updateFighterPhysics, resolveFighterBodyCollisions } from './physics.js?v=1';
+import { updateFighterFootsteps } from './footstep-audio.js?v=1';
 import { applyHealthRegenFromStats, applyStaminaTick, getStatProfile } from './stat-hooks.js?v=1';
 import { ensureNpcAbilityDirector, updateNpcAbilityDirector } from './npcAbilityDirector.js?v=1';
 import { removeNpcFighter } from './fighter.js?v=8';
@@ -1060,6 +1061,7 @@ function updateNpcMovement(G, state, dt, abilityIntent = null) {
     const previousDeadTime = Number.isFinite(state.deadTime) ? state.deadTime : 0;
     state.deadTime = previousDeadTime + dt;
     updateFighterPhysics(state, C, dt, { input: null, attackActive: false });
+    updateFighterFootsteps(state, C, dt);
     fadeNpcDashTrail(visuals, dt);
     fadeNpcAttackTrailEntry(visuals, dt);
     const destroyDelay = resolveNpcDeathDestroyDelay(state);
@@ -1134,6 +1136,7 @@ function updateNpcMovement(G, state, dt, abilityIntent = null) {
 
   if (state.ragdoll || state.recovering) {
     updateFighterPhysics(state, C, dt, { input: null, attackActive: false });
+    updateFighterFootsteps(state, C, dt);
     if (state.ragdoll && aggression.triggered && !aggression.active) {
       aggression.wakeTimer = Math.max(0, (aggression.wakeTimer || 0) - dt);
       if (aggression.wakeTimer <= 0) {
@@ -1431,6 +1434,7 @@ function updateNpcMovement(G, state, dt, abilityIntent = null) {
   });
 
   updateFighterPhysics(state, C, dt, { input, attackActive });
+  updateFighterFootsteps(state, C, dt);
   if (state.mode === 'shuffle') {
     const maxShuffleSpeed = (C.movement?.maxSpeedX || 140) * (shuffleState.speedScale || 0.35);
     state.vel.x = clamp(state.vel.x, -maxShuffleSpeed, maxShuffleSpeed);

--- a/docs/js/vendor/map-runtime.js
+++ b/docs/js/vendor/map-runtime.js
@@ -849,6 +849,15 @@ function normalizeCollider(raw, fallbackIndex = 0) {
   const safe = raw && typeof raw === 'object' ? safeClone(raw) : {};
   const id = safe.id ?? safe.meta?.original?.id ?? fallbackIndex;
   const labelRaw = typeof safe.label === 'string' ? safe.label.trim() : '';
+  const materialTypeRaw = typeof safe.materialType === 'string' ? safe.materialType.trim() : '';
+  const metaMaterialType = typeof safe.meta?.materialType === 'string' ? safe.meta.materialType.trim() : '';
+  const legacyStepSoundRaw = typeof safe.stepSound === 'string' ? safe.stepSound.trim() : '';
+  const legacyMetaStepSound = typeof safe.meta?.stepSound === 'string' ? safe.meta.stepSound.trim() : '';
+  const normalizedMaterialType = materialTypeRaw
+    || metaMaterialType
+    || legacyStepSoundRaw
+    || legacyMetaStepSound
+    || '';
   let left = toNumber(safe.left ?? safe.x ?? safe.position?.x, 0);
   const rightRaw = safe.right ?? safe.meta?.original?.right;
   let width = toNumber(safe.width ?? safe.w, null);
@@ -884,6 +893,7 @@ function normalizeCollider(raw, fallbackIndex = 0) {
     width: Math.max(1, width),
     topOffset,
     height: Math.max(1, height),
+    materialType: normalizedMaterialType || null,
     meta: safe.meta ? safeClone(safe.meta) : {},
   };
 }

--- a/docs/map-editor.html
+++ b/docs/map-editor.html
@@ -366,6 +366,24 @@
         <label><span>Top offset (px)</span><input id="colliderTopOffset" type="number" step="1"></label>
         <label><span>Height (px)</span><input id="colliderHeight" type="number" step="1" min="1"></label>
       </div>
+      <div class="row">
+        <label><span>Material type</span><input id="colliderMaterialType" type="text" list="materialTypePresets" placeholder="default"></label>
+      </div>
+      <datalist id="materialTypePresets">
+        <option value="stone"></option>
+        <option value="concrete"></option>
+        <option value="wood"></option>
+        <option value="metal"></option>
+        <option value="ceramic"></option>
+        <option value="glass"></option>
+        <option value="dirt"></option>
+        <option value="grass"></option>
+        <option value="gravel"></option>
+        <option value="sand"></option>
+        <option value="snow"></option>
+        <option value="ice"></option>
+        <option value="water"></option>
+      </datalist>
       <small style="color:var(--muted);display:block;margin-top:4px">
         Offsets are relative to the ground line. Negative values lift the collider above the ground.
       </small>
@@ -962,6 +980,15 @@ function normalizeCollider(raw, fallbackId = 1){
   const id = safe.id ?? safe.meta?.original?.id ?? fallbackId;
   const labelRaw = typeof safe.label === 'string' ? safe.label.trim() : '';
   const type = (safe.type === 'box' || safe.shape === 'box') ? 'box' : 'box';
+  const materialTypeRaw = typeof safe.materialType === 'string' ? safe.materialType.trim() : '';
+  const metaMaterialType = typeof safe.meta?.materialType === 'string' ? safe.meta.materialType.trim() : '';
+  const legacyStepSoundRaw = typeof safe.stepSound === 'string' ? safe.stepSound.trim() : '';
+  const legacyMetaStepSound = typeof safe.meta?.stepSound === 'string' ? safe.meta.stepSound.trim() : '';
+  const normalizedMaterialType = materialTypeRaw
+    || metaMaterialType
+    || legacyStepSoundRaw
+    || legacyMetaStepSound
+    || '';
 
   let left = toNumber(safe.left ?? safe.x ?? safe.position?.x, 0);
   const rightRaw = safe.right ?? safe.meta?.original?.right;
@@ -997,6 +1024,7 @@ function normalizeCollider(raw, fallbackId = 1){
     width: Math.max(1, width),
     topOffset,
     height: Math.max(1, height),
+    materialType: normalizedMaterialType || null,
     meta,
   };
 }
@@ -1100,7 +1128,8 @@ function buildAreaDescriptor(){
 
   const clonedColliders = colliders.map((col, index) => {
     const normalized = normalizeCollider(col, col.id ?? index + 1);
-    return {
+    const materialType = typeof normalized.materialType === 'string' ? normalized.materialType.trim() : '';
+    const descriptor = {
       id: normalized.id ?? index + 1,
       label: typeof normalized.label === 'string' && normalized.label.trim()
         ? normalized.label.trim()
@@ -1113,6 +1142,10 @@ function buildAreaDescriptor(){
       height: Math.max(1, toNumber(normalized.height, 40) || 40),
       meta: normalized.meta ? JSON.parse(JSON.stringify(normalized.meta)) : {},
     };
+    if (materialType) {
+      descriptor.materialType = materialType;
+    }
+    return descriptor;
   });
 
   const meta = {
@@ -1653,7 +1686,9 @@ function refreshColliderList(){
     const topOffset = toNumber(col.topOffset, 0);
     const height = Math.max(0, toNumber(col.height, 0));
     const meta = document.createElement('span');
-    meta.textContent = `x:${formatColliderNumber(left)} w:${formatColliderNumber(width)} y:${formatColliderNumber(topOffset)} h:${formatColliderNumber(height)}`;
+    const materialType = typeof col.materialType === 'string' && col.materialType.trim() ? col.materialType.trim() : '';
+    const stats = `x:${formatColliderNumber(left)} w:${formatColliderNumber(width)} y:${formatColliderNumber(topOffset)} h:${formatColliderNumber(height)}`;
+    meta.textContent = materialType ? `${stats} · material:${materialType}` : stats;
     div.appendChild(title);
     div.appendChild(meta);
     div.onclick = () => {
@@ -1680,6 +1715,8 @@ function syncColliderFields(){
   if (topField) topField.value = collider ? String(toNumber(collider.topOffset, 0)) : '';
   const heightField = $('#colliderHeight');
   if (heightField) heightField.value = collider ? String(Math.max(1, toNumber(collider.height, 0))) : '';
+  const materialField = $('#colliderMaterialType');
+  if (materialField) materialField.value = collider && typeof collider.materialType === 'string' ? collider.materialType : '';
   const removeBtn = $('#btnDeleteCollider');
   if (removeBtn) removeBtn.disabled = !collider;
 }
@@ -1736,6 +1773,18 @@ function updateSelectedColliderFromFields(){
       if (!changed) pushHistory();
       changed = true;
       collider.height = Math.max(1, value);
+    }
+  }
+
+  const materialField = $('#colliderMaterialType');
+  if (materialField){
+    const raw = materialField.value.trim();
+    const normalized = raw || null;
+    const previous = typeof collider.materialType === 'string' ? collider.materialType : null;
+    if (normalized !== previous){
+      if (!changed) pushHistory();
+      changed = true;
+      collider.materialType = normalized;
     }
   }
 
@@ -1863,7 +1912,7 @@ function updateSelectedInstanceFromFields(){
   el.addEventListener('blur', updateSelectedInstanceFromFields);
 });
 
-['colliderLabel','colliderLeft','colliderWidth','colliderTopOffset','colliderHeight'].forEach(id => {
+['colliderLabel','colliderLeft','colliderWidth','colliderTopOffset','colliderHeight','colliderStepSound'].forEach(id => {
   const el = document.getElementById(id);
   if(!el) return;
   el.addEventListener('change', updateSelectedColliderFromFields);
@@ -2351,6 +2400,7 @@ function pointerDown(ev){
       width: 8,
       topOffset: offsetY,
       height: 8,
+      materialType: null,
       meta: {},
     };
     colliders.push(collider);

--- a/src/map/builderConversion.js
+++ b/src/map/builderConversion.js
@@ -591,6 +591,15 @@ function normalizeCollider(raw, fallbackIndex = 0) {
   const safe = raw && typeof raw === 'object' ? safeClone(raw) : {};
   const id = safe.id ?? safe.meta?.original?.id ?? fallbackIndex;
   const labelRaw = typeof safe.label === 'string' ? safe.label.trim() : '';
+  const materialTypeRaw = typeof safe.materialType === 'string' ? safe.materialType.trim() : '';
+  const metaMaterialType = typeof safe.meta?.materialType === 'string' ? safe.meta.materialType.trim() : '';
+  const legacyStepSoundRaw = typeof safe.stepSound === 'string' ? safe.stepSound.trim() : '';
+  const legacyMetaStepSound = typeof safe.meta?.stepSound === 'string' ? safe.meta.stepSound.trim() : '';
+  const normalizedMaterialType = materialTypeRaw
+    || metaMaterialType
+    || legacyStepSoundRaw
+    || legacyMetaStepSound
+    || '';
   let left = toNumber(safe.left ?? safe.x ?? safe.position?.x, 0);
   const rightRaw = safe.right ?? safe.meta?.original?.right;
   let width = toNumber(safe.width ?? safe.w, null);
@@ -626,6 +635,7 @@ function normalizeCollider(raw, fallbackIndex = 0) {
     width: Math.max(1, width),
     topOffset,
     height: Math.max(1, height),
+    materialType: normalizedMaterialType || null,
     meta: safe.meta ? safeClone(safe.meta) : {},
   };
 }

--- a/tests/map/builderConversion.test.js
+++ b/tests/map/builderConversion.test.js
@@ -171,8 +171,9 @@ test('convertLayoutToArea preserves collider types', () => {
     ],
     instances: [],
     colliders: [
-      { id: 'circle_one', type: 'circle', left: 0, width: 20, topOffset: 10, height: 20 },
-      { id: 'polygon_one', shape: 'polygon', left: 5, width: 40, topOffset: 5, height: 40 },
+      { id: 'circle_one', type: 'circle', left: 0, width: 20, topOffset: 10, height: 20, materialType: 'metal' },
+      { id: 'polygon_one', shape: 'polygon', left: 5, width: 40, topOffset: 5, height: 40, meta: { materialType: 'glass' } },
+      { id: 'legacy_box', type: 'box', left: 10, width: 30, topOffset: 0, height: 30, stepSound: 'ceramic' },
     ],
   };
 
@@ -180,6 +181,10 @@ test('convertLayoutToArea preserves collider types', () => {
 
   assert.equal(area.colliders[0].type, 'circle');
   assert.equal(area.colliders[1].type, 'polygon');
+  assert.equal(area.colliders[2].type, 'box');
+  assert.equal(area.colliders[0].materialType, 'metal');
+  assert.equal(area.colliders[1].materialType, 'glass');
+  assert.equal(area.colliders[2].materialType, 'ceramic');
 });
 
 test('convertLayouts rejects duplicate area ids', () => {


### PR DESCRIPTION
## Summary
- add cat-foot, bird-foot, and sloth-foot audio profiles (with aliases for legacy names) to the runtime footstep synthesizer
- update the existing fighter configs to use the new footstep types and scaffold asset folders for tile, wood, and grass step audio

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919561914a883269296832ab3dce5df)