### PR TITLE
Honor base spriteStyle transforms when rendering bones

### DIFF
--- a/docs/js/sprites.js
+++ b/docs/js/sprites.js
@@ -696,7 +696,8 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style){
 
   // Offset config for fine-tuning sprite placement
   const baseStyleXformSrc = style?.xform || {};
-  const xform = (effectiveStyle.xform || {})[normalizedKey] || (effectiveStyle.xform || {})[styleKey] || {};
+  const xformTable = effectiveStyle.xform || {};
+  const xform = xformTable[normalizedKey] || xformTable[styleKey] || xformTable.base || {};
   const xformUnits = (effectiveStyle.xformUnits || 'px').toLowerCase();
 
   const rawAx = xform.ax ?? 0;
@@ -734,7 +735,7 @@ function drawBoneSprite(ctx, asset, bone, styleKey, style){
   }
 
   // Rotation (fixed): bone.ang + alignRad + extraRotRad + Math.PI
-  const baseStyleXform = baseStyleXformSrc[normalizedKey] || baseStyleXformSrc[styleKey] || {};
+  const baseStyleXform = baseStyleXformSrc[normalizedKey] || baseStyleXformSrc[styleKey] || baseStyleXformSrc.base || {};
   let alignRad;
   if (options?.alignRad != null){
     alignRad = options.alignRad;


### PR DESCRIPTION
## Summary
- fall back to base spriteStyle xform entries when resolving offsets and scaling for bone sprites
- allow rotation alignment to inherit base xform defaults so shared settings apply across style keys

## Testing
- npm test *(fails: ensureCosmeticLayers exposes layer extra bone influence metadata; clampFighterToBounds applies world width from camera)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224891a338832695b02e1cc41f1e14)