### PR TITLE
Initialize proximity scale in builder layout conversion

### DIFF
--- a/docs/js/vendor/map-runtime.js
+++ b/docs/js/vendor/map-runtime.js
@@ -871,6 +871,7 @@ export function convertLayoutToArea(layout, options = {}) {
   const prefabResolver = options.prefabResolver ?? (() => null);
   const prefabErrorLookup = options.prefabErrorLookup ?? null;
   const includeRaw = options.includeRaw ?? false;
+  const proximityScale = clampScale(layout.proximityScale ?? layout.meta?.proximityScale, 1);
 
   const layers = Array.isArray(layout.layers) ? layout.layers : [];
   const instances = Array.isArray(layout.instances)


### PR DESCRIPTION
## Summary
- initialize `proximityScale` within `convertLayoutToArea` to prevent reference errors and align with source runtime behavior

## Testing
- node --test tests/map/builderConversion.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692290c21f488326b0794c135f1b2ddc)