### PR TITLE
Decouple weapon draw state from walk mode

### DIFF
--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -638,8 +638,10 @@ function getActiveWeaponKey(F, C) {
     || (C?.characters?.player?.weapon ?? null);
 }
 
-function isNonCombatPoseActive(F) {
-  return !!(F?.renderProfile?.nonCombat || F?.nonCombat);
+function isWeaponDrawn(F) {
+  if (typeof F?.renderProfile?.weaponDrawn === 'boolean') return F.renderProfile.weaponDrawn;
+  if (typeof F?.weaponDrawn === 'boolean') return F.weaponDrawn;
+  return true;
 }
 
 function isSneakMode(F) {
@@ -2085,7 +2087,9 @@ export function updatePoses(){
 
     const preActiveLayers = getActiveLayers(F, now);
     const attackActive = preActiveLayers.some(layer => layer?.id === 'primary');
-    const stowActive = isNonCombatPoseActive(F);
+    const weaponDrawn = isWeaponDrawn(F);
+    const combatEngaged = attackActive || F?.attack?.active || F?.charge?.active;
+    const stowActive = !combatEngaged && !weaponDrawn;
     const sneakActive = isSneakMode(F);
     let poseMode = 'combat';
     if (stowActive) {

--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -127,8 +127,27 @@ export function makeCombat(G, C, options = {}){
     fighter.nonCombat = resolved === 'nonCombat';
     fighter.sneak = resolved === 'sneak';
     fighter.renderProfile ||= {};
-    fighter.renderProfile.nonCombat = resolved === 'nonCombat';
+    fighter.renderProfile.walkMode = resolved;
     fighter.renderProfile.sneak = resolved === 'sneak';
+  };
+
+  const applyWeaponDrawnState = (fighter, weaponDrawn) => {
+    if (!fighter || typeof fighter !== 'object') return;
+    const resolved = weaponDrawn != null
+      ? !!weaponDrawn
+      : (typeof fighter.weaponDrawn === 'boolean' ? fighter.weaponDrawn : true);
+    fighter.weaponDrawn = resolved;
+    fighter.nonCombatRagdoll = !resolved;
+    fighter.renderProfile ||= {};
+    fighter.renderProfile.weaponDrawn = resolved;
+    fighter.renderProfile.weaponStowed = !resolved;
+    if (fighter.renderProfile.character && typeof fighter.renderProfile.character === 'object') {
+      fighter.renderProfile.character.weaponDrawn = resolved;
+      fighter.renderProfile.character.weaponStowed = !resolved;
+    }
+    if (fighter.anim?.weapon && typeof fighter.anim.weapon === 'object') {
+      fighter.anim.weapon.stowed = !resolved;
+    }
   };
 
   const now = ()=> performance.now();
@@ -2304,6 +2323,13 @@ export function makeCombat(G, C, options = {}){
 
     const walkMode = resolveWalkMode(p, input);
     applyWalkMode(p, walkMode);
+
+    const weaponDrawnInput = typeof input?.weaponDrawn === 'boolean' ? input.weaponDrawn : null;
+    if (isFighterBusy()) {
+      applyWeaponDrawnState(p, true);
+    } else if (weaponDrawnInput != null) {
+      applyWeaponDrawnState(p, weaponDrawnInput);
+    }
 
     const effectiveInput = p.isDead ? null : input;
     const attackBlocksMovement = !p.isDead && ATTACK.active && ATTACK.context?.type !== 'defensive';


### PR DESCRIPTION
## Summary
- sync weapon drawn state from input/combat while keeping walk mode focused on movement
- gate stow poses on the weapon drawn flag in the animator and avoid stowing during combat actions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923806fbe3483268f5447c2c30ddcf8)