### PR TITLE
Adjust proximity scaling to mimic zoom

### DIFF
--- a/docs/js/vendor/map-runtime.js
+++ b/docs/js/vendor/map-runtime.js
@@ -944,22 +944,29 @@ function normalizeAreaDescriptor(area, options = {}) {
       x: toNumber(inst.position?.x ?? inst.x ?? 0, 0),
       y: toNumber(inst.position?.y ?? inst.y ?? 0, 0),
     };
-    const distanceToCamera = Math.hypot(rawPosition.x, rawPosition.y);
-    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
     const appliesProximityScale = !tags.some((tag) => tag === 'player'
       || tag === 'npc'
       || tag.startsWith('spawn:player')
       || tag.startsWith('spawn:npc'));
+    const appliedProximityScale = appliesProximityScale ? proximityScale : 1;
+    const position = appliesProximityScale
+      ? {
+          x: rawPosition.x * proximityScale,
+          y: rawPosition.y * proximityScale,
+        }
+      : rawPosition;
+    const distanceToCamera = Math.hypot(position.x, position.y);
+    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
 
     return {
       instanceId,
       id: inst.id,
       prefabId: inst.prefabId ?? null,
       layerId: inst.layerId ?? null,
-      position: rawPosition,
+      position,
       scale: {
-        x: toNumber(inst.scale?.x ?? inst.scaleX ?? 1, 1) * (appliesProximityScale ? proximityScale : 1),
-        y: toNumber(inst.scale?.y ?? inst.scaleY ?? inst.scale?.x ?? inst.scaleX ?? 1, 1) * (appliesProximityScale ? proximityScale : 1),
+        x: toNumber(inst.scale?.x ?? inst.scaleX ?? 1, 1) * appliedProximityScale,
+        y: toNumber(inst.scale?.y ?? inst.scaleY ?? inst.scale?.x ?? inst.scaleX ?? 1, 1) * appliedProximityScale,
       },
       rotationDeg: toNumber(inst.rotationDeg ?? inst.rot ?? 0, 0),
       locked: !!inst.locked,
@@ -969,8 +976,9 @@ function normalizeAreaDescriptor(area, options = {}) {
       meta: {
         ...meta,
         proximityScale: {
-          applied: appliesProximityScale ? proximityScale : 1,
+          applied: appliedProximityScale,
           inherited: proximityScale,
+          mode: 'zoom',
         },
       },
     };
@@ -1111,22 +1119,29 @@ export function convertLayoutToArea(layout, options = {}) {
       x: computedX,
       y: -toNumber(inst.offsetY, 0),
     };
-    const distanceToCamera = Math.hypot(rawPosition.x, rawPosition.y);
-    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
     const appliesProximityScale = !tags.some((tag) => tag === 'player'
       || tag === 'npc'
       || tag.startsWith('spawn:player')
       || tag.startsWith('spawn:npc'));
+    const appliedProximityScale = appliesProximityScale ? proximityScale : 1;
+    const position = appliesProximityScale
+      ? {
+          x: rawPosition.x * proximityScale,
+          y: rawPosition.y * proximityScale,
+        }
+      : rawPosition;
+    const distanceToCamera = Math.hypot(position.x, position.y);
+    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
 
     return {
       instanceId,
       id: inst.id,
       prefabId: inst.prefabId,
       layerId: inst.layerId,
-      position: rawPosition,
+      position,
       scale: {
-        x: toNumber(inst.scaleX, 1) * (appliesProximityScale ? proximityScale : 1),
-        y: toNumber(inst.scaleY, inst.scaleX ?? 1) * (appliesProximityScale ? proximityScale : 1),
+        x: toNumber(inst.scaleX, 1) * appliedProximityScale,
+        y: toNumber(inst.scaleY, inst.scaleX ?? 1) * appliedProximityScale,
       },
       rotationDeg: toNumber(inst.rot, 0),
       locked: !!inst.locked,
@@ -1136,8 +1151,9 @@ export function convertLayoutToArea(layout, options = {}) {
       meta: {
         ...meta,
         proximityScale: {
-          applied: appliesProximityScale ? proximityScale : 1,
+          applied: appliedProximityScale,
           inherited: proximityScale,
+          mode: 'zoom',
         },
       },
     };

--- a/src/map/builderConversion.js
+++ b/src/map/builderConversion.js
@@ -462,22 +462,29 @@ function normalizeAreaDescriptor(area, options = {}) {
       x: toNumber(inst.position?.x ?? inst.x ?? 0, 0),
       y: toNumber(inst.position?.y ?? inst.y ?? 0, 0),
     };
-    const distanceToCamera = Math.hypot(rawPosition.x, rawPosition.y);
-    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
     const appliesProximityScale = !tags.some((tag) => tag === 'player'
       || tag === 'npc'
       || tag.startsWith('spawn:player')
       || tag.startsWith('spawn:npc'));
+    const appliedProximityScale = appliesProximityScale ? proximityScale : 1;
+    const position = appliesProximityScale
+      ? {
+          x: rawPosition.x * proximityScale,
+          y: rawPosition.y * proximityScale,
+        }
+      : rawPosition;
+    const distanceToCamera = Math.hypot(position.x, position.y);
+    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
 
     return {
       instanceId,
       id: inst.id,
       prefabId: inst.prefabId ?? null,
       layerId: inst.layerId ?? null,
-      position: rawPosition,
+      position,
       scale: {
-        x: toNumber(inst.scale?.x ?? inst.scaleX ?? 1, 1) * (appliesProximityScale ? proximityScale : 1),
-        y: toNumber(inst.scale?.y ?? inst.scaleY ?? inst.scale?.x ?? inst.scaleX ?? 1, 1) * (appliesProximityScale ? proximityScale : 1),
+        x: toNumber(inst.scale?.x ?? inst.scaleX ?? 1, 1) * appliedProximityScale,
+        y: toNumber(inst.scale?.y ?? inst.scaleY ?? inst.scale?.x ?? inst.scaleX ?? 1, 1) * appliedProximityScale,
       },
       rotationDeg: toNumber(inst.rotationDeg ?? inst.rot ?? 0, 0),
       locked: !!inst.locked,
@@ -487,8 +494,9 @@ function normalizeAreaDescriptor(area, options = {}) {
       meta: {
         ...meta,
         proximityScale: {
-          applied: appliesProximityScale ? proximityScale : 1,
+          applied: appliedProximityScale,
           inherited: proximityScale,
+          mode: 'zoom',
         },
       },
     };
@@ -635,22 +643,29 @@ export function convertLayoutToArea(layout, options = {}) {
       x: computedX,
       y: -toNumber(inst.offsetY, 0),
     };
-    const distanceToCamera = Math.hypot(rawPosition.x, rawPosition.y);
-    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
     const appliesProximityScale = !tags.some((tag) => tag === 'player'
       || tag === 'npc'
       || tag.startsWith('spawn:player')
       || tag.startsWith('spawn:npc'));
+    const appliedProximityScale = appliesProximityScale ? proximityScale : 1;
+    const position = appliesProximityScale
+      ? {
+          x: rawPosition.x * proximityScale,
+          y: rawPosition.y * proximityScale,
+        }
+      : rawPosition;
+    const distanceToCamera = Math.hypot(position.x, position.y);
+    const intraLayerDepth = Number.isFinite(distanceToCamera) ? -distanceToCamera : 0;
 
     return {
       instanceId,
       id: inst.id,
       prefabId: inst.prefabId,
       layerId: inst.layerId,
-      position: rawPosition,
+      position,
       scale: {
-        x: toNumber(inst.scaleX, 1) * (appliesProximityScale ? proximityScale : 1),
-        y: toNumber(inst.scaleY, inst.scaleX ?? 1) * (appliesProximityScale ? proximityScale : 1),
+        x: toNumber(inst.scaleX, 1) * appliedProximityScale,
+        y: toNumber(inst.scaleY, inst.scaleX ?? 1) * appliedProximityScale,
       },
       rotationDeg: toNumber(inst.rot, 0),
       locked: !!inst.locked,
@@ -660,8 +675,9 @@ export function convertLayoutToArea(layout, options = {}) {
       meta: {
         ...meta,
         proximityScale: {
-          applied: appliesProximityScale ? proximityScale : 1,
+          applied: appliedProximityScale,
           inherited: proximityScale,
+          mode: 'zoom',
         },
       },
     };

--- a/tests/map/builderConversion.test.js
+++ b/tests/map/builderConversion.test.js
@@ -133,7 +133,7 @@ test('convertLayoutToArea applies proximity scale and intra-layer depth', () => 
       { id: 'game', name: 'Game', parallax: 1, yOffset: 0, sep: 150, scale: 1 },
     ],
     instances: [
-      { id: 'close', prefabId: 'tree', layerId: 'game', x: 0, offsetY: 0, scaleX: 1 },
+      { id: 'close', prefabId: 'tree', layerId: 'game', x: 4, offsetY: 0, scaleX: 1 },
       { id: 'far', prefabId: 'rock', layerId: 'game', x: 10, offsetY: 0, scaleX: 1, tags: ['spawn:player'] },
     ],
   };
@@ -144,8 +144,11 @@ test('convertLayoutToArea applies proximity scale and intra-layer depth', () => 
   assert.equal(area.meta.proximityScale, 1.5);
   const [closeInst, farInst] = area.instances;
   assert.equal(closeInst.scale.x, 1.5);
+  assert.equal(closeInst.position.x, 6);
+  assert.equal(closeInst.meta.proximityScale.mode, 'zoom');
   assert.equal(closeInst.meta.proximityScale.applied, 1.5);
   assert.equal(farInst.scale.x, 1); // player spawn tags remain unscaled
+  assert.equal(farInst.position.x, 10);
   assert.ok(closeInst.intraLayerDepth > farInst.intraLayerDepth);
 });
 


### PR DESCRIPTION
## Summary
- apply proximity scale as a zoom-style transform to instance positions and scales while skipping player/npc tags
- record the proximity scaling mode in metadata and mirror the runtime bundle
- update map conversion tests to cover zoom-like position scaling

## Testing
- npm test *(fails: ensureCosmeticLayers exposes layer extra bone influence metadata; clampFighterToBounds applies world width from camera — existing issues)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922c4b9ea448326a7a888bd5845da5a)