### PR TITLE
Guard NPC aiming to active aggression

### DIFF
--- a/docs/js/npc.js
+++ b/docs/js/npc.js
@@ -1011,8 +1011,15 @@ function updateNpcAttack(G, state, dt) {
   applyNpcPoseForCurrentPhase(state);
 }
 
-function updateNpcAiming(state, player) {
+function updateNpcAiming(state, player, { aggressionActive } = {}) {
   const aim = ensureAimState(state);
+  if (!aggressionActive) {
+    aim.active = false;
+    aim.torsoOffset = 0;
+    aim.shoulderOffset = 0;
+    aim.hipOffset = 0;
+    return;
+  }
   if (!player) {
     aim.active = false;
     aim.torsoOffset = 0;
@@ -1241,7 +1248,7 @@ function updateNpcMovement(G, state, dt, abilityIntent = null) {
         aggression.wakeTimer = 0;
       }
     }
-    updateNpcAiming(state, player);
+    updateNpcAiming(state, player, { aggressionActive: aggression.active });
     updateDashTrail(visuals, state, dt);
     updateNpcAttackTrail(visuals, state, dt);
     regenerateStamina(state, dt);
@@ -1560,7 +1567,7 @@ function updateNpcMovement(G, state, dt, abilityIntent = null) {
   regenerateStamina(state, dt);
   updateDashTrail(visuals, state, dt);
   updateNpcAttackTrail(visuals, state, dt);
-  updateNpcAiming(state, player);
+  updateNpcAiming(state, player, { aggressionActive: aggression.active });
 }
 
 function updateNpcHud(G) {


### PR DESCRIPTION
## Summary
- gate NPC aiming updates behind active aggression before enabling upper-body targeting
- reset torso and shoulder offsets when aggression is inactive or player unavailable
- propagate aggression state into aiming updates to keep non-combat NPCs neutral

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230e64a16083269c4b76990ff1820c)