### PR TITLE
Add proximity scaling controls and depth ordering to maps

### DIFF
--- a/docs/js/vendor/map-runtime.js
+++ b/docs/js/vendor/map-runtime.js
@@ -728,6 +728,7 @@ function normalizeAreaDescriptor(area, options = {}) {
     prefabResolver = () => null,
     prefabErrorLookup = null,
   } = options;
+  const proximityScale = clampScale(area.proximityScale ?? area.meta?.proximityScale, 1);
 
   const rawLayers = Array.isArray(area.layers) ? area.layers : [];
   const rawInstances = Array.isArray(area.instances)
@@ -785,24 +786,39 @@ function normalizeAreaDescriptor(area, options = {}) {
       instanceId,
       source: meta.identity?.source || instanceIdSource,
     };
+    const rawPosition = {
+      x: toNumber(inst.position?.x ?? inst.x ?? 0, 0),
+      y: toNumber(inst.position?.y ?? inst.y ?? 0, 0),
+    };
+    const distanceToCamera = Math.hypot(rawPosition.x, rawPosition.y);
+    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
+    const appliesProximityScale = !tags.some((tag) => tag === 'player'
+      || tag === 'npc'
+      || tag.startsWith('spawn:player')
+      || tag.startsWith('spawn:npc'));
+
     return {
       instanceId,
       id: inst.id,
       prefabId: inst.prefabId ?? null,
       layerId: inst.layerId ?? null,
-      position: {
-        x: toNumber(inst.position?.x ?? inst.x ?? 0, 0),
-        y: toNumber(inst.position?.y ?? inst.y ?? 0, 0),
-      },
+      position: rawPosition,
       scale: {
-        x: toNumber(inst.scale?.x ?? inst.scaleX ?? 1, 1),
-        y: toNumber(inst.scale?.y ?? inst.scaleY ?? inst.scale?.x ?? inst.scaleX ?? 1, 1),
+        x: toNumber(inst.scale?.x ?? inst.scaleX ?? 1, 1) * (appliesProximityScale ? proximityScale : 1),
+        y: toNumber(inst.scale?.y ?? inst.scaleY ?? inst.scale?.x ?? inst.scaleX ?? 1, 1) * (appliesProximityScale ? proximityScale : 1),
       },
       rotationDeg: toNumber(inst.rotationDeg ?? inst.rot ?? 0, 0),
       locked: !!inst.locked,
+      intraLayerDepth,
       prefab: resolvedPrefab,
       tags,
-      meta,
+      meta: {
+        ...meta,
+        proximityScale: {
+          applied: appliesProximityScale ? proximityScale : 1,
+          inherited: proximityScale,
+        },
+      },
     };
   });
 
@@ -821,13 +837,17 @@ function normalizeAreaDescriptor(area, options = {}) {
     ground: {
       offset: toNumber(area.ground?.offset ?? area.groundOffset, 0),
     },
+    proximityScale,
     layers: convertedLayers,
     instances: convertedInstances,
     instancesById: buildInstanceIndex(convertedInstances),
     colliders: alignedColliders,
     playableBounds,
     warnings,
-    meta: area.meta ? safeClone(area.meta) : {},
+    meta: {
+      ...(area.meta ? safeClone(area.meta) : {}),
+      proximityScale,
+    },
   };
 }
 
@@ -924,24 +944,39 @@ export function convertLayoutToArea(layout, options = {}) {
       source: meta.identity?.source || instanceIdSource,
     };
 
+    const rawPosition = {
+      x: computedX,
+      y: -toNumber(inst.offsetY, 0),
+    };
+    const distanceToCamera = Math.hypot(rawPosition.x, rawPosition.y);
+    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
+    const appliesProximityScale = !tags.some((tag) => tag === 'player'
+      || tag === 'npc'
+      || tag.startsWith('spawn:player')
+      || tag.startsWith('spawn:npc'));
+
     return {
       instanceId,
       id: inst.id,
       prefabId: inst.prefabId,
       layerId: inst.layerId,
-      position: {
-        x: computedX,
-        y: -toNumber(inst.offsetY, 0),
-      },
+      position: rawPosition,
       scale: {
-        x: toNumber(inst.scaleX, 1),
-        y: toNumber(inst.scaleY, inst.scaleX ?? 1),
+        x: toNumber(inst.scaleX, 1) * (appliesProximityScale ? proximityScale : 1),
+        y: toNumber(inst.scaleY, inst.scaleX ?? 1) * (appliesProximityScale ? proximityScale : 1),
       },
       rotationDeg: toNumber(inst.rot, 0),
       locked: !!inst.locked,
+      intraLayerDepth,
       prefab,
       tags,
-      meta,
+      meta: {
+        ...meta,
+        proximityScale: {
+          applied: appliesProximityScale ? proximityScale : 1,
+          inherited: proximityScale,
+        },
+      },
     };
   });
 
