### PR TITLE
Remove fallback background fill

### DIFF
--- a/docs/js/render.js
+++ b/docs/js/render.js
@@ -541,8 +541,6 @@ export function renderAll(ctx){
 
   // Fallback background so the viewport is never visually blank
   try{
-    ctx.fillStyle = '#eaeaea';
-    ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
     // If parallax isn't configured, draw a minimal horizon + ground
     if (!window.PARALLAX || !window.PARALLAX.areas || !window.PARALLAX.areas[window.PARALLAX.currentAreaId]){
       const groundY = Math.floor(ctx.canvas.height * 0.8);


### PR DESCRIPTION
## Summary
- remove the fallback canvas fill so the page background can show through when rendering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691987ddd1848326a63a7be2fc0440c3)