### PR TITLE
Add shared map builder configuration

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -378,6 +378,14 @@ const SLAM_MOVE_POSES = {
 };
 
 window.CONFIG = {
+  mapBuilder: {
+    sourceId: 'map-builder-layered-v15f',
+    fallbackBoxMinWidth: 18,
+    tagInstanceIdMapping: {
+      'spawn:player': 'player_spawn',
+      'spawn:npc': 'npc_spawn',
+    },
+  },
   actor: { scale: 0.70 },
   groundRatio: 0.70,
   canvas: { w: 720, h: 460, scale: 1 },

--- a/src/map/builderConversion.js
+++ b/src/map/builderConversion.js
@@ -1,11 +1,10 @@
-const SOURCE_ID = 'map-builder-layered-v15f';
+import { mapBuilderConfig } from './mapBuilderConfig.js';
 
-const FALLBACK_BOX_MIN_WIDTH = 18;
-
-const TAG_INSTANCE_ID_MAPPING = new Map([
-  ['spawn:player', 'player_spawn'],
-  ['spawn:npc', 'npc_spawn'],
-]);
+const {
+  sourceId: SOURCE_ID,
+  fallbackBoxMinWidth: FALLBACK_BOX_MIN_WIDTH,
+  tagInstanceIdMapping: TAG_INSTANCE_ID_MAPPING,
+} = mapBuilderConfig;
 
 function normalizeErrorInfo(raw) {
   if (!raw) {

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -1,2 +1,3 @@
 export { MapRegistry, MapRegistryError } from './MapRegistry.js';
 export { convertLayoutToArea, convertLayouts } from './builderConversion.js';
+export { mapBuilderConfig, loadMapBuilderConfig, getDefaultMapBuilderConfig } from './mapBuilderConfig.js';

--- a/src/map/mapBuilderConfig.js
+++ b/src/map/mapBuilderConfig.js
@@ -1,0 +1,78 @@
+const DEFAULT_SOURCE_ID = 'map-builder-layered-v15f';
+const DEFAULT_FALLBACK_BOX_MIN_WIDTH = 18;
+const DEFAULT_TAG_INSTANCE_ID_MAPPING = new Map([
+  ['spawn:player', 'player_spawn'],
+  ['spawn:npc', 'npc_spawn'],
+]);
+
+const cloneDefaultMapping = () => new Map(DEFAULT_TAG_INSTANCE_ID_MAPPING);
+
+const normalizeSourceId = (value) => {
+  if (typeof value === 'string') {
+    const text = value.trim();
+    if (text) return text;
+  }
+  return DEFAULT_SOURCE_ID;
+};
+
+const normalizeFallbackWidth = (value) => {
+  const size = Number(value);
+  if (Number.isFinite(size) && size > 0) {
+    return Math.max(4, Math.floor(size));
+  }
+  return DEFAULT_FALLBACK_BOX_MIN_WIDTH;
+};
+
+const normalizeMapping = (rawMapping) => {
+  const normalized = new Map();
+
+  const addEntry = (tag, instanceId) => {
+    const key = typeof tag === 'string' ? tag.trim() : '';
+    const value = typeof instanceId === 'string' ? instanceId.trim() : '';
+    if (key && value) {
+      normalized.set(key, value);
+    }
+  };
+
+  if (rawMapping instanceof Map) {
+    rawMapping.forEach((value, key) => addEntry(key, value));
+  } else if (Array.isArray(rawMapping)) {
+    rawMapping.forEach(([key, value]) => addEntry(key, value));
+  } else if (rawMapping && typeof rawMapping === 'object') {
+    Object.entries(rawMapping).forEach(([key, value]) => addEntry(key, value));
+  }
+
+  return normalized.size ? normalized : cloneDefaultMapping();
+};
+
+const readRawConfig = () => {
+  if (typeof globalThis !== 'undefined' && globalThis.CONFIG?.mapBuilder) {
+    return globalThis.CONFIG.mapBuilder;
+  }
+  return null;
+};
+
+export const getDefaultMapBuilderConfig = () => ({
+  sourceId: DEFAULT_SOURCE_ID,
+  fallbackBoxMinWidth: DEFAULT_FALLBACK_BOX_MIN_WIDTH,
+  tagInstanceIdMapping: cloneDefaultMapping(),
+});
+
+export const loadMapBuilderConfig = (rawConfig = readRawConfig()) => {
+  const defaults = getDefaultMapBuilderConfig();
+  const config = rawConfig && typeof rawConfig === 'object' ? rawConfig : {};
+
+  return {
+    sourceId: normalizeSourceId(config.sourceId ?? config.SOURCE_ID),
+    fallbackBoxMinWidth: normalizeFallbackWidth(
+      config.fallbackBoxMinWidth ?? config.FALLBACK_BOX_MIN_WIDTH,
+    ),
+    tagInstanceIdMapping: normalizeMapping(
+      config.tagInstanceIdMapping ?? config.tagToInstanceIdMapping,
+    ),
+    defaults,
+  };
+};
+
+export const mapBuilderConfig = loadMapBuilderConfig();
+


### PR DESCRIPTION
## Summary
- add a mapBuilder section to the docs config to centralize map tooling defaults
- introduce a mapBuilder config adapter for node/browser use and export it from the map module
- update builder conversion utilities to consume the shared config with safe fallbacks

## Testing
- node --test tests/map/builderConversion.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69215fa983408326b5a3e24aa9d98028)