### PR TITLE
Remove duplicate clampValue helper

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -2343,13 +2343,6 @@ function prefabPartSortKey(entry) {
   return layerPriority * 10_000 + (Number.isFinite(z) ? z : 0) * 100 + rotationBias;
 }
 
-function clampValue(v, min, max) {
-  if (!Number.isFinite(v)) return min;
-  if (v < min) return min;
-  if (v > max) return max;
-  return v;
-}
-
 function lerpValue(a, b, t) {
   if (!Number.isFinite(a)) a = 0;
   if (!Number.isFinite(b)) b = 0;


### PR DESCRIPTION
## Summary
- remove the duplicate clampValue declaration from docs/js/app.js to prevent redeclaration errors
- rely on the existing earlier clampValue helper for subsequent uses

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a424451c88326b8446893dfbd5d4b)