### PR TITLE
Refactor stance pose resolution

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -745,6 +745,7 @@ window.CONFIG = {
 
   poses: {
     Stance: deepClone(MODE_BASE_POSES.combat),
+    StanceStowed: deepClone(NON_COMBAT_POSE),
     ...buildWeaponStances(MODE_BASE_POSES.combat),
     NonCombatBase: deepClone(MODE_BASE_POSES.nonCombat),
     SneakBase: deepClone(MODE_BASE_POSES.sneak),


### PR DESCRIPTION
## Summary
- build stance poses at runtime by combining weapon-specific upper body and movement-driven lower body data
- route combat pose resolution to the dynamic stance builder instead of per-attack stance keys
- add a stowed stance fallback pose to the configuration so sheathed weapons reuse the shared stance

## Testing
- npm test *(fails on pre-existing assertions in cosmetics-system.test.js, mode-base-stance.test.js, physics-world-width.test.js, and sprite mirror tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c81329d0832688a20c4307b37c6d)