### PR TITLE
Refactor map bootstrap defaults

### DIFF
--- a/docs/js-src/map-bootstrap.ts
+++ b/docs/js-src/map-bootstrap.ts
@@ -28,6 +28,11 @@ type MapLayoutConfig = {
   areaName: string | null;
 };
 
+const FALLBACK_LAYOUT_PATH = '../config/maps/defaultdistrict.layout.json';
+const FALLBACK_AREA_ID = 'defaultdistrict';
+const FALLBACK_AREA_NAME = 'DefaultDistrict';
+const FALLBACK_PREVIEW_STORAGE_PREFIX = 'sok-map-editor-preview:';
+
 const AREA_NAME_ELEMENT_ID = 'areaName';
 const AREA_OVERLAY_UNSUB_KEY = '__sokAreaNameOverlayUnsub__' as const;
 
@@ -113,7 +118,7 @@ function normalizeLayoutEntry(entry: unknown): MapLayoutConfig | null {
   return { id, path, areaName };
 }
 
-function resolveLayoutUrl(path: string | null | undefined): URL {
+function resolveLayoutUrl(path: string | null | undefined, fallbackPath = FALLBACK_LAYOUT_PATH): URL {
   if (typeof path === 'string' && path.trim()) {
     try {
       const base = typeof window !== 'undefined' && window.location ? window.location.href : import.meta.url;
@@ -122,27 +127,87 @@ function resolveLayoutUrl(path: string | null | undefined): URL {
       console.warn('[map-bootstrap] Failed to resolve configured layout path', error);
     }
   }
-  return new URL('../config/maps/defaultdistrict.layout.json', import.meta.url);
+  return new URL(fallbackPath, import.meta.url);
 }
 
-const MAP_CONFIG = window.CONFIG?.map || {};
-const CONFIG_LAYOUTS = Array.isArray(MAP_CONFIG.layouts)
-  ? MAP_CONFIG.layouts.map((entry) => normalizeLayoutEntry(entry)).filter((entry): entry is MapLayoutConfig => !!entry)
-  : [];
-const PREFERRED_LAYOUT_ID = typeof MAP_CONFIG.defaultLayoutId === 'string' && MAP_CONFIG.defaultLayoutId.trim()
-  ? MAP_CONFIG.defaultLayoutId.trim()
-  : 'defaultdistrict';
-const DEFAULT_LAYOUT_ENTRY = CONFIG_LAYOUTS.find((entry) => entry.id === PREFERRED_LAYOUT_ID)
-  || CONFIG_LAYOUTS.find((entry) => entry.id === 'defaultdistrict')
-  || CONFIG_LAYOUTS[0]
-  || null;
-const DEFAULT_AREA_ID = DEFAULT_LAYOUT_ENTRY?.id || 'defaultdistrict';
-const DEFAULT_AREA_NAME = DEFAULT_LAYOUT_ENTRY?.areaName || 'DefaultDistrict';
-const layoutUrl = resolveLayoutUrl(DEFAULT_LAYOUT_ENTRY?.path);
-const PREVIEW_STORAGE_PREFIX = 'sok-map-editor-preview:';
-const PREFAB_MANIFESTS = Array.isArray(MAP_CONFIG.prefabManifests)
-  ? MAP_CONFIG.prefabManifests.filter((entry) => typeof entry === 'string' && entry.trim())
-  : [];
+type ResolvedMapConfig = {
+  mapConfig: Record<string, unknown>;
+  layouts: MapLayoutConfig[];
+  defaultLayoutEntry: MapLayoutConfig | null;
+  defaultAreaId: string;
+  defaultAreaName: string;
+  layoutUrl: URL;
+  previewStoragePrefix: string;
+  prefabManifests: string[];
+};
+
+function resolveMapConfig(): ResolvedMapConfig {
+  const rawConfig = typeof window !== 'undefined'
+    ? (window as typeof window & { CONFIG?: unknown }).CONFIG
+    : undefined;
+  const mapConfig = rawConfig && typeof rawConfig === 'object' && rawConfig
+    ? (rawConfig as Record<string, unknown>).map
+    : undefined;
+  const mapConfigRecord = mapConfig && typeof mapConfig === 'object'
+    ? mapConfig as Record<string, unknown>
+    : {};
+
+  const layouts = Array.isArray(mapConfigRecord.layouts)
+    ? mapConfigRecord.layouts.map((entry) => normalizeLayoutEntry(entry)).filter((entry): entry is MapLayoutConfig => !!entry)
+    : [];
+
+  const preferredLayoutId = typeof mapConfigRecord.defaultLayoutId === 'string' && mapConfigRecord.defaultLayoutId.trim()
+    ? mapConfigRecord.defaultLayoutId.trim()
+    : FALLBACK_AREA_ID;
+
+  const defaultLayoutEntry = layouts.find((entry) => entry.id === preferredLayoutId)
+    || layouts.find((entry) => entry.id === FALLBACK_AREA_ID)
+    || layouts[0]
+    || null;
+
+  const configuredLayoutPath = typeof mapConfigRecord.defaultLayoutPath === 'string' && mapConfigRecord.defaultLayoutPath.trim()
+    ? mapConfigRecord.defaultLayoutPath.trim()
+    : null;
+
+  const defaultAreaId = typeof mapConfigRecord.defaultAreaId === 'string' && mapConfigRecord.defaultAreaId.trim()
+    ? mapConfigRecord.defaultAreaId.trim()
+    : defaultLayoutEntry?.id || FALLBACK_AREA_ID;
+
+  const defaultAreaName = typeof mapConfigRecord.defaultAreaName === 'string' && mapConfigRecord.defaultAreaName.trim()
+    ? mapConfigRecord.defaultAreaName.trim()
+    : defaultLayoutEntry?.areaName || FALLBACK_AREA_NAME;
+
+  const layoutUrl = resolveLayoutUrl(defaultLayoutEntry?.path || configuredLayoutPath, FALLBACK_LAYOUT_PATH);
+
+  const previewStoragePrefix = typeof mapConfigRecord.previewStoragePrefix === 'string' && mapConfigRecord.previewStoragePrefix.trim()
+    ? mapConfigRecord.previewStoragePrefix.trim()
+    : FALLBACK_PREVIEW_STORAGE_PREFIX;
+
+  const prefabManifests = Array.isArray(mapConfigRecord.prefabManifests)
+    ? mapConfigRecord.prefabManifests.filter((entry) => typeof entry === 'string' && entry.trim())
+    : [];
+
+  return {
+    mapConfig: mapConfigRecord,
+    layouts,
+    defaultLayoutEntry,
+    defaultAreaId,
+    defaultAreaName,
+    layoutUrl,
+    previewStoragePrefix,
+    prefabManifests,
+  };
+}
+
+const MAP_DEFAULTS = resolveMapConfig();
+const MAP_CONFIG = MAP_DEFAULTS.mapConfig;
+const CONFIG_LAYOUTS = MAP_DEFAULTS.layouts;
+const DEFAULT_LAYOUT_ENTRY = MAP_DEFAULTS.defaultLayoutEntry;
+const DEFAULT_AREA_ID = MAP_DEFAULTS.defaultAreaId;
+const DEFAULT_AREA_NAME = MAP_DEFAULTS.defaultAreaName;
+const layoutUrl = MAP_DEFAULTS.layoutUrl;
+const PREVIEW_STORAGE_PREFIX = MAP_DEFAULTS.previewStoragePrefix;
+const PREFAB_MANIFESTS = MAP_DEFAULTS.prefabManifests;
 
 const prefabLibraryPromise: Promise<PrefabLibrary> = (async () => {
   if (!PREFAB_MANIFESTS.length) {


### PR DESCRIPTION
## Summary
- centralize map bootstrap defaults via helper that reads CONFIG.map once
- allow layout URL, area defaults, and preview prefix to derive from configuration with fallbacks
- keep compiled map-bootstrap.js in sync with the new configuration-driven defaults

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921647318988326820bc168032001e0)