### PR TITLE
Add HUD arch demo documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+*.log
+.DS_Store
+
+# Build artifacts
+/dist
+npm-debug.log*

--- a/docs/hud-arch-demo.html
+++ b/docs/hud-arch-demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>HUD Arch Demo</title>
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="hud-arch.css">
+  <style>
+    body {
+      background: radial-gradient(circle at 20% 20%, #111827, #0b1221 40%, #020617 75%);
+      color: #e2e8f0;
+      min-height: 100vh;
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      overflow: hidden;
+    }
+
+    .page-shell {
+      position: relative;
+      min-height: 100vh;
+    }
+
+    .intro-card {
+      position: absolute;
+      top: 24px;
+      left: 24px;
+      max-width: 540px;
+      background: rgba(15, 23, 42, 0.86);
+      border: 1px solid rgba(148, 163, 184, 0.5);
+      box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55);
+      border-radius: 16px;
+      padding: 18px 20px;
+      line-height: 1.6;
+      color: #e5e7eb;
+      backdrop-filter: blur(6px);
+    }
+
+    .intro-card h1 {
+      margin: 0 0 10px;
+      font-size: 20px;
+      letter-spacing: 0.01em;
+    }
+
+    .intro-card code {
+      background: rgba(15, 23, 42, 0.9);
+      border-radius: 6px;
+      padding: 2px 5px;
+      border: 1px solid rgba(148, 163, 184, 0.5);
+      color: #a5b4fc;
+    }
+
+    .intro-card ul {
+      padding-left: 20px;
+      margin: 8px 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="page-shell">
+    <div class="intro-card">
+      <h1>HUD Arch Buttons</h1>
+      <p>
+        This page demonstrates the minimal standalone HUD arch layout. Update
+        <code>docs/js/hud-arch-config.js</code> to change button ordering,
+        arc length percentages, gaps, and sprite images. Hook your existing
+        ability logic where noted in <code>docs/js/hud-arch.js</code>.
+      </p>
+      <ul>
+        <li><strong>Resize-aware</strong>: buttons rebuild on window resize.</li>
+        <li><strong>Debug overlay</strong>: enable or disable via config.</li>
+        <li><strong>Sprites optional</strong>: swap in your own assets.</li>
+      </ul>
+    </div>
+  </div>
+
+  <script src="js/hud-arch-config.js"></script>
+  <script src="js/hud-arch.js"></script>
+</body>
+</html>

--- a/docs/hud-arch.css
+++ b/docs/hud-arch.css
@@ -1,0 +1,55 @@
+/* Fullscreen HUD layer that holds the arch buttons */
+.arch-hud {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 200;
+}
+
+/* Individual buttons */
+.arch-hud__button {
+  position: absolute;
+  width: var(--arch-button-size, 84px);
+  height: var(--arch-button-size, 84px);
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.94);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.6);
+  border: 2px solid rgba(148, 163, 184, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  touch-action: manipulation;
+  overflow: hidden;
+}
+
+.arch-hud__button img {
+  width: 72%;
+  height: 72%;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+/* Optional: you can add hover/pressed styles if needed */
+.arch-hud__button:active {
+  transform: scale(0.96) translateZ(0);
+}
+
+/* Debug markers */
+.arch-hud__debug-dot {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #22c55e;
+  pointer-events: none;
+}
+
+.arch-hud__debug-line {
+  position: absolute;
+  width: 2px;
+  height: 18px;
+  background: rgba(248, 250, 252, 0.7);
+  transform-origin: 50% 100%;
+  pointer-events: none;
+}

--- a/docs/js/hud-arch-config.js
+++ b/docs/js/hud-arch-config.js
@@ -1,0 +1,52 @@
+// HUD arch configuration
+window.HUD_ARCH_CONFIG = {
+  arch: {
+    // circle geometry
+    radiusPx: 150, // distance from arch center to button centers
+    startAngleDeg: -150, // where the arch starts (deg, clockwise from +X)
+    endAngleDeg: -30, // where the arch ends
+    anchor: {
+      // where the circle center sits on screen (0–1)
+      x: 0.9, // near bottom-right
+      y: 0.9
+    },
+
+    scale: 1.0, // global multiplier (can tie to character scale)
+    buttonSizePx: 84, // base button square size
+    defaultGapPx: 10, // default carving distance per segment
+    rotateWithArch: true, // rotate along tangent? (fan out)
+    debug: true // on-screen debug overlay
+  },
+
+  // YOU ONLY EDIT THIS LIST:
+  buttons: [
+    {
+      id: "attackHeavy",
+      order: 0, // first clockwise
+      lengthPct: 0.24, // 24% of full arch length
+      gapPx: 14, // carve 7px off each side AFTER placement math
+      sprite: "img/ui/btn-heavy.png"
+    },
+    {
+      id: "attackLight",
+      order: 1,
+      lengthPct: 0.2,
+      gapPx: 10,
+      sprite: "img/ui/btn-light.png"
+    },
+    {
+      id: "attackSpecial",
+      order: 2,
+      lengthPct: 0.22,
+      gapPx: 12,
+      sprite: "img/ui/btn-special.png"
+    },
+    {
+      id: "attackUtility",
+      order: 3,
+      lengthPct: 0.34,
+      gapPx: 14,
+      sprite: "img/ui/btn-utility.png"
+    }
+  ]
+};

--- a/docs/js/hud-arch.js
+++ b/docs/js/hud-arch.js
@@ -1,0 +1,165 @@
+(function () {
+  const CFG = window.HUD_ARCH_CONFIG;
+
+  function vpX(frac) {
+    return frac * window.innerWidth;
+  }
+  function vpY(frac) {
+    return frac * window.innerHeight;
+  }
+
+  function buildButtonArch(rootEl) {
+    const archCfg = CFG.arch;
+    const btnCfgs = [...CFG.buttons];
+
+    const container = document.createElement("div");
+    container.className = "arch-hud";
+    container.style.setProperty(
+      "--arch-button-size",
+      `${archCfg.buttonSizePx * (archCfg.scale || 1)}px`
+    );
+
+    rootEl.appendChild(container);
+
+    const radius = archCfg.radiusPx * (archCfg.scale || 1);
+    const startRad = (archCfg.startAngleDeg * Math.PI) / 180;
+    const endRad = (archCfg.endAngleDeg * Math.PI) / 180;
+    const totalAngle = endRad - startRad; // signed
+    const totalLength = Math.abs(radius * totalAngle);
+
+    const cx = vpX(archCfg.anchor.x);
+    const cy = vpY(archCfg.anchor.y);
+
+    btnCfgs.sort((a, b) => a.order - b.order);
+
+    let cursorLen = 0;
+    const debug = archCfg.debug;
+    const debugInfo = [];
+
+    btnCfgs.forEach((btnCfg) => {
+      const segLength = btnCfg.lengthPct * totalLength;
+      const gap = btnCfg.gapPx != null ? btnCfg.gapPx : archCfg.defaultGapPx || 0;
+
+      // Raw segment along arc
+      const rawStart = cursorLen;
+      const rawEnd = cursorLen + segLength;
+
+      // Carve AFTER sizing
+      const carvedStart = rawStart + gap / 2;
+      const carvedEnd = rawEnd - gap / 2;
+
+      const startL = Math.min(carvedStart, carvedEnd);
+      const endL = Math.max(carvedStart, carvedEnd);
+      const centerL = (startL + endL) * 0.5;
+
+      const t = centerL / totalLength; // 0..1 along the arch
+      const angleAlong = totalAngle * t + startRad; // radians
+
+      const x = cx + radius * Math.cos(angleAlong);
+      const y = cy + radius * Math.sin(angleAlong);
+
+      const size = archCfg.buttonSizePx * (archCfg.scale || 1);
+      const halfSize = size / 2;
+
+      const btnEl = document.createElement("button");
+      btnEl.className = "arch-hud__button";
+      btnEl.id = `arch-btn-${btnCfg.id}`;
+
+      let rotDeg = 0;
+      if (archCfg.rotateWithArch) {
+        rotDeg = (angleAlong * 180) / Math.PI + 90;
+      }
+
+      btnEl.style.left = `${x - halfSize}px`;
+      btnEl.style.top = `${y - halfSize}px`;
+      btnEl.style.transform = `rotate(${rotDeg}deg)`;
+
+      if (btnCfg.sprite) {
+        const img = document.createElement("img");
+        img.src = btnCfg.sprite;
+        img.alt = btnCfg.id;
+        btnEl.appendChild(img);
+      }
+
+      // --- Hook your existing ability logic here ----------------------------
+      // Example:
+      // btnEl.addEventListener("pointerdown", () => triggerAbility(btnCfg.id));
+      // Replace `triggerAbility` with whatever your current buttons call.
+      // ----------------------------------------------------------------------
+
+      container.appendChild(btnEl);
+
+      if (debug) {
+        debugInfo.push({
+          id: btnCfg.id,
+          rawStart,
+          rawEnd,
+          carvedStart: startL,
+          carvedEnd: endL,
+          angleDeg: (angleAlong * 180) / Math.PI,
+          screenX: x,
+          screenY: y
+        });
+
+        const dot = document.createElement("div");
+        dot.className = "arch-hud__debug-dot";
+        dot.style.left = `${x - 3}px`;
+        dot.style.top = `${y - 3}px`;
+        container.appendChild(dot);
+
+        const line = document.createElement("div");
+        line.className = "arch-hud__debug-line";
+        line.style.left = `${x - 1}px`;
+        line.style.top = `${y - radius - 18}px`;
+        line.style.transform = `rotate(${(angleAlong * 180) / Math.PI}deg)`;
+        container.appendChild(line);
+      }
+
+      cursorLen += segLength;
+    });
+
+    if (debug) {
+      const dbg = document.createElement("pre");
+      dbg.style.position = "fixed";
+      dbg.style.left = "8px";
+      dbg.style.bottom = "8px";
+      dbg.style.maxWidth = "70vw";
+      dbg.style.maxHeight = "40vh";
+      dbg.style.overflow = "auto";
+      dbg.style.fontSize = "10px";
+      dbg.style.background = "rgba(15,23,42,0.9)";
+      dbg.style.color = "#e5e7eb";
+      dbg.style.padding = "6px 8px";
+      dbg.style.borderRadius = "6px";
+      dbg.style.zIndex = "999";
+      dbg.textContent = JSON.stringify(debugInfo, null, 2);
+      container.appendChild(dbg);
+    }
+
+    return container;
+  }
+
+  let currentContainer = null;
+  let resizeTimer = null;
+
+  function rebuildArchHUD() {
+    const root = document.body; // or your HUD root element
+    if (currentContainer && currentContainer.parentNode) {
+      currentContainer.parentNode.removeChild(currentContainer);
+    }
+    currentContainer = buildButtonArch(root);
+  }
+
+  // Public API you can call from elsewhere if the scale/anchor changes
+  window.rebuildArchHUD = rebuildArchHUD;
+
+  function initArchHUD() {
+    rebuildArchHUD();
+    window.addEventListener("resize", () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(rebuildArchHUD, 80);
+    });
+  }
+
+  window.addEventListener("DOMContentLoaded", initArchHUD);
+})();

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -25,6 +25,7 @@
       <li><a href="cosmetic-editor.html">Cosmetic Editor</a></li>
       <li><a href="map-editor.html">Map Editor</a></li>
       <li><a href="structure_builder_v10.html">Structure Builder v10</a></li>
+      <li><a href="hud-arch-demo.html">HUD Arch Demo</a></li>
     </ul>
   </div>
   <div class="section">


### PR DESCRIPTION
## Summary
- add standalone HUD arch configuration, layout script, and styles
- create a HUD arch demo page showcasing configuration guidance
- add an ignore file and link the new demo from the docs table of contents

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69215b49d41c8326a68f105da75866db)