### PR TITLE
Spawn fighters stowed and block aim while relaxed

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -1959,7 +1959,7 @@ function updateAiming(F, currentPose, fighterId){
 
 // Apply aiming offsets to a pose
 function applyAimingOffsets(poseDeg, F, currentPose){
-  if (!F.aim.active) return poseDeg;
+  if (!F.aim.active || F.nonCombatRagdoll) return poseDeg;
 
   const poseFlags = currentPose || {};
   const result = {...poseDeg};

--- a/docs/js/fighter.js
+++ b/docs/js/fighter.js
@@ -69,14 +69,16 @@ function resetRuntimeState(fighter, template, {
   fighter.facingSign = resolvedFacing;
   fighter.facingRad = resolvedFacing < 0 ? Math.PI : 0;
   fighter.footing = fighter.isPlayer ? 50 : 100;
-  fighter.nonCombatRagdoll = false;
+  fighter.nonCombatRagdoll = typeof base.nonCombatRagdoll === 'boolean'
+    ? base.nonCombatRagdoll
+    : true;
   fighter.ragdoll = false;
   fighter.ragdollTime = 0;
   fighter.ragdollVel = { x: 0, y: 0 };
   if (typeof base.weaponDrawn === 'boolean') {
     fighter.weaponDrawn = base.weaponDrawn;
   } else if (typeof fighter.weaponDrawn !== 'boolean') {
-    fighter.weaponDrawn = true;
+    fighter.weaponDrawn = false;
   }
   fighter.recovering = false;
   fighter.recoveryTime = 0;
@@ -706,8 +708,8 @@ export function initFighters(cv, cx, options = {}){
       cosmetics: cosmeticsBase ? clone(cosmeticsBase) : null,
       appearance: appearanceBase ? clone(appearanceBase) : null,
       weapon: weaponBase,
-      weaponDrawn: weaponDrawnBase != null ? weaponDrawnBase : true,
-      weaponStowed: weaponDrawnBase != null ? !weaponDrawnBase : false,
+      weaponDrawn: weaponDrawnBase != null ? weaponDrawnBase : false,
+      weaponStowed: weaponDrawnBase != null ? !weaponDrawnBase : true,
       slottedAbilities: abilityBase,
       stats,
       statProfile,
@@ -750,7 +752,9 @@ export function initFighters(cv, cx, options = {}){
       facingRad: faceSign < 0 ? Math.PI : 0,
       facingSign: faceSign,
       footing: isPlayer ? 50 : 100,
-      nonCombatRagdoll: false,
+      nonCombatRagdoll: typeof renderProfile.nonCombatRagdoll === 'boolean'
+        ? renderProfile.nonCombatRagdoll
+        : true,
       weaponDrawn: renderProfile.weaponDrawn,
       ragdoll: false,
       ragdollTime: 0,

--- a/docs/js/npc.js
+++ b/docs/js/npc.js
@@ -1013,7 +1013,7 @@ function updateNpcAttack(G, state, dt) {
 
 function updateNpcAiming(state, player, { aggressionActive } = {}) {
   const aim = ensureAimState(state);
-  if (!aggressionActive) {
+  if (!aggressionActive || state.nonCombatRagdoll) {
     aim.active = false;
     aim.torsoOffset = 0;
     aim.shoulderOffset = 0;


### PR DESCRIPTION
## Summary
- default fighters now spawn with weapons sheathed and non-combat ragdoll enabled
- suppress NPC aiming when they remain in a non-combat ragdoll pose
- skip applying animator aiming offsets while fighters are in non-combat ragdoll state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69231ce515148326b75249d7c27e0bdc)