### PR TITLE
Fix ragdoll physics and character movement

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -803,10 +803,10 @@ window.CONFIG = {
 
     // Unified legs pose (used across all movement modes)
     Legs: {
-      lHip: -90,
-      lKnee: 0,
-      rHip: -90,
-      rKnee: 0
+      lHip: 100,
+      lKnee: 70,
+      rHip: 30,
+      rKnee: 70
     },
 
     Windup: deepClone(BASE_POSES.Windup),

--- a/docs/js/animator.js
+++ b/docs/js/animator.js
@@ -1812,11 +1812,15 @@ function computeMovementPose(F, fcfg, C, movementProfile, basePoseConfig, { pose
   const keyB = useMovement ? movementB : (useIdle ? idleB : {});
 
   // Interpolate leg/torso angles and scale by amp
-  pose.lHip   = lerp(keyA.lHip   || 0, keyB.lHip   || 0, s) * amp;
-  pose.lKnee  = lerp(keyA.lKnee  || 0, keyB.lKnee  || 0, s) * amp;
-  pose.rHip   = lerp(keyA.rHip   || 0, keyB.rHip   || 0, s) * amp;
-  pose.rKnee  = lerp(keyA.rKnee  || 0, keyB.rKnee  || 0, s) * amp;
-  pose.torso  = lerp(keyA.torso  || 0, keyB.torso  || 0, s) * amp;
+  // When not moving/idle, preserve the base pose legs instead of setting to 0
+  if (useMovement || useIdle) {
+    pose.lHip   = lerp(keyA.lHip   || 0, keyB.lHip   || 0, s) * amp;
+    pose.lKnee  = lerp(keyA.lKnee  || 0, keyB.lKnee  || 0, s) * amp;
+    pose.rHip   = lerp(keyA.rHip   || 0, keyB.rHip   || 0, s) * amp;
+    pose.rKnee  = lerp(keyA.rKnee  || 0, keyB.rKnee  || 0, s) * amp;
+    pose.torso  = lerp(keyA.torso  || 0, keyB.torso  || 0, s) * amp;
+  }
+  // else: keep the legs/torso from basePoseConfig (already in pose from line 1801)
 
   // Shoulders/elbows: still seeded from base offsets only
   const base = basePoseConfig || resolveStancePose(C, F);


### PR DESCRIPTION
Fixed critical issues introduced by movement system refactor:

1. Fix legs stuck in base pose when not moving
   - computeMovementPose() was setting legs to 0 when not moving/idle
   - Now preserves base stance legs when movement/idle is inactive
   - Prevents legs from being forced into T-pose

2. Fix Legs pose configuration
   - Changed from T-pose values {lHip:-90, lKnee:0, rHip:-90, rKnee:0}
   - To correct stance values {lHip:100, lKnee:70, rHip:30, rKnee:70}
   - Matches BASE_POSES.Stance legs for proper standing pose

These fixes restore:
- Normal standing animation
- Movement/walking animations
- Jump functionality (dependent on working leg animations)