### PR TITLE
Adjust non-combat ragdoll shoulders to gravity

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -1716,13 +1716,19 @@ function computeGravityDownDeg(movement){
 
 function buildNonCombatRagdollPose(F, basePose, movement){
   const noise = advanceNonCombatNoise(F);
+  const gravity = movement?.gravity;
+  const hasGravity = Number.isFinite(gravity) && gravity !== 0;
   const downDeg = computeGravityDownDeg(movement);
-  const lBase = Number.isFinite(basePose?.lShoulder) ? basePose.lShoulder : 0;
-  const rBase = Number.isFinite(basePose?.rShoulder) ? basePose.rShoulder : 0;
+  const lDown = hasGravity
+    ? downDeg
+    : (Number.isFinite(basePose?.lShoulder) ? basePose.lShoulder : downDeg);
+  const rDown = hasGravity
+    ? -downDeg
+    : (Number.isFinite(basePose?.rShoulder) ? basePose.rShoulder : -downDeg);
   return {
-    lShoulder: downDeg - lBase + noise.shoulder,
+    lShoulder: lDown + noise.shoulder,
     lElbow: (NON_COMBAT_RAGDOLL_POSE.lElbow || 0) + noise.elbow,
-    rShoulder: downDeg - rBase - noise.shoulder,
+    rShoulder: rDown - noise.shoulder,
     rElbow: (NON_COMBAT_RAGDOLL_POSE.rElbow || 0) - noise.elbow,
   };
 }


### PR DESCRIPTION
## Summary
- derive non-combat ragdoll shoulder targets directly from gravity down vector when available
- fall back to base pose shoulders when gravity is unavailable while preserving small noise offsets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69233d8d3f408326be9396581e4dc035)