### PR TITLE
Preserve drum skin data when normalizing area descriptors

### DIFF
--- a/src/map/builderConversion.js
+++ b/src/map/builderConversion.js
@@ -309,7 +309,11 @@ function normalizeAreaDescriptor(area, options = {}) {
       : [];
   const rawColliders = Array.isArray(area.colliders) ? area.colliders : [];
   const rawTilers = Array.isArray(area.tilers) ? area.tilers : [];
-  const rawDrumSkins = Array.isArray(area.drumSkins) ? area.drumSkins : [];
+  const rawDrumSkins = Array.isArray(area.drumSkins)
+    ? area.drumSkins
+    : Array.isArray(area.meta?.raw?.drumSkins)
+      ? area.meta.raw.drumSkins
+      : [];
 
   const warnings = Array.isArray(area.warnings) ? [...area.warnings] : [];
   if (!Array.isArray(area.layers)) {

--- a/tests/map/builderConversion.test.js
+++ b/tests/map/builderConversion.test.js
@@ -89,6 +89,38 @@ test('convertLayoutToArea normalizes area descriptors', () => {
   assert.equal(area.warnings.length, 0);
 });
 
+test('convertLayoutToArea preserves drum skins from area descriptors', () => {
+  const areaDescriptor = {
+    id: 'drum_area',
+    camera: { startX: 0, startZoom: 1 },
+    ground: { offset: 0 },
+    layers: [
+      { id: 'layerA', name: 'Layer A', parallaxSpeed: 1, offsetY: 0, separation: 100 },
+      { id: 'layerB', name: 'Layer B', parallaxSpeed: 1, offsetY: 0, separation: 100 },
+    ],
+    instances: [],
+    meta: {
+      raw: {
+        drumSkins: [
+          { layerA: 'layerA', layerB: 'layerB', heightA: 12, heightB: -6, tileScale: 1.5, imageURL: 'pattern.png' },
+        ],
+      },
+    },
+  };
+
+  const area = convertLayoutToArea(areaDescriptor);
+
+  assert.equal(area.drumSkins.length, 1);
+  const skin = area.drumSkins[0];
+  assert.equal(skin.layerA, 'layerA');
+  assert.equal(skin.layerB, 'layerB');
+  assert.equal(skin.heightA, 12);
+  assert.equal(skin.heightB, -6);
+  assert.equal(skin.tileScale, 1.5);
+  assert.equal(skin.imageURL, 'pattern.png');
+  assert.equal(skin.visible, true);
+});
+
 test('convertLayoutToArea generates fallback prefab art when prefab is missing', () => {
   const layout = {
     areaId: 'prefab_fallback',


### PR DESCRIPTION
## Summary
- ensure drum skin layers are retained when normalizing prebuilt area descriptors
- add coverage to verify drum skins survive area descriptor conversion

## Testing
- node --test tests/map/builderConversion.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69215bc867f4832686f0104454ae5a55)