### PR TITLE
Add ragdoll death delay and fade out

### DIFF
--- a/docs/js/npc.js
+++ b/docs/js/npc.js
@@ -223,7 +223,7 @@ function resolveNpcDeathDestroyDelay(state) {
   if (Number.isFinite(configDelay)) {
     return Math.max(0, configDelay);
   }
-  return 0;
+  return 3.5;
 }
 
 function destroyNpcInstance(state) {


### PR DESCRIPTION
## Summary
- trigger ragdoll knockback and death timing when fighters die
- increase NPC death cleanup delay defaults and preserve fade timing values
- render fighters with death fade-out opacity before removal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9ed3edcc8326b656d9699d001399)