### PR TITLE
Add reusable NPC group library

### DIFF
--- a/docs/modular-map-pipeline.md
+++ b/docs/modular-map-pipeline.md
@@ -49,3 +49,21 @@ registry.registerAreas({ practice_hall: practiceHall });
 
 This pattern keeps the map pipeline modular—if a layout fails to convert, the
 rest of the runtime keeps running with previously registered areas.
+
+## Shared NPC group JSONs
+
+- Author reusable NPC group definitions as plain JSON under
+  `src/config/groups/` (see `npc-groups.json` for a starter set). Each record
+  can declare `members`, `interests`, and fallback `exitTags` without being
+  tied to a specific map.
+- Import the normalized library from `src/config/groups/index.js` and hand it
+  to the converter:
+
+  ```js
+  import { groupLibrary } from '../src/config/groups/index.js';
+  const area = convertLayoutToArea(layout, { groupLibrary });
+  ```
+
+- Spawners with `groupId` (or inline `group` metadata) will automatically pull
+  the matching JSON definition so the same patrol, family, or adventuring party
+  can be reused across maps while sharing path-target interests.

--- a/src/config/groups/index.js
+++ b/src/config/groups/index.js
@@ -1,0 +1,13 @@
+import { createRequire } from 'node:module';
+
+import { mergeGroupLibraries, normalizeGroupLibrary } from '../../map/groupLibrary.js';
+
+const require = createRequire(import.meta.url);
+const rawNpcGroups = require('./npc-groups.json');
+
+const npcGroupLibrary = normalizeGroupLibrary(rawNpcGroups, [], { source: 'config/groups/npc-groups.json' });
+
+export const groupLibrary = mergeGroupLibraries(npcGroupLibrary);
+export const npcGroups = npcGroupLibrary;
+
+export default groupLibrary;

--- a/src/config/groups/npc-groups.json
+++ b/src/config/groups/npc-groups.json
@@ -1,0 +1,24 @@
+{
+  "city_guard_patrol": {
+    "name": "City Guard Patrol",
+    "interests": ["patrol point", "gate", "barracks"],
+    "exitTags": ["map-exit:left", "map-exit:right"],
+    "exitWeights": { "map-exit:left": 2, "map-exit:right": 1 },
+    "members": [
+      { "templateId": "guard_captain", "count": 1 },
+      { "templateId": "guard", "count": 3 }
+    ],
+    "meta": { "role": "patrol" }
+  },
+  "inn_family_guest": {
+    "name": "Inn Family Guest Group",
+    "interests": ["inn", "apartment", "restaurant"],
+    "exitTags": ["map-exit:right"],
+    "members": [
+      { "templateId": "traveler_parent", "count": 1 },
+      { "templateId": "traveler_child", "count": 1 },
+      { "templateId": "traveler_companion", "count": 1 }
+    ],
+    "meta": { "role": "lodging" }
+  }
+}

