### PR TITLE
Use cat/sloth tile footstep sample names

### DIFF
--- a/docs/map-editor.html
+++ b/docs/map-editor.html
@@ -1912,7 +1912,7 @@ function updateSelectedInstanceFromFields(){
   el.addEventListener('blur', updateSelectedInstanceFromFields);
 });
 
-['colliderLabel','colliderLeft','colliderWidth','colliderTopOffset','colliderHeight','colliderStepSound'].forEach(id => {
+['colliderLabel','colliderLeft','colliderWidth','colliderTopOffset','colliderHeight','colliderMaterialType'].forEach(id => {
   const el = document.getElementById(id);
   if(!el) return;
   el.addEventListener('change', updateSelectedColliderFromFields);


### PR DESCRIPTION
## Summary
- hook the collider material type input into the change/blur listeners so edits are saved

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197898bda08326a63957e8535c6211)