### PR TITLE
Prevent drum skin cards from hijacking control taps

### DIFF
--- a/docs/map-editor.html
+++ b/docs/map-editor.html
@@ -2222,7 +2222,10 @@ function refreshDrumSkinList() {
     const isActive = drum.id === selectedDrumSkinId;
     card.style.outline = isActive ? '2px solid #22c55e' : '';
     card.style.outlineOffset = '1px';
-    card.onclick = () => {
+    card.onclick = (event) => {
+      const target = event.target;
+      const withinControl = target instanceof HTMLElement && target.closest('button, input, select, option, textarea');
+      if (withinControl) return;
       selectedDrumSkinId = drum.id;
       refreshDrumSkinList();
     };


### PR DESCRIPTION
## Summary
- guard drum skin card selection clicks so form controls remain interactive
- allow touch and click interactions within drum skin configuration fields without rerendering the card

## Testing
- `npm test` *(fails: existing assertion in tests/physics-world-width.test.js expecting width 960 but got 680)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692219fd141083268a9125bb3eecd800)