### PR TITLE
Reset mirror flags after attacks and improve footstep cadence detection

### DIFF
--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -751,6 +751,7 @@ export function makeCombat(G, C, options = {}){
   function runAttackTimeline({ segments, context, onComplete, resetMirrorBeforeStance=false, sequenceSteps=[] }){
     const ordered = Array.isArray(segments) ? segments.slice() : [];
     if (!ordered.length){
+      resetMirror(poseTarget);
       if (typeof onComplete === 'function') onComplete();
       return;
     }
@@ -765,6 +766,7 @@ export function makeCombat(G, C, options = {}){
       active: true
     };
     let stanceReset = false;
+    let mirrorCleared = false;
 
     const triggerStepsThrough = (timeMs) => {
       if (!timelineState.steps.length) return;
@@ -786,6 +788,10 @@ export function makeCombat(G, C, options = {}){
 
     const runSegmentAt = (idx) => {
       if (idx >= ordered.length){
+        if (!mirrorCleared){
+          resetMirror(poseTarget);
+          mirrorCleared = true;
+        }
         timelineState.active = false;
         ATTACK.timelineState = null;
         if (typeof onComplete === 'function') onComplete();
@@ -795,6 +801,7 @@ export function makeCombat(G, C, options = {}){
       if (resetMirrorBeforeStance && !stanceReset && segment.phase === 'Stance'){
         resetMirror(poseTarget);
         stanceReset = true;
+        mirrorCleared = true;
       }
       triggerStepsThrough(segment.startTime);
       startTransition(segment.pose, segment.phase, segment.duration, ()=>{


### PR DESCRIPTION
## Summary
- ensure attack timelines clear mirror flags even when a stance pose does not request a reset
- track fighter displacement to advance stride progress when moving slowly or via animation
- retain previous position in footstep state so cadence detection remains consistent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9e2c482c8326ada485a5e91bb2e9)