### PR TITLE
Add manual non-combat ragdoll arm overrides

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -812,7 +812,17 @@ window.CONFIG = {
     autoCalvesMidAir:false, stiffness:10.0,
     limbs:{ lCalf:false, rCalf:false, lThigh:false, rThigh:false, lUpperArm:false, rUpperArm:false, lForearm:false, rForearm:false, torso:false, head:false }
   },
-  
+
+  // Optional manual pre-ragdoll arm angles (degrees, absolute, before physics noise is added)
+  nonCombatRagdoll: {
+    manualArmRotation: {
+      lShoulder: null, // set to override the left shoulder's resting target (e.g., 90 keeps the arm pointing down)
+      rShoulder: null, // set to override the right shoulder's resting target
+      lElbow: null,
+      rElbow: null,
+    },
+  },
+
   colliders: {
     handMultiplier: 2.0,
     footMultiplier: 1.0


### PR DESCRIPTION
## Summary
- add configurable manual arm rotation values for non-combat ragdoll baselines
- allow animator to honor per-arm overrides while keeping noise and base-pose alignment
- expose config stub for tweaking shoulders and elbows before ragdoll physics

## Testing
- Not run (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69233c4020148326a2ec54e8b6764049)