### PR TITLE
Scope mirror flags per fighter

### DIFF
--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -758,7 +758,7 @@ export function makeCombat(G, C, options = {}){
       }
       const segment = ordered[idx];
       if (resetMirrorBeforeStance && !stanceReset && segment.phase === 'Stance'){
-        resetMirror();
+        resetMirror(poseTarget);
         stanceReset = true;
       }
       triggerStepsThrough(segment.startTime);
@@ -2237,7 +2237,7 @@ export function makeCombat(G, C, options = {}){
       if (progress >= TRANSITION.flipAt){
         console.log(logPrefix, `Applying flip at progress ${progress.toFixed(2)} (flipAt=${TRANSITION.flipAt})`);
         for (const part of TRANSITION.flipParts){
-          setMirrorForPart(part, true);
+          setMirrorForPart(part, true, poseTarget);
         }
         TRANSITION.flipApplied = true;
       }


### PR DESCRIPTION
## Summary
- scope sprite mirror flags to fighter-specific maps and reuse them when rendering each entity
- update cosmetic and limb rendering to read the fighter-local mirror state
- pass fighter ids through animator and combat flows so flips are applied and reset per fighter

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923804a39508326b3320d5d76397c7d)