--- a/src/map/groupLibrary.js
+++ b/src/map/groupLibrary.js
@@ -1,0 +1,143 @@
+import { mapBuilderConfig } from './mapBuilderConfig.js';
+
+const { sourceId: SOURCE_ID } = mapBuilderConfig;
+
+const clone = (value) => {
+  if (!value || typeof value !== 'object') return value ?? null;
+  try {
+    return structuredClone(value);
+  } catch {
+    return JSON.parse(JSON.stringify(value));
+  }
+};
+
+const pickNonEmptyString = (...candidates) => {
+  for (const candidate of candidates) {
+    if (candidate == null) continue;
+    const text = String(candidate).trim();
+    if (text) return text;
+  }
+  return null;
+};
+
+function normalizeGroupMember(member) {
+  if (member == null) return null;
+  if (typeof member === 'string') {
+    const templateId = pickNonEmptyString(member);
+    return templateId ? { templateId } : null;
+  }
+  if (typeof member !== 'object') return null;
+  const templateId = pickNonEmptyString(
+    member.templateId,
+    member.characterTemplateId,
+    member.character,
+    member.characterId,
+    member.id,
+  );
+  const characterId = pickNonEmptyString(member.characterId, member.character);
+  const count = Number.isFinite(Number(member.count)) && Number(member.count) > 0
+    ? Math.round(Number(member.count))
+    : 1;
+  const normalized = {
+    ...clone(member),
+    templateId: templateId ?? null,
+    characterId: characterId ?? null,
+    count,
+  };
+  return normalized;
+}
+
+export function normalizeGroupRecord(raw, warnings = [], context = {}) {
+  const source = typeof context.source === 'string' ? context.source : 'group';
+  const safe = raw && typeof raw === 'object' ? clone(raw) : {};
+  const groupId = pickNonEmptyString(safe.id, context.groupId);
+  if (!groupId) {
+    warnings.push(`Ignored ${source} without id`);
+    return null;
+  }
+
+  const name = pickNonEmptyString(safe.name, safe.label, groupId);
+  const interests = Array.isArray(safe.interests)
+    ? safe.interests.map((tag) => pickNonEmptyString(tag)).filter(Boolean)
+    : [];
+  const exitTags = Array.isArray(safe.exitTags)
+    ? safe.exitTags.map((tag) => pickNonEmptyString(tag)).filter(Boolean)
+    : [];
+  const exitWeights = safe.exitWeights && typeof safe.exitWeights === 'object'
+    ? clone(safe.exitWeights)
+    : {};
+  const members = Array.isArray(safe.members)
+    ? safe.members.map((member) => normalizeGroupMember(member)).filter(Boolean)
+    : [];
+  const meta = safe.meta && typeof safe.meta === 'object' ? clone(safe.meta) : {};
+
+  return {
+    ...safe,
+    id: groupId,
+    name,
+    interests,
+    exitTags,
+    exitWeights,
+    members,
+    meta,
+    source: pickNonEmptyString(safe.source, source, SOURCE_ID),
+  };
+}
+
+export function normalizeGroupLibrary(rawLibrary = {}, warnings = [], context = {}) {
+  const normalized = {};
+  const source = typeof context.source === 'string' ? context.source : 'groupLibrary';
+
+  const addRecord = (record, keyHint) => {
+    const group = normalizeGroupRecord(record, warnings, { source, groupId: keyHint });
+    if (!group) return;
+    if (!normalized[group.id]) {
+      normalized[group.id] = group;
+    }
+  };
+
+  if (Array.isArray(rawLibrary)) {
+    rawLibrary.forEach((record, index) => addRecord(record, `group_${index}`));
+  } else if (rawLibrary && typeof rawLibrary === 'object') {
+    Object.entries(rawLibrary).forEach(([key, record]) => addRecord(record, key));
+  }
+
+  return normalized;
+}
+
+export function mergeGroupLibraries(...libraries) {
+  const merged = {};
+  libraries.forEach((lib) => {
+    if (!lib || typeof lib !== 'object') return;
+    Object.entries(lib).forEach(([id, group]) => {
+      merged[id] = clone(group);
+    });
+  });
+  return merged;
+}
+
+export function attachGroupsToSpawners(spawners = [], groupLibrary = {}, warnings = []) {
+  if (!Array.isArray(spawners)) return [];
+  return spawners.map((spawner) => {
+    if (!spawner || typeof spawner !== 'object') return spawner;
+    const inlineGroup = spawner.group && typeof spawner.group === 'object' ? clone(spawner.group) : null;
+    const groupId = pickNonEmptyString(
+      spawner.groupId,
+      spawner.meta?.groupId,
+      inlineGroup?.id,
+      inlineGroup?.groupId,
+    );
+    const resolved = groupId && groupLibrary[groupId] ? clone(groupLibrary[groupId]) : null;
+    const group = inlineGroup || resolved || null;
+    if (!group && groupId) {
+      warnings.push(`Spawner "${spawner.spawnerId}" references missing group "${groupId}"`);
+    }
+    return {
+      ...spawner,
+      groupId: groupId || null,
+      group: group || undefined,
+    };
+  });
+}
+
+export default normalizeGroupLibrary;

--- a/tests/map/builderConversion.test.js
+++ b/tests/map/builderConversion.test.js
@@ -92,6 +92,42 @@ test('convertLayoutToArea normalizes npc spawners from instances and explicit li
   assert.strictEqual(area.spawnersById[manual.spawnerId], manual);
 });
 
+test('convertLayoutToArea attaches reusable group library records', () => {
+  const layout = {
+    areaId: 'group_area',
+    layers: [
+      { id: 'game', name: 'Game', parallax: 1, yOffset: 0, sep: 120, scale: 1, type: 'gameplay' },
+    ],
+    spawners: [
+      {
+        spawnerId: 'party',
+        type: 'npc',
+        position: { x: 0, y: 0 },
+        groupId: 'city_guard_patrol',
+      },
+    ],
+  };
+
+  const groupLibrary = {
+    city_guard_patrol: {
+      name: 'Guard Patrol',
+      interests: ['patrol point'],
+      members: [{ templateId: 'guard', count: 2 }],
+      exitTags: ['map-exit:right'],
+    },
+  };
+
+  const area = convertLayoutToArea(layout, { prefabResolver: (id) => ({ id }), groupLibrary });
+
+  const spawner = area.spawners.find((s) => s.spawnerId === 'party');
+  assert.ok(spawner);
+  assert.equal(spawner.groupId, 'city_guard_patrol');
+  assert.ok(spawner.group);
+  assert.equal(spawner.group.members[0].templateId, 'guard');
+  assert.equal(spawner.group.members[0].count, 2);
+  assert.deepEqual(area.groupLibrary.city_guard_patrol.interests, ['patrol point']);
+});
+
 test('convertLayoutToArea collects gameplay path targets and respects ordering', () => {
   const layout = {
     areaId: 'path_area',


### PR DESCRIPTION
## Summary
- add normalized NPC group library utilities and attach shared groups to converted spawners
- ship starter JSON group definitions and re-export them for map conversion
- document how to pass shared group JSON into map conversion and cover it with a new unit test

## Testing
- npm test (fails: tests/cosmetics-system.test.js ensureCosmeticLayers exposes layer extra bone influence metadata; tests/physics-world-width.test.js clampFighterToBounds applies world width from camera)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923351934c88326a6a9a43bb41c7a5e)