### PR TITLE
Add configurable time-based far background

### DIFF
--- a/docs/js-src/map-bootstrap.ts
+++ b/docs/js-src/map-bootstrap.ts
@@ -514,6 +514,7 @@ function adaptAreaToParallax(area: MapArea) {
     source: area.source,
     camera: area.camera,
     ground: area.ground,
+    background: area.background || area.meta?.background || null,
     layers: area.layers.map((layer, index) => ({
       id: layer.id,
       name: layer.name,

--- a/docs/js/map-bootstrap.js
+++ b/docs/js/map-bootstrap.js
@@ -482,6 +482,7 @@ function adaptAreaToParallax(area) {
     source: area.source,
     camera: area.camera,
     ground: area.ground,
+    background: area.background || (area.meta?.background ?? null),
     layers: area.layers.map((layer, index) => ({
       id: layer.id,
       name: layer.name,

--- a/docs/js/vendor/map-runtime.js
+++ b/docs/js/vendor/map-runtime.js
@@ -948,6 +948,13 @@ export function convertLayoutToArea(layout, options = {}) {
   const convertedColliders = colliders.map((col, index) => normalizeCollider(col, index));
   const playableBounds = normalizePlayableBounds(layout.playableBounds, convertedColliders, warnings);
   const alignedColliders = alignCollidersToPlayableBounds(convertedColliders, playableBounds);
+  const backgroundFromLayout = typeof layout.background === 'object' && layout.background
+    ? safeClone(layout.background)
+    : null;
+  const backgroundFromMeta = typeof layout.meta?.background === 'object' && layout.meta.background
+    ? safeClone(layout.meta.background)
+    : null;
+  const background = backgroundFromLayout || backgroundFromMeta || null;
 
   if (!Array.isArray(layout.layers)) {
     warnings.push('layout.layers missing – produced area has zero parallax layers');
@@ -977,6 +984,7 @@ export function convertLayoutToArea(layout, options = {}) {
     colliders: alignedColliders,
     playableBounds,
     warnings,
+    background,
     meta: {
       exportedAt: layout.meta?.exportedAt || null,
       raw: includeRaw ? safeClone(layout) : undefined,


### PR DESCRIPTION
## Summary
- add reusable background defaults and time-of-day parsing utilities for gradients
- expose a window.setBackgroundTime24h helper and normalize configurable sky/tile background options
- draw the far background with a time-lerped gradient and optional tiled image portion instead of a fixed fill

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692266e1bc488326bb87fc4a5e182718)