### PR TITLE
Add vertical camera tracking with configurable framing

### DIFF
--- a/docs/js/camera.js
+++ b/docs/js/camera.js
@@ -2,7 +2,9 @@
 import { pickFighterConfig, pickFighterName } from './fighter-utils.js?v=1';
 
 const DEFAULT_WORLD_WIDTH = 1600;
+const DEFAULT_WORLD_HEIGHT = 900;
 const DEFAULT_VIEWPORT_WIDTH = 720;
+const DEFAULT_VIEWPORT_HEIGHT = 460;
 const DEFAULT_SMOOTHING = 0.15;
 const DEFAULT_ZOOM_SMOOTHING = 0.08;
 const DEFAULT_INACTIVITY_SECONDS = 15;
@@ -13,6 +15,7 @@ const EPSILON = 1e-4;
 let attachedRegistry = null;
 let detachRegistryListener = null;
 let lastViewportWidth = DEFAULT_VIEWPORT_WIDTH;
+let lastViewportHeight = DEFAULT_VIEWPORT_HEIGHT;
 let lastLoggedPlayerX = null;
 let lastLoggedAreaId = null;
 let makeAwareListenerAttached = false;
@@ -48,11 +51,56 @@ function measureViewportWidth(canvas) {
   return null;
 }
 
