### PR TITLE
Respect area ground offsets in preview sandbox

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -2874,7 +2874,7 @@ function createEditorPreviewSandbox() {
 
   const renderScene = ({ width, height, camX = 0, zoom = 1, groundY, camOrigin = 'left', worldWidth }) => {
     if (!state.ready || !ctx) {
-      return false;
+      return { rendered: false, groundLine: null };
     }
     const effectiveZoom = Math.max(Number.isFinite(zoom) ? zoom : 1, 0.05);
     const viewWidth = Math.max(1, Number(width) || state.canvas?.width || 1);
@@ -2898,12 +2898,16 @@ function createEditorPreviewSandbox() {
     }
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, viewWidth, viewHeight);
+    const derivedAreaGround = state.ready && Number.isFinite(state.groundOffset)
+      ? viewHeight - state.groundOffset
+      : null;
     const resolvedGround = Number.isFinite(groundY)
       ? groundY
-      : computeGroundYFromConfig(window.CONFIG, viewHeight);
+      : (Number.isFinite(derivedAreaGround) ? derivedAreaGround : computeGroundYFromConfig(window.CONFIG, viewHeight));
+    const fallbackOffset = Number.isFinite(state.groundOffset) ? state.groundOffset : 140;
     const groundLine = Number.isFinite(resolvedGround)
       ? resolvedGround
-      : (viewHeight - state.groundOffset);
+      : (viewHeight - fallbackOffset);
 
     const sky = ctx.createLinearGradient(0, 0, 0, viewHeight);
     sky.addColorStop(0, 'rgba(59,63,69,0.9)');
@@ -3158,19 +3162,19 @@ function createEditorPreviewSandbox() {
     ctx.stroke();
     ctx.restore();
 
-    return true;
+    return { rendered: true, groundLine };
   };
 
   const renderAndBlit = (targetCtx, options) => {
-    const rendered = renderScene(options || {});
-    if (!rendered || !targetCtx) {
-      return false;
+    const result = renderScene(options || {});
+    if (!result?.rendered || !targetCtx) {
+      return { rendered: false, groundY: result?.groundLine ?? null };
     }
     targetCtx.save();
     targetCtx.setTransform(1, 0, 0, 1, 0, 0);
     targetCtx.drawImage(canvas, 0, 0, options.width, options.height);
     targetCtx.restore();
-    return true;
+    return { rendered: true, groundY: result.groundLine };
   };
 
   return {
@@ -3424,16 +3428,17 @@ function drawStage(){
   cx.clearRect(0,0,cv.width,cv.height);
   cx.fillStyle = '#0b1220';
   cx.fillRect(0,0,cv.width,cv.height);
-  // ground (with camera offset)
-  const gy = computeGroundYFromConfig(C, cv?.height);
-  const previewRendered = EDITOR_PREVIEW_SANDBOX.renderAndBlit(cx, {
+  const previewResult = EDITOR_PREVIEW_SANDBOX.renderAndBlit(cx, {
     width: cv.width,
     height: cv.height,
     camX,
     zoom,
-    groundY: gy,
     worldWidth: worldW,
   });
+
+  const gyFallback = computeGroundYFromConfig(C, cv?.height);
+  const gy = Number.isFinite(previewResult?.groundY) ? previewResult.groundY : gyFallback;
+  const previewRendered = !!previewResult?.rendered;
 
   cx.save();
   cx.setTransform(zoom, 0, 0, zoom, -zoom * camX, cv.height * (1 - zoom));


### PR DESCRIPTION
## Summary
- derive the preview sandbox ground line from the active area's ground offset when available
- propagate the resolved ground baseline through rendering helpers for consistent map placement
- fall back to the global configuration ground height when no area data is available

## Testing
- npm test --silent


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217c1a4a348326b950bf045d4eb510)