### PR TITLE
Ensure base pose legs stay neutral for mode stances

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -591,9 +591,9 @@ window.CONFIG = {
     lElbow: 0,
     rShoulder: -90,
     rElbow: 0,
-    lHip: 90,
+    lHip: 0,
     lKnee: 0,
-    rHip: 90,
+    rHip: 0,
     rKnee: 0
   },
 

--- a/tests/mode-base-stance.test.js
+++ b/tests/mode-base-stance.test.js
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'fs/promises';
+import vm from 'node:vm';
+
+const LEG_KEYS = ['lHip', 'rHip', 'lKnee', 'rKnee'];
+
+const addAngles = (base = {}, delta = {}) => {
+  const combined = {};
+  for (const key of LEG_KEYS) {
+    combined[key] = (base?.[key] ?? 0) + (delta?.[key] ?? 0);
+  }
+  return combined;
+};
+
+describe('Mode base poses', () => {
+  it('basePose does not alter idle leg stances for each walk profile', async () => {
+    const script = await readFile('docs/config/config.js', 'utf8');
+    const sharedConfig = {};
+    const context = { window: { CONFIG: sharedConfig }, CONFIG: sharedConfig, console };
+    vm.createContext(context);
+    vm.runInContext(script, context);
+
+    const config = context.window.CONFIG || {};
+    const basePose = config.basePose || {};
+
+    const modes = [
+      { key: 'combat', pose: config.poses?.Stance },
+      { key: 'nonCombat', pose: config.poses?.NonCombatBase },
+      { key: 'sneak', pose: config.poses?.SneakBase },
+    ];
+
+    for (const { key, pose } of modes) {
+      assert.ok(pose, `${key} stance should exist`);
+      const combined = addAngles(basePose, pose);
+      for (const joint of LEG_KEYS) {
+        assert.strictEqual(
+          combined[joint],
+          pose[joint],
+          `basePose should not adjust ${joint} for ${key} stance`
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- set the global basePose leg angles to neutral so additive corrections no longer twist idle stances
- add a unit test confirming idle leg stances match the selected walk profile bases

## Testing
- npm test *(fails: ensureCosmeticLayers exposes layer extra bone influence metadata; clampFighterToBounds applies world width from camera; drawArmBranch checks RENDER.MIRROR flags; sprites.js drawArmBranch does not have facingFlip parameter; sprites.js drawLegBranch does not have facingFlip parameter)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69238fe52ec883268edafbcb585f9762)