+function measureViewportHeight(canvas) {
+  if (!canvas) return null;
+
+  const attrHeight = Number.isFinite(canvas.height) ? canvas.height : null;
+
+  try {
+    if (typeof canvas.getBoundingClientRect === 'function') {
+      const rect = canvas.getBoundingClientRect();
+      if (rect && Number.isFinite(rect.height) && rect.height > 0) {
+        if (attrHeight && attrHeight > 0) {
+          return attrHeight;
+        }
+        return rect.height;
+      }
+    }
+  } catch (_error) {
+    // Ignore DOM measurement failures (e.g., detached canvas)
+  }
+
+  if (attrHeight && attrHeight > 0) {
+    return attrHeight;
+  }
+
+  const clientHeight = Number.isFinite(canvas.clientHeight) ? canvas.clientHeight : null;
+  if (clientHeight && clientHeight > 0) {
+    return clientHeight;
+  }
+
+  return null;
+}
+
 function getManualCameraOffset() {
   const config = (typeof window !== 'undefined' && window.CONFIG) ? window.CONFIG : null;
   if (!config || !config.camera) return 0;
   const manual = config.camera.manualOffsetX;
   return Number.isFinite(manual) ? manual : 0;
+}
+
+function getManualCameraOffsetY() {
+  const config = (typeof window !== 'undefined' && window.CONFIG) ? window.CONFIG : null;
+  if (!config || !config.camera) return 0;
+  const manual = config.camera.manualOffsetY;
+  return Number.isFinite(manual) ? manual : 0;
+}
+
+function firstFinite(...values) {
+  for (const value of values) {
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
 }
 
 function clamp(value, min, max) {
@@ -193,15 +241,26 @@ function ensureGameCamera() {
   camera.y = Number.isFinite(camera.y) ? camera.y : 0;
   camera.zoom = Number.isFinite(camera.zoom) ? camera.zoom : 1;
   camera.smoothing = Number.isFinite(camera.smoothing) ? camera.smoothing : DEFAULT_SMOOTHING;
+  camera.smoothingY = Number.isFinite(camera.smoothingY) ? camera.smoothingY : camera.smoothing;
   camera.worldWidth = Number.isFinite(camera.worldWidth) ? camera.worldWidth : DEFAULT_WORLD_WIDTH;
+  camera.worldHeight = Number.isFinite(camera.worldHeight) ? camera.worldHeight : DEFAULT_WORLD_HEIGHT;
   camera.bounds = camera.bounds || { min: 0, max: DEFAULT_WORLD_WIDTH };
+  camera.verticalBounds = camera.verticalBounds || { min: -DEFAULT_WORLD_HEIGHT * 0.5, max: DEFAULT_WORLD_HEIGHT * 0.5 };
   if (!Number.isFinite(camera.viewportWidth)) {
     camera.viewportWidth = lastViewportWidth;
+  }
+  if (!Number.isFinite(camera.viewportHeight)) {
+    camera.viewportHeight = lastViewportHeight;
   }
   if (!Number.isFinite(camera.viewportWorldWidth)) {
     const effectiveZoom = Math.max(Number.isFinite(camera.zoom) ? camera.zoom : 1, MIN_EFFECTIVE_ZOOM);
     const width = Number.isFinite(camera.viewportWidth) ? camera.viewportWidth : DEFAULT_VIEWPORT_WIDTH;
     camera.viewportWorldWidth = width / effectiveZoom;
+  }
+  if (!Number.isFinite(camera.viewportWorldHeight)) {
+    const effectiveZoom = Math.max(Number.isFinite(camera.zoom) ? camera.zoom : 1, MIN_EFFECTIVE_ZOOM);
+    const height = Number.isFinite(camera.viewportHeight) ? camera.viewportHeight : DEFAULT_VIEWPORT_HEIGHT;
+    camera.viewportWorldHeight = height / effectiveZoom;
   }
   const awareness = ensureCameraAwareness(camera);
   camera.targetZoom = Number.isFinite(camera.targetZoom) ? camera.targetZoom : awareness.targetZoom;
@@ -236,6 +295,27 @@ function deriveBoundsFromColliders(colliders) {
     return null;
   }
   return { min: minLeft, max: maxRight };
+}
+
+function deriveVerticalBoundsFromColliders(colliders) {
+  if (!Array.isArray(colliders) || !colliders.length) {
+    return null;
+  }
+  let minTop = Infinity;
+  let maxBottom = -Infinity;
+  colliders.forEach((col) => {
+    if (!col || typeof col !== 'object') return;
+    const top = Number(col.top ?? col.y);
+    const height = Number(col.height ?? col.h);
+    if (!Number.isFinite(top) || !Number.isFinite(height)) return;
+    const bottom = top + height;
+    minTop = Math.min(minTop, Math.min(top, bottom));
+    maxBottom = Math.max(maxBottom, Math.max(top, bottom));
+  });
+  if (!Number.isFinite(minTop) || !Number.isFinite(maxBottom) || maxBottom <= minTop) {
+    return null;
+  }
+  return { min: minTop, max: maxBottom };
 }
 
 function computeAreaBounds(area) {
@@ -285,35 +365,127 @@ function computeAreaBounds(area) {
   return { min: minBound, max: maxBound };
 }
 
+function computeAreaVerticalBounds(area) {
+  if (!area) {
+    return { min: -DEFAULT_WORLD_HEIGHT * 0.5, max: DEFAULT_WORLD_HEIGHT * 0.5 };
+  }
+  const playable = area.playableBounds || null;
+  const playableTop = Number(playable?.top ?? playable?.minY ?? playable?.yMin);
+  const playableBottom = Number(playable?.bottom ?? playable?.maxY ?? playable?.yMax);
+  if (Number.isFinite(playableTop) && Number.isFinite(playableBottom) && playableBottom > playableTop) {
+    return { min: playableTop, max: playableBottom };
+  }
+
+  const colliderBounds = deriveVerticalBoundsFromColliders(area.colliders);
+  if (colliderBounds) {
+    return colliderBounds;
+  }
+
+  let minY = Infinity;
+  let maxY = -Infinity;
+  const consider = (inst) => {
+    const y = inst?.position?.y ?? inst?.y;
+    if (Number.isFinite(y)) {
+      minY = Math.min(minY, y);
+      maxY = Math.max(maxY, y);
+    }
+  };
+  if (Array.isArray(area.instances)) {
+    for (const inst of area.instances) consider(inst);
+  }
+  if (Array.isArray(area.props)) {
+    for (const prop of area.props) consider(prop);
+  }
+  const startY = area.camera?.startY;
+  if (Number.isFinite(startY)) {
+    minY = Math.min(minY, startY);
+    maxY = Math.max(maxY, startY);
+  }
+  if (!Number.isFinite(minY) || !Number.isFinite(maxY)) {
+    return { min: -DEFAULT_WORLD_HEIGHT * 0.5, max: DEFAULT_WORLD_HEIGHT * 0.5 };
+  }
+  if (minY === maxY) {
+    maxY = minY + DEFAULT_WORLD_HEIGHT;
+  }
+  const minBound = Math.min(-DEFAULT_WORLD_HEIGHT * 0.5, minY);
+  const maxBound = Math.max(minBound + DEFAULT_WORLD_HEIGHT, maxY);
+  return { min: minBound, max: maxBound };
+}
+
+function resolveCameraFraming(area) {
+  const config = window.CONFIG || {};
+  const fighterName = pickFighterName(config);
+  const fighterConfig = pickFighterConfig(config, fighterName);
+  const baseCamera = config.camera || {};
+  const fighterCamera = fighterConfig?.camera || {};
+  const areaCamera = area?.camera || {};
+
+  const offsetX = firstFinite(areaCamera.offsetX, fighterCamera.offsetX, baseCamera.offsetX, 0) ?? 0;
+  const offsetY = firstFinite(areaCamera.offsetY, fighterCamera.offsetY, baseCamera.offsetY, 0) ?? 0;
+
+  const smoothingXRaw = firstFinite(areaCamera.smoothingX, fighterCamera.smoothingX, baseCamera.smoothingX, null);
+  const smoothingYRaw = firstFinite(areaCamera.smoothingY, fighterCamera.smoothingY, baseCamera.smoothingY, smoothingXRaw);
+  const smoothingX = Number.isFinite(smoothingXRaw) ? clamp(smoothingXRaw, 0, 1) : null;
+  const smoothingY = Number.isFinite(smoothingYRaw) ? clamp(smoothingYRaw, 0, 1) : null;
+
+  return { offsetX, offsetY, smoothingX, smoothingY };
+}
+
 function syncCameraToArea(area) {
   const camera = ensureGameCamera();
   const bounds = computeAreaBounds(area);
+  const verticalBounds = computeAreaVerticalBounds(area);
   const awareness = ensureCameraAwareness(camera);
   const viewportWidth = lastViewportWidth || DEFAULT_VIEWPORT_WIDTH;
+  const viewportHeight = lastViewportHeight || DEFAULT_VIEWPORT_HEIGHT;
   const effectiveZoom = Math.max(
     Number.isFinite(camera.zoom) ? camera.zoom : awareness.defaultZoom,
     MIN_EFFECTIVE_ZOOM
   );
   const viewportWorldWidth = viewportWidth / effectiveZoom;
+  const viewportWorldHeight = viewportHeight / effectiveZoom;
   const span = Math.max(bounds.max - bounds.min, viewportWorldWidth, 1);
+  const verticalSpan = Math.max(verticalBounds.max - verticalBounds.min, viewportWorldHeight, 1);
   const maxTarget = bounds.min + span - viewportWorldWidth;
+  const maxTargetY = verticalBounds.min + verticalSpan - viewportWorldHeight;
   const clampedStart = clamp(area?.camera?.startX, bounds.min, maxTarget);
+  const clampedStartY = clamp(area?.camera?.startY, verticalBounds.min, maxTargetY);
   const manualOffset = getManualCameraOffset();
+  const manualOffsetY = getManualCameraOffsetY();
+  const framing = resolveCameraFraming(area);
+
+  if (Number.isFinite(framing.smoothingY)) {
+    camera.smoothingY = framing.smoothingY;
+  }
+  if (Number.isFinite(framing.smoothingX)) {
+    camera.smoothing = framing.smoothingX;
+  }
 
   camera.bounds = { min: bounds.min, max: bounds.min + span };
+  camera.verticalBounds = { min: verticalBounds.min, max: verticalBounds.min + verticalSpan };
   camera.worldWidth = span;
+  camera.worldHeight = verticalSpan;
   if (Number.isFinite(area?.camera?.startZoom)) {
     camera.zoom = clamp(area.camera.startZoom, awareness.minZoom ?? MIN_EFFECTIVE_ZOOM, awareness.maxZoom ?? area.camera.startZoom);
   }
   camera.viewportWidth = viewportWidth;
+  camera.viewportHeight = viewportHeight;
   camera.viewportWorldWidth = viewportWorldWidth;
+  camera.viewportWorldHeight = viewportWorldHeight;
 
   if (Number.isFinite(clampedStart)) {
-    camera.x = clamp(clampedStart + manualOffset, bounds.min, maxTarget);
+    camera.x = clamp(clampedStart + manualOffset + framing.offsetX, bounds.min, maxTarget);
   } else {
-    camera.x = clamp(camera.x, bounds.min, maxTarget);
+    camera.x = clamp(camera.x + framing.offsetX + manualOffset, bounds.min, maxTarget);
   }
   camera.targetX = camera.x;
+
+  if (Number.isFinite(clampedStartY)) {
+    camera.y = clamp(clampedStartY + manualOffsetY + framing.offsetY, verticalBounds.min, maxTargetY);
+  } else {
+    camera.y = clamp(camera.y + framing.offsetY + manualOffsetY, verticalBounds.min, maxTargetY);
+  }
+  camera.targetY = camera.y;
 }
 
 function attachToRegistry(registry) {
@@ -345,19 +517,27 @@ export function initCamera({ canvas, mapRegistry } = {}) {
   const camera = ensureGameCamera();
   const config = window.CONFIG || {};
   const measuredWidth = measureViewportWidth(canvas);
+  const measuredHeight = measureViewportHeight(canvas);
   lastViewportWidth = measuredWidth
     || canvas?.width
     || config.canvas?.w
     || lastViewportWidth
     || DEFAULT_VIEWPORT_WIDTH;
+  lastViewportHeight = measuredHeight
+    || canvas?.height
+    || config.canvas?.h
+    || lastViewportHeight
+    || DEFAULT_VIEWPORT_HEIGHT;
   camera.bounds = camera.bounds || { min: 0, max: camera.worldWidth || DEFAULT_WORLD_WIDTH };
   camera.viewportWidth = lastViewportWidth;
+  camera.viewportHeight = lastViewportHeight;
   refreshAwarenessConfig(camera);
   const awareness = ensureCameraAwareness(camera);
   setAwarenessState(camera, 'default', { now: getNowSeconds() });
   camera.zoom = awareness.defaultZoom;
   camera.targetZoom = awareness.targetZoom;
   camera.viewportWorldWidth = lastViewportWidth / Math.max(camera.zoom, MIN_EFFECTIVE_ZOOM);
+  camera.viewportWorldHeight = lastViewportHeight / Math.max(camera.zoom, MIN_EFFECTIVE_ZOOM);
   attachMakeAwareListener();
 
   const registry = mapRegistry || window.GAME?.mapRegistry || window.__MAP_REGISTRY__;
@@ -392,23 +572,49 @@ export function updateCamera(canvas) {
   const activeAreaId = (attachedRegistry && typeof attachedRegistry.getActiveAreaId === 'function')
     ? attachedRegistry.getActiveAreaId()
     : (window.GAME?.currentAreaId || null);
+  const activeArea = (attachedRegistry && typeof attachedRegistry.getActiveArea === 'function')
+    ? attachedRegistry.getActiveArea()
+    : null;
+  const framing = resolveCameraFraming(activeArea);
+  if (Number.isFinite(framing.smoothingX)) {
+    camera.smoothing = framing.smoothingX;
+  }
+  if (Number.isFinite(framing.smoothingY)) {
+    camera.smoothingY = framing.smoothingY;
+  }
+  const manualOffsetX = getManualCameraOffset();
+  const manualOffsetY = getManualCameraOffsetY();
 
   const measuredWidth = measureViewportWidth(canvas);
+  const measuredHeight = measureViewportHeight(canvas);
   const viewportWidth = measuredWidth
     || canvas?.width
     || C.canvas?.w
     || lastViewportWidth
     || DEFAULT_VIEWPORT_WIDTH;
+  const viewportHeight = measuredHeight
+    || canvas?.height
+    || C.canvas?.h
+    || lastViewportHeight
+    || DEFAULT_VIEWPORT_HEIGHT;
   lastViewportWidth = viewportWidth;
+  lastViewportHeight = viewportHeight;
   camera.viewportWidth = viewportWidth;
+  camera.viewportHeight = viewportHeight;
   const effectiveZoom = Math.max(Number.isFinite(camera.zoom) ? camera.zoom : awareness.defaultZoom, MIN_EFFECTIVE_ZOOM);
   let viewportWorldWidth = viewportWidth / effectiveZoom;
+  let viewportWorldHeight = viewportHeight / effectiveZoom;
   camera.viewportWorldWidth = viewportWorldWidth;
+  camera.viewportWorldHeight = viewportWorldHeight;
 
   const bounds = camera.bounds || { min: 0, max: camera.worldWidth || DEFAULT_WORLD_WIDTH };
   const minBound = Number.isFinite(bounds.min) ? bounds.min : 0;
   const maxBound = Number.isFinite(bounds.max) ? bounds.max : minBound + (camera.worldWidth || DEFAULT_WORLD_WIDTH);
   const maxCameraX = Math.max(minBound, maxBound - viewportWorldWidth);
+  const verticalBounds = camera.verticalBounds || { min: -DEFAULT_WORLD_HEIGHT * 0.5, max: DEFAULT_WORLD_HEIGHT * 0.5 };
+  const minBoundY = Number.isFinite(verticalBounds.min) ? verticalBounds.min : -DEFAULT_WORLD_HEIGHT * 0.5;
+  const maxBoundY = Number.isFinite(verticalBounds.max) ? verticalBounds.max : minBoundY + (camera.worldHeight || DEFAULT_WORLD_HEIGHT);
+  const maxCameraY = Math.max(minBoundY, maxBoundY - viewportWorldHeight);
 
   const playerX = Number.isFinite(P.hitbox?.x)
     ? P.hitbox.x
@@ -430,13 +636,24 @@ export function updateCamera(canvas) {
       });
     }
   }
-  const desiredX = playerX - viewportWorldWidth * 0.5;
+  const playerY = Number.isFinite(P.hitbox?.y)
+    ? P.hitbox.y
+    : Number.isFinite(P.pos?.y)
+      ? P.pos.y
+      : 0;
+  const desiredX = playerX - viewportWorldWidth * 0.5 + framing.offsetX + manualOffsetX;
   const target = clamp(desiredX, minBound, maxCameraX);
+  const desiredY = playerY - viewportWorldHeight * 0.5 + framing.offsetY + manualOffsetY;
+  const targetY = clamp(desiredY, minBoundY, maxCameraY);
 
   const smoothing = Number.isFinite(camera.smoothing) ? camera.smoothing : DEFAULT_SMOOTHING;
+  const smoothingY = Number.isFinite(camera.smoothingY) ? camera.smoothingY : smoothing;
   const currentX = Number.isFinite(camera.x) ? camera.x : minBound;
+  const currentY = Number.isFinite(camera.y) ? camera.y : minBoundY;
   camera.x = currentX + (target - currentX) * smoothing;
   camera.targetX = target;
+  camera.y = currentY + (targetY - currentY) * smoothingY;
+  camera.targetY = targetY;
 
   const input = G.input;
   if (isInputActive(input)) {
@@ -463,6 +680,8 @@ export function updateCamera(canvas) {
   const updatedZoom = Math.max(camera.zoom, MIN_EFFECTIVE_ZOOM);
   viewportWorldWidth = viewportWidth / updatedZoom;
   camera.viewportWorldWidth = viewportWorldWidth;
+  viewportWorldHeight = viewportHeight / updatedZoom;
+  camera.viewportWorldHeight = viewportWorldHeight;
 }
 
 export function applyManualZoom({
@@ -500,6 +719,10 @@ export function applyManualZoom({
       ? camera.viewportWidth
       : lastViewportWidth || DEFAULT_VIEWPORT_WIDTH;
   lastViewportWidth = viewportPxWidth;
+  const viewportPxHeight = Number.isFinite(camera.viewportHeight)
+    ? camera.viewportHeight
+    : lastViewportHeight || DEFAULT_VIEWPORT_HEIGHT;
+  lastViewportHeight = viewportPxHeight;
 
   const effectiveCurrentZoom = Math.max(currentZoom, MIN_EFFECTIVE_ZOOM);
   const beforeWorldWidth = viewportPxWidth / effectiveCurrentZoom;
@@ -522,6 +745,8 @@ export function applyManualZoom({
 
   camera.viewportWidth = viewportPxWidth;
   camera.viewportWorldWidth = afterWorldWidth;
+  camera.viewportHeight = viewportPxHeight;
+  camera.viewportWorldHeight = viewportPxHeight / effectiveNextZoom;
   camera.targetZoom = nextZoom;
   camera.targetX = nextX;
   camera.x = nextX;


### PR DESCRIPTION
## Summary
- measure viewport height and world height to support vertical camera bounds
- add configurable vertical offsets and smoothing for camera framing per fighter or area
- clamp and smooth camera Y position alongside X, keeping viewport dimensions updated when zooming

## Testing
- npm test -- --runInBand *(fails: ensureCosmeticLayers exposes layer extra bone influence metadata; clampFighterToBounds applies world width from camera)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922679851208326b0165ab720f558e3)