### PR TITLE
Expose configurable horizontal bounds

### DIFF
--- a/docs/js/physics.js
+++ b/docs/js/physics.js
@@ -59,6 +59,62 @@ function dampingForFrame(base, dt) {
   return Math.pow(base, dt / frame);
 }
 
+function resolveCanvasWidth(config) {
+  const canvasWidth = Number(config?.canvas?.w);
+  if (Number.isFinite(canvasWidth) && canvasWidth > 0) return canvasWidth;
+  return 720;
+}
+
+function resolveHorizontalBounds(config) {
+  const width = resolveCanvasWidth(config);
+  const defaultMargin = 40;
+  const margins = config?.canvas?.margins || {};
+  const marginLeft = Number.isFinite(margins.left) && margins.left >= 0 ? margins.left : defaultMargin;
+  const marginRight = Number.isFinite(margins.right) && margins.right >= 0 ? margins.right : marginLeft;
+
+  const movementBounds = config?.movement?.bounds || {};
+  const movementLeft = Number.isFinite(movementBounds.left)
+    ? movementBounds.left
+    : Number.isFinite(movementBounds.min)
+      ? movementBounds.min
+      : null;
+  const movementRight = Number.isFinite(movementBounds.right)
+    ? movementBounds.right
+    : Number.isFinite(movementBounds.max)
+      ? movementBounds.max
+      : null;
+
+  const candidates = [];
+
+  if (movementLeft != null && movementRight != null) {
+    candidates.push({ minX: movementLeft, maxX: movementRight });
+  }
+
+  candidates.push({
+    minX: marginLeft,
+    maxX: width - marginRight,
+  });
+
+  const defaultBounds = {
+    minX: defaultMargin,
+    maxX: width - defaultMargin,
+  };
+
+  const chosen = candidates.find(
+    (bounds) =>
+      Number.isFinite(bounds.minX) &&
+      Number.isFinite(bounds.maxX) &&
+      bounds.maxX > bounds.minX,
+  );
+
+  if (chosen) return chosen;
+  if (Number.isFinite(defaultBounds.maxX) && defaultBounds.maxX > defaultBounds.minX) {
+    return defaultBounds;
+  }
+
+  return { minX: 0, maxX: Math.max(0, width) };
+}
+
 function ensurePhysicsState(fighter) {
   fighter.physics ||= {};
   const state = fighter.physics;
@@ -146,17 +202,21 @@ function clampFighterToBounds(fighter, config) {
   const playableBounds = resolvePlayableBounds();
   const mapMinX = Number.isFinite(config?.map?.playAreaMinX) ? config.map.playAreaMinX : null;
   const mapMaxX = Number.isFinite(config?.map?.playAreaMaxX) ? config.map.playAreaMaxX : null;
-  const canvasWidth = Number.isFinite(config?.canvas?.w) ? config.canvas.w : 720;
 
-  let minX = mapMinX ?? 40;
-  let maxX = mapMaxX ?? (canvasWidth - 40);
+  const { minX: resolvedMinX, maxX: resolvedMaxX } = resolveHorizontalBounds(config);
+  let minX = resolvedMinX;
+  let maxX = resolvedMaxX;
 
   if (playableBounds) {
     minX = playableBounds.left;
     maxX = playableBounds.right;
-  } else if (mapMinX == null || mapMaxX == null) {
-    minX = 40;
-    maxX = canvasWidth - 40;
+  } else {
+    if (mapMinX != null) minX = mapMinX;
+    if (mapMaxX != null) maxX = mapMaxX;
+    if (!(Number.isFinite(minX) && Number.isFinite(maxX) && maxX > minX)) {
+      minX = resolvedMinX;
+      maxX = resolvedMaxX;
+    }
   }
   fighter.pos.x = clamp(fighter.pos.x, minX, maxX);
 
@@ -407,9 +467,8 @@ export function updateFighterPhysics(fighter, config, dt, options = {}) {
   fighter.pos.x += fighter.vel.x * dt;
   fighter.pos.y += fighter.vel.y * dt;
 
-  const margin = 40;
-  const worldWidth = config?.canvas?.w || 720;
-  fighter.pos.x = clamp(fighter.pos.x, margin, worldWidth - margin);
+  const { minX: movementMinX, maxX: movementMaxX } = resolveHorizontalBounds(config);
+  fighter.pos.x = clamp(fighter.pos.x, movementMinX, movementMaxX);
 
   let onGround = false;
   const prevY = Number.isFinite(fighter.prevPosY) ? fighter.prevPosY : fighter.pos.y - fighter.vel.y * dt;

--- a/tests/physics-playable-bounds.test.js
+++ b/tests/physics-playable-bounds.test.js
@@ -27,11 +27,15 @@ async function loadClampFunction() {
   }
 
   const clampSrc = extractFunction('clamp');
+  const resolveCanvasWidthSrc = extractFunction('resolveCanvasWidth');
+  const resolveHorizontalBoundsSrc = extractFunction('resolveHorizontalBounds');
   const clampBoundsSrc = extractFunction('clampFighterToBounds');
 
   const script = `
     function computeGroundY(config){ return Number.isFinite(config?.groundY) ? config.groundY : 0; }
     ${clampSrc}
+    ${resolveCanvasWidthSrc}
+    ${resolveHorizontalBoundsSrc}
     ${clampBoundsSrc}
     exports.clamp = clamp;
     exports.clampFighterToBounds = clampFighterToBounds;
@@ -58,4 +62,40 @@ test('clampFighterToBounds uses playableBounds when provided', async () => {
 
   clampFighterToBounds(fighter, config);
   assert.equal(fighter.pos.x, 180);
+});
+
+test('clampFighterToBounds uses movement bounds when provided', async () => {
+  const clampFighterToBounds = await loadClampFunction();
+  const fighter = { pos: { x: 300, y: 0 } };
+  const config = {
+    groundY: 0,
+    movement: { bounds: { left: -25, right: 125 } },
+  };
+
+  clampFighterToBounds(fighter, config);
+  assert.equal(fighter.pos.x, 125);
+});
+
+test('clampFighterToBounds falls back to canvas margins', async () => {
+  const clampFighterToBounds = await loadClampFunction();
+  const fighter = { pos: { x: 950, y: 0 } };
+  const config = {
+    groundY: 0,
+    canvas: { w: 900, margins: { left: 10, right: 30 } },
+  };
+
+  clampFighterToBounds(fighter, config);
+  assert.equal(fighter.pos.x, 870);
+});
+
+test('clampFighterToBounds uses sane defaults when numbers are invalid', async () => {
+  const clampFighterToBounds = await loadClampFunction();
+  const fighter = { pos: { x: 1000, y: 0 } };
+  const config = {
+    groundY: 0,
+    canvas: { w: Number.NaN, margins: { left: -5, right: Number.NaN } },
+  };
+
+  clampFighterToBounds(fighter, config);
+  assert.equal(fighter.pos.x, 680);
 });


### PR DESCRIPTION
## Summary
- add helpers to resolve canvas width and horizontal bounds from movement and canvas config with sane defaults
- apply the shared bounds resolver in physics clamping logic instead of hardcoded margin and width values
- extend playable-bounds tests to cover movement bounds, canvas margins, and invalid configuration fallbacks

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69220e05eb508326afe125304a86e5f3)