### PR TITLE
Fix simple poncho shoulder style key mapping

### DIFF
--- a/docs/config/cosmetics/simple_poncho.json
+++ b/docs/config/cosmetics/simple_poncho.json
@@ -43,7 +43,8 @@
             "url": ""
           },
           "attachBone": "arm_R_upper",
-          "drawSlot": "arm_R_lower", 
+          "styleKey": "arm_R_upper",
+          "drawSlot": "arm_R_lower",
           "spriteStyle": {
             "base": {
               "xform": {


### PR DESCRIPTION
## Summary
- set the simple poncho shoulder layer to use the arm_R_upper style key so its xform entry is applied
- keep the shoulder xform keyed to the normalized armUpper value to match normalizeStyleKey behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228fcd108083268bd1ab707f2d2731)