### PR TITLE
Propagate playable bounds into physics

### DIFF
--- a/docs/js-src/map-bootstrap.ts
+++ b/docs/js-src/map-bootstrap.ts
@@ -495,8 +495,8 @@ function syncConfigPlayableBounds(area: MapArea | null): void {
 
   mapConfig.playableBounds = null;
   mapConfig.activePlayableBounds = null;
-  mapConfig.playAreaMinX = initialBounds.minX ?? null;
-  mapConfig.playAreaMaxX = initialBounds.maxX ?? null;
+  mapConfig.playAreaMinX = Number.isFinite(initialBounds?.minX) ? initialBounds.minX : null;
+  mapConfig.playAreaMaxX = Number.isFinite(initialBounds?.maxX) ? initialBounds.maxX : null;
 }
 
 function syncConfigPlatforming(area: MapArea): void {


### PR DESCRIPTION
## Summary
- sync playable bounds from map layouts into CONFIG map state via registry updates
- prioritize active playable bounds when clamping fighters in physics, falling back to legacy defaults only when needed
- add a regression test ensuring clampFighterToBounds respects playableBounds
- reset map play area min/max when playable bounds are missing to avoid stale clamping

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692202c60b2c83268980423f03c6722c)