### PR TITLE
Make HUD arch geometry scale with viewport

### DIFF
--- a/docs/hud-arch.css
+++ b/docs/hud-arch.css
@@ -30,6 +30,21 @@
   pointer-events: none;
 }
 
+@media (max-width: 640px), (max-height: 480px) {
+  .arch-hud__button {
+    border-radius: calc(var(--arch-button-size, 84px) * 0.32);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.55);
+    border-width: 1.5px;
+  }
+}
+
+@media (min-width: 1440px) and (min-height: 900px) {
+  .arch-hud__button {
+    border-radius: calc(var(--arch-button-size, 84px) * 0.28);
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.65);
+  }
+}
+
 /* Optional: you can add hover/pressed styles if needed */
 .arch-hud__button:active {
   transform: scale(0.96) translateZ(0);

--- a/docs/js/hud-arch-config.js
+++ b/docs/js/hud-arch-config.js
@@ -2,7 +2,14 @@
 window.HUD_ARCH_CONFIG = {
   arch: {
     // circle geometry
-    radiusPx: 150, // distance from arch center to button centers
+    // Option 1: set an absolute pixel override (number)
+    // Option 2: use adaptive sizing below (preferred default)
+    radiusPx: {
+      base: 150, // fallback for very small viewports
+      viewportPct: 0.18, // portion of the smaller viewport side
+      min: 120,
+      max: 240,
+    },
     start: {
       x: 0.98, // near the far bottom-right edge
       y: 0.94
@@ -13,7 +20,12 @@ window.HUD_ARCH_CONFIG = {
     },
 
     scale: 1.0, // global multiplier (can tie to character scale)
-    buttonSizePx: 84, // base button square size
+    buttonSizePx: {
+      base: 84,
+      viewportPct: 0.1, // portion of the smaller viewport side
+      min: 68,
+      max: 124,
+    }, // base button square size
     defaultGapPx: 10, // default carving distance per segment
     rotateWithArch: true, // rotate along tangent? (fan out)
     flipVertical: false, // mirror along the horizontal axis to hug the gameplay viewport

--- a/docs/js/hud-arch.js
+++ b/docs/js/hud-arch.js
@@ -34,6 +34,53 @@
     };
   }
 
+  function clampSize(val, min, max) {
+    let result = val;
+    if (min != null) result = Math.max(result, min);
+    if (max != null) result = Math.min(result, max);
+    return result;
+  }
+
+  function resolveAdaptiveSize(setting, vp, fallbackPct) {
+    const minDim = Math.min(vp.width || 0, vp.height || 0);
+    const hasViewport = Number.isFinite(minDim) && minDim > 0;
+
+    if (typeof setting === "function") {
+      return setting(vp);
+    }
+
+    if (typeof setting === "number") {
+      return setting;
+    }
+
+    if (setting && typeof setting === "object") {
+      const pct =
+        typeof setting.viewportPct === "number" ? setting.viewportPct : null;
+      const base = typeof setting.base === "number" ? setting.base : null;
+
+      let size = null;
+      if (pct != null && hasViewport) {
+        size = minDim * pct;
+      } else if (base != null) {
+        size = base;
+      }
+
+      if (size == null && base != null) size = base;
+      if (size == null && fallbackPct != null && hasViewport) {
+        size = minDim * fallbackPct;
+      }
+
+      size = size != null ? size : 0;
+      return clampSize(size, setting.min, setting.max);
+    }
+
+    if (fallbackPct != null && hasViewport) {
+      return minDim * fallbackPct;
+    }
+
+    return 0;
+  }
+
   function vpPoint(coord, vp, flipVertical) {
     const normY = flipVertical ? 1 - coord.y : coord.y;
     return {
@@ -79,15 +126,17 @@
     container.className = "arch-hud";
     container.style.position = rootEl === document.body ? "fixed" : "absolute";
     container.style.inset = "0";
-    container.style.setProperty(
-      "--arch-button-size",
-      `${archCfg.buttonSizePx * (archCfg.scale || 1)}px`
-    );
 
     rootEl.appendChild(container);
 
     const vp = getViewportRect(rootEl);
-    const radius = archCfg.radiusPx * (archCfg.scale || 1);
+    const scale = archCfg.scale || 1;
+    const baseButtonSize = resolveAdaptiveSize(archCfg.buttonSizePx, vp, 0.1);
+    const baseRadius = resolveAdaptiveSize(archCfg.radiusPx, vp, 0.18);
+    const buttonSize = baseButtonSize * scale;
+    const radius = baseRadius * scale;
+    container.style.setProperty("--arch-button-size", `${buttonSize}px`);
+    if (!Number.isFinite(radius) || radius <= 0) return container;
     const flipY = archCfg.flipVertical !== false;
     const startPt = vpPoint(archCfg.start, vp, flipY);
     const endPt = vpPoint(archCfg.end, vp, flipY);
@@ -108,6 +157,16 @@
     let cursorLen = 0;
     const debug = archCfg.debug;
     const debugInfo = [];
+
+    if (debug) {
+      debugInfo.push({
+        id: "__meta",
+        viewport: { width: vp.width, height: vp.height },
+        radius,
+        buttonSize,
+        scale,
+      });
+    }
 
     btnCfgs.forEach((btnCfg) => {
       const segLength = btnCfg.lengthPct * totalLength;
@@ -131,7 +190,7 @@
       const x = center.x + radius * Math.cos(angleAlong);
       const y = center.y + radius * Math.sin(angleAlong);
 
-      const size = archCfg.buttonSizePx * (archCfg.scale || 1);
+      const size = buttonSize;
       const halfSize = size / 2;
 
       const btnEl = document.createElement("button");


### PR DESCRIPTION
## Summary
- allow HUD arch radius and button size to be defined with adaptive viewport-based sizing and clamped fallbacks
- apply computed sizes when building the HUD arch and surface debug metadata for the chosen sizing
- add media query tweaks to keep perceived button styling consistent across device sizes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da87003c4832687f90183fdc4f291)