@@ -978,6 +1013,7 @@ export function convertLayoutToArea(layout, options = {}) {
     ground: {
       offset: toNumber(layout.groundOffset, 0),
     },
+    proximityScale,
     layers: convertedLayers,
     instances: convertedInstances,
     instancesById: buildInstanceIndex(convertedInstances),
@@ -987,6 +1023,7 @@ export function convertLayoutToArea(layout, options = {}) {
     background,
     meta: {
       exportedAt: layout.meta?.exportedAt || null,
+      proximityScale,
       raw: includeRaw ? safeClone(layout) : undefined,
     },
   };
@@ -1027,6 +1064,12 @@ function computeLayerSlotCenters(instances) {
 function toNumber(value, fallback) {
   const num = Number(value);
   return Number.isFinite(num) ? num : fallback;
+}
+
+function clampScale(value, fallback = 1) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return Math.max(0.001, num);
 }
 
 function normalizeCollider(raw, fallbackIndex = 0) {

--- a/docs/map-editor.html
+++ b/docs/map-editor.html
@@ -645,6 +645,10 @@
               <span>Ground from bottom (px)</span>
               <input id="groundOffset" type="number" value="140">
             </label>
+            <label>
+              <span>Proximity scale</span>
+              <input id="proximityScale" type="number" step="0.05" min="0.05" value="1">
+            </label>
           </div>
           <div id="exportStatus"></div>
           <textarea id="exportText" readonly
@@ -659,7 +663,8 @@
           <div class="row">
             <label>
               <span>Tile image URL</span>
-              <input id="bgTileUrl" type="text" placeholder="https://.../tile.png">
+              <input id="bgTileUrl" type="text" placeholder="https://.../tile.png" list="bgTileUrlOptions">
+              <datalist id="bgTileUrlOptions"></datalist>
             </label>
             <label>
               <span>Tile scale</span>
@@ -847,6 +852,7 @@ let runtimeModulePromise = null;
 let prefabBootstrapPromise = null;
 
 $('#groundOffset').value = DEFAULT_GROUND_OFFSET;
+$('#proximityScale').value = clampValue(toNumber($('#proximityScale').value, 1) || 1, 0.05, 50);
 
 function getRuntimeModule(){
   if (!runtimeModulePromise){
@@ -1123,6 +1129,7 @@ function restoreState(state){
   cameraX = toNumber(adopted.camera?.startX, 0);
   zoom = toNumber(adopted.camera?.startZoom, 1);
   $('#groundOffset').value = toNumber(adopted.ground?.offset, DEFAULT_GROUND_OFFSET);
+  $('#proximityScale').value = clampValue(adopted.proximityScale ?? layoutMeta.proximityScale ?? 1, 0.05, 50);
   selectedInstId = getPlayerSpawnInstance()?.id || (instances[0]?.id ?? null);
 
   rebuildActiveLayerSelect();
@@ -1622,6 +1629,7 @@ function adoptAreaState(area, context = {}){
   const ground = {
     offset: toNumber(raw.ground?.offset ?? raw.groundOffset, DEFAULT_GROUND_OFFSET),
   };
+  const proximityScale = clampValue(toNumber(raw.proximityScale ?? raw.meta?.proximityScale, 1) || 1, 0.05, 50);
   const layersList = Array.isArray(raw.layers) && raw.layers.length
     ? raw.layers.map((layer, index) => normalizeLayer(layer, index))
     : createDefaultLayers();
@@ -1692,6 +1700,7 @@ function adoptAreaState(area, context = {}){
     name,
     camera,
     ground,
+    proximityScale,
     layers: layersList,
     instances: normalizedInstances,
     colliders: normalizedColliders,
@@ -1702,6 +1711,7 @@ function adoptAreaState(area, context = {}){
       areaName: name,
       sourcePath: context.sourcePath ?? meta.sourcePath ?? null,
       repositoryId: context.repositoryId ?? meta.repositoryId ?? null,
+      proximityScale,
       background,
     },
     background,
@@ -1774,6 +1784,7 @@ function buildAreaDescriptor(){
 
   const meta = {
     ...layoutMeta,
+    proximityScale: getProximityScale(),
     background: normalizedBackground,
     activeLayerId,
   };
@@ -1789,6 +1800,7 @@ function buildAreaDescriptor(){
     ground: {
       offset: getGroundOffset(),
     },
+    proximityScale: getProximityScale(),
     background: normalizedBackground,
     layers: clonedLayers,
     instances: clonedInstances,
@@ -1867,6 +1879,10 @@ let debugOverlay = false;
 
 function getGroundOffset(){
   return parseFloat($('#groundOffset').value) || DEFAULT_GROUND_OFFSET;
+}
+
+function getProximityScale(){
+  return clampValue(toNumber($('#proximityScale').value, 1) || 1, 0.05, 50);
 }
 
 /*** Layer UI & stack ***/
@@ -2112,15 +2128,22 @@ async function ensureConfiguredPrefabsLoaded(){
   })();
   return prefabBootstrapPromise;
 }
-async function importDrumSkinImagesFromAssetManifest(){
-  let manifest = [];
+let cachedAssetManifest = null;
+async function loadAssetManifest(){
+  if (cachedAssetManifest) return cachedAssetManifest;
   try {
     const response = await fetch('./assets/asset-manifest.json', { cache: 'no-cache' });
-    manifest = await response.json();
+    cachedAssetManifest = await response.json();
+    return cachedAssetManifest;
   } catch (error) {
-    console.warn('[map-editor] Failed to load asset manifest for drum skins', error);
-    return;
+    console.warn('[map-editor] Failed to load asset manifest', error);
+    cachedAssetManifest = [];
+    return cachedAssetManifest;
   }
+}
+async function importDrumSkinImagesFromAssetManifest(){
+  const manifest = await loadAssetManifest();
+  if (!Array.isArray(manifest)) return manifest;
 
   const drumSkinUrls = Array.isArray(manifest)
     ? manifest.filter((entry) => typeof entry === 'string' && entry.startsWith('./assets/prefabs/images/'))
@@ -2195,6 +2218,21 @@ async function importDrumSkinImagesFromAssetManifest(){
     refreshLibrarySelect();
     refreshDrumSkinList();
   }
+}
+
+function populateBackgroundTileChoices(manifest){
+  const list = document.getElementById('bgTileUrlOptions');
+  if (!list) return;
+  list.innerHTML = '';
+  const urls = Array.isArray(manifest)
+    ? manifest.filter((entry) => typeof entry === 'string' && entry.startsWith('./assets/prefabs/images/'))
+    : [];
+  urls.forEach((url) => {
+    const option = document.createElement('option');
+    option.value = url;
+    option.label = url.split('/').pop() || url;
+    list.appendChild(option);
+  });
 }
 function registerImagePrefab(file){
   const url=URL.createObjectURL(file);
@@ -4041,6 +4079,12 @@ if (spawnHeightField){
     spawnHeightField.addEventListener(evt, updateSpawnHeightFromField);
   });
 }
+const proximityScaleField = $('#proximityScale');
+if (proximityScaleField){
+  ['change','blur'].forEach((evt) => {
+    proximityScaleField.addEventListener(evt, () => pushHistory());
+  });
+}
 
 /*** Loaders for prefab/image ***/
 $('#btnLoadPrefab').addEventListener('click',()=>{
@@ -4096,6 +4140,8 @@ requestAnimationFrame(render);
 (async () => {
   try {
     await ensureConfiguredPrefabsLoaded();
+    const manifest = await loadAssetManifest();
+    populateBackgroundTileChoices(manifest);
     await importDrumSkinImagesFromAssetManifest();
     const initialId = layoutMeta.repositoryId || layoutMeta.areaId || DEFAULT_LAYOUT_META.areaId;
     await loadRepositoryMapById(initialId);


### PR DESCRIPTION
## Summary
- add map-level proximity scaling and intra-layer depth metadata to map builder outputs
- sync map runtime and tests with the new scaling behavior
- expose proximity scale and background tile selection options in the map editor UI

## Testing
- node --test tests/map/builderConversion.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228abf88ec83269d4c922a9bc25e14)