### PR TITLE
Ensure breathing breathing override uses global style store

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -406,6 +406,8 @@ function isFighterMarkedDead(F){
 }
 
 export function updateBreathing(F, fighterId, spec){
+  const G = window.GAME || {};
+  const store = (G.ANIM_STYLE_OVERRIDES ||= {});
   const breathState = F?.anim?.breath;
   if (!breathState){
     return;


### PR DESCRIPTION
## Summary
- add global animator store initialization within updateBreathing to align with other style composers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69216b68fba8832683557a968793b642)