### PR TITLE
Add stretch quad controls

### DIFF
--- a/docs/map-editor.html
+++ b/docs/map-editor.html
@@ -423,6 +423,26 @@
         <label><span>Rot (deg)</span><input id="instRot" type="number" step="1"></label>
       </div>
       <div class="row">
+        <label style="flex:none;display:flex;align-items:center;gap:4px">
+          <input id="instStretchEnabled" type="checkbox">
+          <span>Stretch quad</span>
+        </label>
+        <label>
+          <span>Target layer</span>
+          <select id="instStretchLayer" class="hidden-select"></select>
+        </label>
+      </div>
+      <div class="row">
+        <label><span>Top height (px)</span><input id="instStretchHeight" type="number" step="1" min="1"></label>
+        <label><span>Top offset (px)</span><input id="instStretchTopOffset" type="number" step="1"></label>
+      </div>
+      <div class="row">
+        <label><span>Slices</span><input id="instStretchSlices" type="number" step="1" min="4" max="80"></label>
+      </div>
+      <small style="color:var(--muted);display:block;margin-top:4px">
+        Stretch quads span the selected prefab toward another layer. Leave disabled to render normally.
+      </small>
+      <div class="row">
         <label><span>&nbsp;</span><button id="btnDuplicateInst">Duplicate</button></label>
       </div>
       <small style="color:var(--muted);display:block;margin-top:4px">
@@ -943,6 +963,28 @@ function normalizeScale(scale){
   return { x, y };
 }
 
