### PR TITLE
Consolidate config pascal case helper

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -30,12 +30,17 @@ const abilityKnockback = (base, { clamp } = {}) => {
 
 const deepClone = (value) => JSON.parse(JSON.stringify(value || {}));
 
-const toPascalCase = (value) => {
+const toPascalCase = (value = '') => {
   if (!value) return '';
   return String(value)
-    .split(/[^a-zA-Z0-9]+/g)
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replace(/([0-9]+)/g, ' $1 ')
+    .trim()
+    .split(/\s+/)
     .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
     .join('');
 };
 
@@ -1936,19 +1941,6 @@ window.CONFIG = {
     }
   }
 }
-
-const toPascalCase = (value = '') => {
-  return value
-    .replace(/[_-]+/g, ' ')
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
-    .replace(/([0-9]+)/g, ' $1 ')
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
-    .join('');
-};
 
 const posePhaseInfo = (poseName) => {
   const normalized = toPascalCase(poseName);


### PR DESCRIPTION
## Summary
- consolidate the PascalCase helper in docs/config/config.js so it is defined once for all consumers
- apply the more robust normalization logic globally to prevent duplicate-const syntax errors

## Testing
- npm test *(fails: existing test suite has 5 expected failures unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239edc5ea48326a20dc58e7793a89d)