### PR TITLE
Add weapon draw toggle and sync state

### DIFF
--- a/docs/js/controls.js
+++ b/docs/js/controls.js
@@ -6,6 +6,7 @@ export function initControls(){
   G.input ||= {
     left:false, right:false, jump:false, dash:false,
     nonCombatRagdoll: false,
+    weaponDrawn: true,
     buttonA: { down:false, downTime:0, upTime:0 },
     buttonB: { down:false, downTime:0, upTime:0 },
     buttonC: { down:false, downTime:0, upTime:0 }
@@ -19,6 +20,23 @@ export function initControls(){
     const fighter = window.GAME?.FIGHTERS?.player;
     if (fighter) {
       fighter.nonCombatRagdoll = I.nonCombatRagdoll;
+    }
+  }
+
+  function toggleWeaponDrawn(){
+    I.weaponDrawn = !I.weaponDrawn;
+    const fighter = window.GAME?.FIGHTERS?.player;
+    if (fighter) {
+      fighter.weaponDrawn = I.weaponDrawn;
+      fighter.renderProfile ||= {};
+      fighter.renderProfile.weaponDrawn = I.weaponDrawn;
+      fighter.renderProfile.weaponStowed = !I.weaponDrawn;
+      if (fighter.anim?.weapon) {
+        fighter.anim.weapon.stowed = !I.weaponDrawn;
+      }
+      if (typeof window.syncWeaponDrawnState === 'function') {
+        window.syncWeaponDrawnState({ fighterKey: 'player', weaponDrawn: I.weaponDrawn });
+      }
     }
   }
 
@@ -49,6 +67,7 @@ export function initControls(){
       case 'KeyF': case 'KeyK': setButton('buttonB', down); break;
       case 'KeyR': case 'KeyL': setButton('buttonC', down); break;
       case 'KeyN': if (down) toggleNonCombatRagdoll(); break;
+      case 'KeyT': if (down) toggleWeaponDrawn(); break;
       default: return;
     }
   }
@@ -95,13 +114,23 @@ export function initControls(){
     e.preventDefault();
   }); // Prevent right-click menu over game viewport
   window.addEventListener('blur', ()=>{
-    Object.assign(I,{left:false,right:false,jump:false,dash:false,nonCombatRagdoll:false});
+    Object.assign(I,{left:false,right:false,jump:false,dash:false,nonCombatRagdoll:false,weaponDrawn:true});
     I.buttonA.down = false;
     I.buttonB.down = false;
     I.buttonC.down = false;
     const fighter = window.GAME?.FIGHTERS?.player;
     if (fighter) {
       fighter.nonCombatRagdoll = false;
+      fighter.weaponDrawn = true;
+      fighter.renderProfile ||= {};
+      fighter.renderProfile.weaponDrawn = true;
+      fighter.renderProfile.weaponStowed = false;
+      if (fighter.anim?.weapon) {
+        fighter.anim.weapon.stowed = false;
+      }
+      if (typeof window.syncWeaponDrawnState === 'function') {
+        window.syncWeaponDrawnState({ fighterKey: 'player', weaponDrawn: true });
+      }
     }
     mouseBindings[0] = mouseBindings[1] = mouseBindings[2] = null;
   });

--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -73,6 +73,11 @@ function resetRuntimeState(fighter, template, {
   fighter.ragdoll = false;
   fighter.ragdollTime = 0;
   fighter.ragdollVel = { x: 0, y: 0 };
+  if (typeof base.weaponDrawn === 'boolean') {
+    fighter.weaponDrawn = base.weaponDrawn;
+  } else if (typeof fighter.weaponDrawn !== 'boolean') {
+    fighter.weaponDrawn = true;
+  }
   fighter.recovering = false;
   fighter.recoveryTime = 0;
   fighter.recoveryDuration = base.recoveryDuration ?? fighter.recoveryDuration ?? 0.8;
@@ -682,6 +687,8 @@ export function initFighters(cv, cx, options = {}){
     const appearanceBase = prevProfile?.appearance
       ?? (characterData?.appearance ? clone(characterData.appearance) : null);
     const weaponBase = prevProfile?.weapon ?? characterData?.weapon ?? null;
+    const weaponDrawnBase = prevProfile?.weaponDrawn
+      ?? (prevProfile?.weaponStowed != null ? !prevProfile.weaponStowed : null);
     const abilityBase = Array.isArray(prevProfile?.slottedAbilities)
       ? prevProfile.slottedAbilities.slice()
       : (Array.isArray(characterData?.slottedAbilities)
@@ -699,6 +706,8 @@ export function initFighters(cv, cx, options = {}){
       cosmetics: cosmeticsBase ? clone(cosmeticsBase) : null,
       appearance: appearanceBase ? clone(appearanceBase) : null,
       weapon: weaponBase,
+      weaponDrawn: weaponDrawnBase != null ? weaponDrawnBase : true,
+      weaponStowed: weaponDrawnBase != null ? !weaponDrawnBase : false,
       slottedAbilities: abilityBase,
       stats,
       statProfile,
@@ -742,6 +751,7 @@ export function initFighters(cv, cx, options = {}){
       facingSign: faceSign,
       footing: isPlayer ? 50 : 100,
       nonCombatRagdoll: false,
+      weaponDrawn: renderProfile.weaponDrawn,
       ragdoll: false,
       ragdollTime: 0,
       ragdollVel: { x: 0, y: 0 },


### PR DESCRIPTION
## Summary
- add a weapon drawn toggle input binding that updates the player fighter state
- thread drawn/stowed state through weapon runtime and render profiles without changing weapon selection
- persist the draw flag in fighter templates and character state for future consumers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f273b9c88326b3ac2edf8034824a)