### PR TITLE
Add tiler support to map conversion

### DIFF
--- a/src/map/MapRegistry.js
+++ b/src/map/MapRegistry.js
@@ -201,6 +201,9 @@ function validateAreaDescriptor(descriptor) {
   if (!Array.isArray(descriptor.instances) && !Array.isArray(descriptor.props)) {
     warnings.push('Area declares neither "instances" nor "props" – runtime may need one');
   }
+  if (descriptor.tilers && !Array.isArray(descriptor.tilers)) {
+    warnings.push('"tilers" should be an array when provided');
+  }
 
   let seenInstanceIds = null;
   if (Array.isArray(descriptor.instances)) {

--- a/tests/attack-timeline-state.test.js
+++ b/tests/attack-timeline-state.test.js
@@ -42,6 +42,7 @@ test('attack timeline retains a single definition and exposes timeline state', a
 
   const runTimelineSrc = extractFunction(source, 'runAttackTimeline');
   const updateTimelineSrc = extractFunction(source, 'updateAttackTimeline');
+  const normalizeStepsSrc = extractFunction(source, 'normalizeSequenceStepTimings');
 
   const script = [
     'const ATTACK = { timelineState: null };',
@@ -52,6 +53,7 @@ test('attack timeline retains a single definition and exposes timeline state', a
     'function startTransition(pose, phase, duration, callback) {',
     '  lastTransitionCallback = callback;',
     '}',
+    normalizeStepsSrc,
     runTimelineSrc,
     '',
     updateTimelineSrc,


### PR DESCRIPTION
## Summary
- add tiler extraction/normalization to the map builder conversion flow, including helpers to derive visual tilers from collider metadata
- ensure the registry validation surfaces a warning when tilers are provided in the wrong format
- expand the test suite with coverage for tilers and make the attack timeline test load its helper dependency

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198ab153048326a2c5ab7d27284d9b)