### PR TITLE
Fix duplicate playFootstepSample declaration

### DIFF
--- a/docs/js/footstep-audio.js
+++ b/docs/js/footstep-audio.js
@@ -136,7 +136,7 @@ function computeStrideLength(config, profile) {
   return BASE_STRIDE_LENGTH * scale * strideScale;
 }
 
-function playFootstepSample(materialProfile, footProfile, intensity) {
+function playSyntheticFootstep(materialProfile, footProfile, intensity) {
   const ctx = resolveAudioContext();
   if (!ctx) return;
   const now = ctx.currentTime;


### PR DESCRIPTION
## Summary
- rename the synthetic footstep helper to `playSyntheticFootstep` to avoid colliding with the exported footstep dispatcher

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691986b1af3483269581cef01727d0fa)