### PR TITLE
Handle missing aggression state in NPC aiming

### DIFF
--- a/docs/js/npc.js
+++ b/docs/js/npc.js
@@ -1089,24 +1089,27 @@ function updateNpcPassiveHeadTracking(state, player) {
   aim.headWorldTarget = withinLimits ? worldAim : null;
 }
 
-function updateNpcAiming(state, player, { aggressionActive } = {}) {
-  const aim = ensureAimState(state);
-  if (!aggressionActive || state.nonCombatRagdoll) {
-    aim.active = false;
-    aim.torsoOffset = 0;
-    aim.shoulderOffset = 0;
-    aim.hipOffset = 0;
-    return;
+  function updateNpcAiming(state, player, { aggressionActive } = {}) {
+    const aim = ensureAimState(state);
+    const aggression = ensureNpcAggressionState(state);
+    const isAggressive = aggressionActive ?? aggression.active;
+
+    if (!isAggressive || state.nonCombatRagdoll) {
+      aim.active = false;
+      aim.torsoOffset = 0;
+      aim.shoulderOffset = 0;
+      aim.hipOffset = 0;
+      return;
   }
   if (!player) {
     resetNpcAimingOffsets(aim);
     return;
   }
 
-  if (!aggression.active) {
-    updateNpcPassiveHeadTracking(state, player);
-    return;
-  }
+    if (!aggression.active) {
+      updateNpcPassiveHeadTracking(state, player);
+      return;
+    }
 
   aim.headTrackingOnly = false;
   const shouldAim = !state.onGround;


### PR DESCRIPTION
## Summary
- ensure NPC aiming derives aggression state safely to prevent undefined reference errors
- maintain passive head-tracking fallback when aggression is inactive

## Testing
- npm test *(fails: ensureCosmeticLayers exposes layer extra bone influence metadata; clampFighterToBounds applies world width from camera)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692376f628ac8326883790a3683227d1)