### PR TITLE
Add proximity scaling controls and depth ordering to maps

### DIFF
--- a/docs/js/vendor/map-runtime.js
+++ b/docs/js/vendor/map-runtime.js
@@ -871,7 +871,10 @@ export function convertLayoutToArea(layout, options = {}) {
   const prefabResolver = options.prefabResolver ?? (() => null);
   const prefabErrorLookup = options.prefabErrorLookup ?? null;
   const includeRaw = options.includeRaw ?? false;
-  const proximityScale = clampScale(layout.proximityScale ?? layout.meta?.proximityScale, 1);
+  const proximityScale = clampScale(
+    layout.proximityScale ?? layout.meta?.proximityScale,
+    1,
+  );
 
   const layers = Array.isArray(layout.layers) ? layout.layers : [];
   const instances = Array.isArray(layout.instances)


### PR DESCRIPTION
## Summary
- add map-level proximity scaling and intra-layer depth metadata to map builder outputs
- sync map runtime and tests with the new scaling behavior
- expose proximity scale and background tile selection options in the map editor UI
- initialize proximity scale in the bundled runtime before converting layouts

## Testing
- node --test tests/map/builderConversion.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922968d70688326a33205c0e8c51073)