### PR TITLE
Ensure offset edits trigger live preview

### DIFF
--- a/docs/js/cosmetic-editor-app.js
+++ b/docs/js/cosmetic-editor-app.js
@@ -3115,6 +3115,7 @@ class CosmeticEditorApp {
     }
     this.cleanupEmptyOverrides(slot);
     this.overrideManager.refreshOutputs();
+    this.queuePreviewRender();
   }
 
   getEffectivePartImage(slot, cosmetic, partKey, layerPosition){


### PR DESCRIPTION
## Summary
- trigger preview rerender after clothing style edits so offset tweaks appear immediately in the editor

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a4f0754fc8326b3b71403e507c119)