+function normalizeStretchQuadSpec(raw){
+  if (!raw || typeof raw !== 'object') return null;
+  const targetLayerId = typeof raw.targetLayerId === 'string' ? raw.targetLayerId.trim() : '';
+  const height = toNumber(raw.height ?? raw.span ?? raw.topHeight ?? raw.topAboveGround, null);
+  if (!targetLayerId || !Number.isFinite(height) || height <= 0) return null;
+
+  const topOffset = toNumber(raw.topOffset ?? raw.topYOffset ?? raw.yOffset, 0) || 0;
+  const slicesRaw = Math.round(toNumber(raw.slices ?? raw.strips ?? raw.steps, 24) || 24);
+  const slices = clamp(slicesRaw, 4, 80);
+
+  return { targetLayerId, height, topOffset, slices };
+}
+
+function getStretchQuadMeta(inst){
+  const meta = inst?.meta && typeof inst.meta === 'object' ? inst.meta : null;
+  if (!meta) return { spec: null, key: null };
+  if (meta.stretchQuad) return { spec: normalizeStretchQuadSpec(meta.stretchQuad), key: 'stretchQuad' };
+  if (meta.groundSpan) return { spec: normalizeStretchQuadSpec(meta.groundSpan), key: 'groundSpan' };
+  if (meta.drumSkin) return { spec: normalizeStretchQuadSpec(meta.drumSkin), key: 'drumSkin' };
+  return { spec: null, key: null };
+}
+
 function normalizeLayer(layer, index = 0){
   const safe = layer && typeof layer === 'object' ? JSON.parse(JSON.stringify(layer)) : {};
   const id = safe.id || `layer_${index}`;
@@ -1246,8 +1288,16 @@ function getGroundOffset(){
 function rebuildActiveLayerSelect(){
   const sel = $('#activeLayerSelect');
   const instLayerSel = $('#instLayer');
+  const stretchLayerSel = $('#instStretchLayer');
   sel.innerHTML = '';
   instLayerSel.innerHTML = '';
+  if (stretchLayerSel){
+    stretchLayerSel.innerHTML = '';
+    const noneOpt = document.createElement('option');
+    noneOpt.value = '';
+    noneOpt.textContent = '—';
+    stretchLayerSel.appendChild(noneOpt);
+  }
   layers.forEach(layer=>{
     const o = document.createElement('option');
     o.value = layer.id; o.textContent = layer.name;
@@ -1255,6 +1305,11 @@ function rebuildActiveLayerSelect(){
     const o2 = document.createElement('option');
     o2.value = layer.id; o2.textContent = layer.name;
     instLayerSel.appendChild(o2);
+    if (stretchLayerSel){
+      const o3 = document.createElement('option');
+      o3.value = layer.id; o3.textContent = layer.name;
+      stretchLayerSel.appendChild(o3);
+    }
   });
   if(!findLayer(activeLayerId) && layers.length){
     activeLayerId = layers[0].id;
@@ -1642,6 +1697,11 @@ function fillInstEditor(){
     $('#instScaleY').value='';
     $('#instOffY').value='';
     $('#instRot').value='';
+    $('#instStretchEnabled').checked = false;
+    $('#instStretchLayer').value = '';
+    $('#instStretchHeight').value = '';
+    $('#instStretchTopOffset').value = '';
+    $('#instStretchSlices').value = 24;
     return;
   }
   $('#instId').value=inst.id;
@@ -1655,6 +1715,12 @@ function fillInstEditor(){
   $('#instScaleY').value=scale.y;
   $('#instOffY').value=pos.y;
   $('#instRot').value=Number.isFinite(inst.rotationDeg) ? inst.rotationDeg : 0;
+  const stretch = getStretchQuadMeta(inst).spec;
+  $('#instStretchEnabled').checked = !!stretch;
+  $('#instStretchLayer').value = stretch?.targetLayerId || '';
+  $('#instStretchHeight').value = stretch?.height ?? '';
+  $('#instStretchTopOffset').value = stretch?.topOffset ?? '';
+  $('#instStretchSlices').value = stretch?.slices ?? 24;
 }
 
 function getSelectedCollider(){
@@ -1898,13 +1964,53 @@ function updateSelectedInstanceFromFields(){
     }
   }
 
+  const stretchEnabled = $('#instStretchEnabled').checked;
+  const stretchTarget = ($('#instStretchLayer').value || '').trim();
+  const stretchHeight = parseFloat($('#instStretchHeight').value);
+  const stretchTopOffset = parseFloat($('#instStretchTopOffset').value);
+  const stretchSlices = parseInt($('#instStretchSlices').value, 10);
+
+  const currentStretch = getStretchQuadMeta(inst);
+  const nextStretch = (() => {
+    if (!stretchEnabled) return null;
+    const normalizedHeight = Number.isFinite(stretchHeight) ? stretchHeight : null;
+    if (!stretchTarget || normalizedHeight === null || normalizedHeight <= 0){
+      return null;
+    }
+    return {
+      targetLayerId: stretchTarget,
+      height: normalizedHeight,
+      topOffset: Number.isFinite(stretchTopOffset) ? stretchTopOffset : 0,
+      slices: Number.isFinite(stretchSlices) ? clamp(Math.round(stretchSlices), 4, 80) : 24,
+    };
+  })();
+
+  const serializeSpec = (spec) => (spec ? JSON.stringify(spec) : null);
+  if (serializeSpec(currentStretch.spec) !== serializeSpec(nextStretch)){
+    if(!changed) pushHistory();
+    changed = true;
+    if(!inst.meta || typeof inst.meta !== 'object') inst.meta = {};
+    if(nextStretch){
+      inst.meta.stretchQuad = nextStretch;
+      if (currentStretch.key && currentStretch.key !== 'stretchQuad'){
+        delete inst.meta[currentStretch.key];
+      }
+    } else {
+      delete inst.meta.stretchQuad;
+      if (currentStretch.key){
+        delete inst.meta[currentStretch.key];
+      }
+    }
+  }
+
   if(changed){
     refreshInstanceList();
   }
 }
 
 ['instPrefab','instLayer','instLocked',
- 'instScaleX','instScaleY','instOffY','instRot','instX'
+ 'instScaleX','instScaleY','instOffY','instRot','instX',
+ 'instStretchEnabled','instStretchLayer','instStretchHeight','instStretchTopOffset','instStretchSlices'
 ].forEach(id=>{
   const el = document.getElementById(id);
   if(!el) return;


### PR DESCRIPTION
## Summary
- add stretch-quad controls to the selected instance panel, including target layer, height, offset, and slice inputs
- normalize stretch-quad metadata when loading instances and populate the target-layer select
- persist stretch-quad settings into instance metadata with history support

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a4af26ec08326a36d5d610674a519)