### PR TITLE
Refactor weapon combos into per-ability manifests

### DIFF
--- a/docs/animation-editor.html
+++ b/docs/animation-editor.html
@@ -201,6 +201,18 @@
     </section>
   </main>
 
+  <script src="./config/abilities/shared.js"></script>
+  <script src="./config/abilities/combo_light.js"></script>
+  <script src="./config/abilities/dagger_swords_combo_light.js"></script>
+  <script src="./config/abilities/greatclub_combo_light.js"></script>
+  <script src="./config/abilities/hatchets_combo_light.js"></script>
+  <script src="./config/abilities/light_greatblade_combo_light.js"></script>
+  <script src="./config/abilities/sarrarru_combo_light.js"></script>
+  <script src="./config/abilities/unarmed_combo_light.js"></script>
+  <script src="./config/abilities/quick_light.js"></script>
+  <script src="./config/abilities/quick_punch.js"></script>
+  <script src="./config/abilities/heavy_hold.js"></script>
+  <script src="./config/abilities/evade_defensive.js"></script>
   <script src="./config/config.js"></script>
   <script type="module" src="./js/animation-editor-app.js?v=1"></script>
 </body>

--- a/docs/config/abilities/combo_light.js
+++ b/docs/config/abilities/combo_light.js
@@ -1,0 +1,13 @@
+(function registerComboLight() {
+  if (typeof window.registerAbility !== 'function') return;
+  window.registerAbility('combo_light', {
+    name: 'Weapon Combo',
+    type: 'light',
+    trigger: 'combo',
+    tags: ['combo', 'light'],
+    comboFromWeapon: true,
+    fallbackWeapon: 'unarmed',
+    multipliers: { durations: 1 },
+    onHit: window.abilityKnockback?.(8),
+  });
+})();

--- a/docs/config/abilities/dagger_swords_combo_light.js
+++ b/docs/config/abilities/dagger_swords_combo_light.js
@@ -1,0 +1,99 @@
+(function registerDaggerSwordsCombo() {
+  if (typeof window.registerAbility !== 'function') return;
+
+  const ability = {
+    name: 'Dual Blade Flow',
+    type: 'light',
+    trigger: 'combo',
+    tags: ['combo', 'light', 'dagger-swords'],
+    sequence: ['DaSwCA1', 'DaSwCA2', 'DaSwCA3', 'DaSwCA4'],
+    defaultAttack: 'DaSwCA1',
+    comboWindowMs: 2500
+  };
+
+  const buildContent = () => {
+    const clone = (value) => JSON.parse(JSON.stringify(value || {}));
+    const RIGHT_ARM_MASK = ['rShoulder', 'rElbow', 'rWrist', 'rHand'];
+    const LEFT_ARM_MASK = ['lShoulder', 'lElbow', 'lWrist', 'lHand'];
+
+    const punchDurations = { toWindup: 380, toStrike: 110, toRecoil: 200, toStance: 120 };
+    const slamDurations = { toWindup: 400, toStrike: 160, toRecoil: 200, toStance: 120 };
+
+    const moves = {
+      DaSwCA1: {
+        name: 'Dual Blade Flow A1',
+        tags: ['combo', 'light', 'dagger-swords'],
+        durations: clone(punchDurations),
+        poses: clone(window.PUNCH_MOVE_POSES || {})
+      },
+      DaSwCA2: {
+        name: 'Dual Blade Flow A2',
+        tags: ['combo', 'light', 'dagger-swords'],
+        durations: clone(slamDurations),
+        poses: clone(window.SLAM_MOVE_POSES || {})
+      },
+      DaSwCA3: {
+        name: 'Dual Blade Flow A3',
+        tags: ['combo', 'light', 'dagger-swords'],
+        durations: clone(punchDurations),
+        poses: clone(window.PUNCH_MOVE_POSES || {})
+      },
+      DaSwCA4: {
+        name: 'Dual Blade Flow A4',
+        tags: ['combo', 'light', 'dagger-swords'],
+        durations: clone(slamDurations),
+        poses: clone(window.SLAM_MOVE_POSES || {})
+      }
+    };
+
+    const punchAttack = (id, mask, colliders) => ({
+      preset: id,
+      tags: ['combo', 'light', 'dagger-swords'],
+      sequence: [{ move: id, mask }],
+      attackData: {
+        damage: { health: 9 },
+        staminaCost: 10,
+        colliders,
+        range: 65,
+        dash: { velocity: 240, duration: 0.18 },
+        useWeaponColliders: true
+      }
+    });
+
+    const slamAttack = (id, mask, colliders) => ({
+      preset: id,
+      tags: ['combo', 'light', 'dagger-swords'],
+      sequence: [{ move: id, mask }],
+      multipliers: { durations: 1.1, knockback: 1.2 },
+      attackData: {
+        damage: { health: 22 },
+        staminaCost: 28,
+        colliders,
+        range: 75,
+        dash: { velocity: 400, duration: 1.2 },
+        useWeaponColliders: true
+      }
+    });
+
+    const attacks = {
+      DaSwCA1: punchAttack('DaSwCA1', RIGHT_ARM_MASK, ['handR']),
+      DaSwCA2: slamAttack('DaSwCA2', LEFT_ARM_MASK, ['handL']),
+      DaSwCA3: punchAttack('DaSwCA3', RIGHT_ARM_MASK, ['handR']),
+      DaSwCA4: slamAttack('DaSwCA4', LEFT_ARM_MASK, ['handL'])
+    };
+
+    const weaponCombos = {
+      'dagger-swords': {
+        weapon: 'dagger-swords',
+        name: 'Dual Blade Flow',
+        sequence: ['DaSwCA1', 'DaSwCA2', 'DaSwCA3', 'DaSwCA4'],
+        comboWindowMs: 2500,
+        type: 'sharp'
+      }
+    };
+
+    return { moves, attacks, weaponCombos };
+  };
+
+  window.registerAbility('dagger_swords_combo_light', ability, buildContent);
+})();

--- a/docs/config/abilities/evade_defensive.js
+++ b/docs/config/abilities/evade_defensive.js
@@ -1,0 +1,15 @@
+(function registerEvadeDefensive() {
+  if (typeof window.registerAbility !== 'function') return;
+  window.registerAbility('evade_defensive', {
+    name: 'Evade',
+    type: 'defensive',
+    trigger: 'defensive',
+    tags: ['defensive', 'mobility'],
+    defensive: {
+      poseKey: 'Stance',
+      poseRefreshMs: 220,
+      staminaDrainPerSecond: 40,
+      minStaminaRatio: 0.6,
+    },
+  });
+})();

--- a/docs/config/abilities/greatclub_combo_light.js
+++ b/docs/config/abilities/greatclub_combo_light.js
@@ -1,0 +1,61 @@
+(function registerGreatclubCombo() {
+  if (typeof window.registerAbility !== 'function') return;
+
+  const ability = {
+    name: 'Greatclub Crush',
+    type: 'light',
+    trigger: 'combo',
+    tags: ['combo', 'light', 'greatclub'],
+    sequence: ['GrClCA1', 'GrClCA2', 'GrClCA3', 'GrClCA4'],
+    defaultAttack: 'GrClCA1',
+    comboWindowMs: 3000
+  };
+
+  const buildContent = () => {
+    const clone = (value) => JSON.parse(JSON.stringify(value || {}));
+    const slamDurations = { toWindup: 400, toStrike: 160, toRecoil: 200, toStance: 120 };
+
+    const moves = {
+      GrClCA1: { name: 'Greatclub Crush A1', tags: ['combo', 'light', 'greatclub'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) },
+      GrClCA2: { name: 'Greatclub Crush A2', tags: ['combo', 'light', 'greatclub'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) },
+      GrClCA3: { name: 'Greatclub Crush A3', tags: ['combo', 'light', 'greatclub'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) },
+      GrClCA4: { name: 'Greatclub Crush A4', tags: ['combo', 'light', 'greatclub'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) }
+    };
+
+    const slamAttack = (id) => ({
+      preset: id,
+      tags: ['combo', 'light', 'greatclub'],
+      sequence: [{ move: id }],
+      multipliers: { durations: 1.1, knockback: 1.2 },
+      attackData: {
+        damage: { health: 22 },
+        staminaCost: 28,
+        colliders: ['handL', 'handR'],
+        range: 75,
+        dash: { velocity: 400, duration: 1.2 },
+        useWeaponColliders: true
+      }
+    });
+
+    const attacks = {
+      GrClCA1: slamAttack('GrClCA1'),
+      GrClCA2: slamAttack('GrClCA2'),
+      GrClCA3: slamAttack('GrClCA3'),
+      GrClCA4: slamAttack('GrClCA4')
+    };
+
+    const weaponCombos = {
+      greatclub: {
+        weapon: 'greatclub',
+        name: 'Greatclub Crush',
+        sequence: ['GrClCA1', 'GrClCA2', 'GrClCA3', 'GrClCA4'],
+        comboWindowMs: 3000,
+        type: 'blunt'
+      }
+    };
+
+    return { moves, attacks, weaponCombos };
+  };
+
+  window.registerAbility('greatclub_combo_light', ability, buildContent);
+})();

--- a/docs/config/abilities/hatchets_combo_light.js
+++ b/docs/config/abilities/hatchets_combo_light.js
@@ -1,0 +1,63 @@
+(function registerHatchetsCombo() {
+  if (typeof window.registerAbility !== 'function') return;
+
+  const ability = {
+    name: 'Hatchet Fury',
+    type: 'light',
+    trigger: 'combo',
+    tags: ['combo', 'light', 'hatchets'],
+    sequence: ['HaChCA1', 'HaChCA2', 'HaChCA3', 'HaChCA4'],
+    defaultAttack: 'HaChCA1',
+    comboWindowMs: 2800
+  };
+
+  const buildContent = () => {
+    const clone = (value) => JSON.parse(JSON.stringify(value || {}));
+    const slamDurations = { toWindup: 400, toStrike: 160, toRecoil: 200, toStance: 120 };
+    const RIGHT_ARM_MASK = ['rShoulder', 'rElbow', 'rWrist', 'rHand'];
+    const LEFT_ARM_MASK = ['lShoulder', 'lElbow', 'lWrist', 'lHand'];
+
+    const moves = {
+      HaChCA1: { name: 'Hatchet Fury A1', tags: ['combo', 'light', 'hatchets'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) },
+      HaChCA2: { name: 'Hatchet Fury A2', tags: ['combo', 'light', 'hatchets'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) },
+      HaChCA3: { name: 'Hatchet Fury A3', tags: ['combo', 'light', 'hatchets'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) },
+      HaChCA4: { name: 'Hatchet Fury A4', tags: ['combo', 'light', 'hatchets'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) }
+    };
+
+    const slamAttack = (id, mask, colliders) => ({
+      preset: id,
+      tags: ['combo', 'light', 'hatchets'],
+      sequence: [{ move: id, mask }],
+      multipliers: { durations: 1.1, knockback: 1.2 },
+      attackData: {
+        damage: { health: 22 },
+        staminaCost: 28,
+        colliders,
+        range: 75,
+        dash: { velocity: 400, duration: 1.2 },
+        useWeaponColliders: true
+      }
+    });
+
+    const attacks = {
+      HaChCA1: slamAttack('HaChCA1', RIGHT_ARM_MASK, ['handR']),
+      HaChCA2: slamAttack('HaChCA2', LEFT_ARM_MASK, ['handL']),
+      HaChCA3: slamAttack('HaChCA3', RIGHT_ARM_MASK, ['handR']),
+      HaChCA4: slamAttack('HaChCA4', LEFT_ARM_MASK, ['handL'])
+    };
+
+    const weaponCombos = {
+      hatchets: {
+        weapon: 'hatchets',
+        name: 'Hatchet Fury',
+        sequence: ['HaChCA1', 'HaChCA2', 'HaChCA3', 'HaChCA4'],
+        comboWindowMs: 2800,
+        type: 'sharp'
+      }
+    };
+
+    return { moves, attacks, weaponCombos };
+  };
+
+  window.registerAbility('hatchets_combo_light', ability, buildContent);
+})();

--- a/docs/config/abilities/heavy_hold.js
+++ b/docs/config/abilities/heavy_hold.js
@@ -1,0 +1,20 @@
+(function registerHeavyHold() {
+  if (typeof window.registerAbility !== 'function') return;
+  window.registerAbility('heavy_hold', {
+    name: 'Charged Slam',
+    type: 'heavy',
+    trigger: 'hold-release',
+    tags: ['heavy', 'hold'],
+    attack: 'Slam',
+    charge: {
+      minStage: 1,
+      maxStage: 5,
+      stageDurationMs: 200,
+      stageMultipliers: (stage) => ({
+        durations: 1 + stage * 0.05,
+        knockback: 1 + stage * 0.25,
+      }),
+    },
+    onHit: window.abilityKnockback?.(14),
+  });
+})();

--- a/docs/config/abilities/light_greatblade_combo_light.js
+++ b/docs/config/abilities/light_greatblade_combo_light.js
@@ -1,0 +1,61 @@
+(function registerLightGreatbladeCombo() {
+  if (typeof window.registerAbility !== 'function') return;
+
+  const ability = {
+    name: 'Greatblade Cascade',
+    type: 'light',
+    trigger: 'combo',
+    tags: ['combo', 'light', 'light-greatblade'],
+    sequence: ['LiGrCA1', 'LiGrCA2', 'LiGrCA3', 'LiGrCA4'],
+    defaultAttack: 'LiGrCA1',
+    comboWindowMs: 4000
+  };
+
+  const buildContent = () => {
+    const clone = (value) => JSON.parse(JSON.stringify(value || {}));
+    const slamDurations = { toWindup: 400, toStrike: 160, toRecoil: 200, toStance: 120 };
+
+    const moves = {
+      LiGrCA1: { name: 'Greatblade Cascade A1', tags: ['combo', 'light', 'light-greatblade'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) },
+      LiGrCA2: { name: 'Greatblade Cascade A2', tags: ['combo', 'light', 'light-greatblade'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) },
+      LiGrCA3: { name: 'Greatblade Cascade A3', tags: ['combo', 'light', 'light-greatblade'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) },
+      LiGrCA4: { name: 'Greatblade Cascade A4', tags: ['combo', 'light', 'light-greatblade'], durations: clone(slamDurations), poses: clone(window.SLAM_MOVE_POSES || {}) }
+    };
+
+    const slamAttack = (id) => ({
+      preset: id,
+      tags: ['combo', 'light', 'light-greatblade'],
+      sequence: [{ move: id }],
+      multipliers: { durations: 1.1, knockback: 1.2 },
+      attackData: {
+        damage: { health: 22 },
+        staminaCost: 28,
+        colliders: ['handL', 'handR'],
+        range: 75,
+        dash: { velocity: 400, duration: 1.2 },
+        useWeaponColliders: true
+      }
+    });
+
+    const attacks = {
+      LiGrCA1: slamAttack('LiGrCA1'),
+      LiGrCA2: slamAttack('LiGrCA2'),
+      LiGrCA3: slamAttack('LiGrCA3'),
+      LiGrCA4: slamAttack('LiGrCA4')
+    };
+
+    const weaponCombos = {
+      'light-greatblade': {
+        weapon: 'light-greatblade',
+        name: 'Greatblade Cascade',
+        sequence: ['LiGrCA1', 'LiGrCA2', 'LiGrCA3', 'LiGrCA4'],
+        comboWindowMs: 4000,
+        type: 'sharp'
+      }
+    };
+
+    return { moves, attacks, weaponCombos };
+  };
+
+  window.registerAbility('light_greatblade_combo_light', ability, buildContent);
+})();

--- a/docs/config/abilities/quick_light.js
+++ b/docs/config/abilities/quick_light.js
@@ -1,0 +1,15 @@
+(function registerQuickLight() {
+  if (typeof window.registerAbility !== 'function') return;
+  window.registerAbility('quick_light', {
+    name: 'Quick Kick',
+    type: 'light',
+    trigger: 'single',
+    tags: ['quick', 'light'],
+    variants: [
+      { id: 'postCombo', attack: 'QuickKickCombo', require: { comboHitsGte: 4, comboActive: true } },
+      { id: 'default', attack: 'QuickKick' }
+    ],
+    multipliers: { durations: 1 },
+    onHit: window.abilityKnockback?.(10),
+  });
+})();

--- a/docs/config/abilities/quick_punch.js
+++ b/docs/config/abilities/quick_punch.js
@@ -1,0 +1,15 @@
+(function registerQuickPunch() {
+  if (typeof window.registerAbility !== 'function') return;
+  window.registerAbility('quick_punch', {
+    name: 'Quick Punch',
+    type: 'light',
+    trigger: 'single',
+    tags: ['quick', 'light'],
+    variants: [
+      { id: 'postCombo', attack: 'QuickPunchCombo', require: { comboHitsGte: 4, comboActive: true } },
+      { id: 'default', attack: 'QuickPunch' }
+    ],
+    multipliers: { durations: 1 },
+    onHit: window.abilityKnockback?.(10),
+  });
+})();

--- a/docs/config/abilities/sarrarru_combo_light.js
+++ b/docs/config/abilities/sarrarru_combo_light.js
@@ -1,0 +1,90 @@
+(function registerSarrarruCombo() {
+  if (typeof window.registerAbility !== 'function') return;
+
+  const ability = {
+    name: 'Spear Rhythm',
+    type: 'light',
+    trigger: 'combo',
+    tags: ['combo', 'light', 'sarrarru'],
+    sequence: ['SaRaCA1', 'SaRaCA2', 'SaRaCA3', 'SaRaCA4'],
+    defaultAttack: 'SaRaCA1',
+    comboWindowMs: 3500
+  };
+
+  const buildContent = () => {
+    const clone = (value) => JSON.parse(JSON.stringify(value || {}));
+    const punchDurations = { toWindup: 380, toStrike: 110, toRecoil: 200, toStance: 120 };
+
+    const moves = {
+      SaRaCA1: { name: 'Spear Rhythm A1', tags: ['combo', 'light', 'sarrarru'], durations: clone(punchDurations), poses: clone(window.PUNCH_MOVE_POSES || {}) },
+      SaRaCA2: { name: 'Spear Rhythm A2', tags: ['combo', 'light', 'sarrarru'], durations: clone(punchDurations), poses: clone(window.PUNCH_MOVE_POSES || {}) },
+      SaRaCA3: { name: 'Spear Rhythm A3', tags: ['combo', 'light', 'sarrarru'], durations: clone(punchDurations), poses: clone(window.PUNCH_MOVE_POSES || {}) },
+      SaRaCA4: { name: 'Spear Rhythm A4', tags: ['combo', 'light', 'sarrarru'], durations: clone(punchDurations), poses: clone(window.PUNCH_MOVE_POSES || {}) }
+    };
+
+    const attacks = {
+      SaRaCA1: {
+        preset: 'SaRaCA1',
+        tags: ['combo', 'light', 'sarrarru'],
+        sequence: [{ move: 'SaRaCA1' }],
+        attackData: {
+          damage: { health: 18 },
+          staminaCost: 16,
+          useWeaponColliders: true,
+          range: 95,
+          dash: { impulse: 520, duration: 0.18 }
+        }
+      },
+      SaRaCA2: {
+        preset: 'SaRaCA2',
+        tags: ['combo', 'light', 'sarrarru'],
+        sequence: [{ move: 'SaRaCA2' }],
+        attackData: {
+          damage: { health: 20 },
+          staminaCost: 18,
+          useWeaponColliders: true,
+          range: 100,
+          dash: { impulse: 540, duration: 0.2 }
+        }
+      },
+      SaRaCA3: {
+        preset: 'SaRaCA3',
+        tags: ['combo', 'light', 'sarrarru'],
+        sequence: [{ move: 'SaRaCA3' }],
+        attackData: {
+          damage: { health: 22 },
+          staminaCost: 20,
+          useWeaponColliders: true,
+          range: 105,
+          dash: { impulse: 560, duration: 0.18 }
+        }
+      },
+      SaRaCA4: {
+        preset: 'SaRaCA4',
+        tags: ['combo', 'light', 'sarrarru'],
+        sequence: [{ move: 'SaRaCA4' }],
+        attackData: {
+          damage: { health: 24 },
+          staminaCost: 22,
+          useWeaponColliders: true,
+          range: 110,
+          dash: { impulse: 580, duration: 0.2 }
+        }
+      }
+    };
+
+    const weaponCombos = {
+      sarrarru: {
+        weapon: 'sarrarru',
+        name: 'Spear Rhythm',
+        sequence: ['SaRaCA1', 'SaRaCA2', 'SaRaCA3', 'SaRaCA4'],
+        comboWindowMs: 3500,
+        type: 'sharp'
+      }
+    };
+
+    return { moves, attacks, weaponCombos };
+  };
+
+  window.registerAbility('sarrarru_combo_light', ability, buildContent);
+})();

--- a/docs/config/abilities/shared.js
+++ b/docs/config/abilities/shared.js
@@ -1,0 +1,28 @@
+(function initAbilityShared() {
+  const abilityKnockback = window.abilityKnockback || function abilityKnockback(base, { clamp } = {}) {
+    return (context, opponent) => {
+      if (!opponent?.pos) return;
+      const facing = context?.character?.facingRad ?? context?.character?.facing ?? 0;
+      const dir = Math.cos(facing) >= 0 ? 1 : -1;
+      const multiplier = context?.multipliers?.knockback ?? 1;
+      let delta = base * multiplier * dir;
+      if (Number.isFinite(clamp)) {
+        delta = Math.max(-clamp, Math.min(clamp, delta));
+      }
+      opponent.pos.x += delta;
+    };
+  };
+
+  window.abilityKnockback = abilityKnockback;
+  window.ABILITY_LIBRARY = window.ABILITY_LIBRARY || {};
+  window.ABILITY_MANIFESTS = window.ABILITY_MANIFESTS || [];
+
+  window.registerAbility = function registerAbility(id, def, extras = {}) {
+    if (id && def) {
+      window.ABILITY_LIBRARY[id] = def;
+    }
+
+    const payload = typeof extras === 'function' ? extras : () => extras;
+    window.ABILITY_MANIFESTS.push(payload);
+  };
+})();

--- a/docs/config/abilities/unarmed_combo_light.js
+++ b/docs/config/abilities/unarmed_combo_light.js
@@ -1,0 +1,181 @@
+(function registerUnarmedComboLight() {
+  if (typeof window.registerAbility !== 'function') return;
+
+  const ability = {
+    name: 'Unarmed Combo',
+    type: 'light',
+    trigger: 'combo',
+    tags: ['combo', 'light', 'unarmed'],
+    sequence: ['UnArCA1', 'UnArCA2', 'UnArCA3', 'UnArCA4'],
+    defaultAttack: 'UnArCA1',
+    comboWindowMs: 3000,
+    onHit: window.abilityKnockback?.(8)
+  };
+
+  const buildContent = () => {
+    const clone = (value) => JSON.parse(JSON.stringify(value || {}));
+
+    const moves = {
+      ComboKICK_S: {
+        name: 'Combo Kick - Side',
+        tags: ['light', 'combo'],
+        inherits: 'KICK',
+        durations: { toWindup: 380, toStrike: 110, toRecoil: 680, toStance: 0 },
+        knockbackBase: 360,
+        cancelWindow: 0.6,
+        poses: clone(window.KICK_MOVE_POSES || {})
+      },
+      ComboKICK_F: {
+        name: 'Combo Kick - Front',
+        tags: ['light', 'combo'],
+        inherits: 'KICK',
+        durations: { toWindup: 380, toStrike: 110, toRecoil: 680, toStance: 0 },
+        knockbackBase: 420,
+        cancelWindow: 0.6,
+        poses: clone(window.KICK_MOVE_POSES || {})
+      },
+      ComboPUNCH_R: {
+        name: 'Combo Punch - Right',
+        tags: ['light', 'combo'],
+        durations: { toWindup: 380, toStrike: 110, toRecoil: 200, toStance: 120 },
+        knockbackBase: 140,
+        cancelWindow: 0.7,
+        poses: (() => {
+          const base = clone(window.PUNCH_MOVE_POSES || {});
+          const strikeBase = clone(window.PUNCH_MOVE_POSES?.Strike || {});
+          const stanceArms = clone(window.PUNCH_MOVE_POSES?.Stance || {});
+          strikeBase.lShoulder = stanceArms.lShoulder;
+          strikeBase.lElbow = stanceArms.lElbow;
+          strikeBase.rShoulder = stanceArms.rShoulder;
+          strikeBase.rElbow = stanceArms.rElbow;
+          strikeBase.layerOverrides = [
+            {
+              id: 'combo-right',
+              pose: {
+                rShoulder: window.PUNCH_MOVE_POSES?.Strike?.rShoulder,
+                rElbow: window.PUNCH_MOVE_POSES?.Strike?.rElbow
+              },
+              mask: [],
+              durMs: 110,
+              delayMs: 0,
+              priority: 140
+            }
+          ];
+          base.Strike = strikeBase;
+          return base;
+        })()
+      },
+      ComboPUNCH_L: {
+        name: 'Combo Punch - Left',
+        tags: ['light', 'combo'],
+        durations: { toWindup: 380, toStrike: 110, toRecoil: 200, toStance: 120 },
+        knockbackBase: 140,
+        cancelWindow: 0.7,
+        poses: (() => {
+          const base = clone(window.PUNCH_MOVE_POSES || {});
+          const strikeBase = clone(window.PUNCH_MOVE_POSES?.Strike || {});
+          const stanceArms = clone(window.PUNCH_MOVE_POSES?.Stance || {});
+          strikeBase.lShoulder = stanceArms.lShoulder;
+          strikeBase.lElbow = stanceArms.lElbow;
+          strikeBase.rShoulder = stanceArms.rShoulder;
+          strikeBase.rElbow = stanceArms.rElbow;
+          strikeBase.layerOverrides = [
+            {
+              id: 'combo-left',
+              pose: {
+                lShoulder: window.PUNCH_MOVE_POSES?.Strike?.lShoulder,
+                lElbow: window.PUNCH_MOVE_POSES?.Strike?.lElbow
+              },
+              mask: [],
+              durMs: 220,
+              delayMs: 0,
+              priority: 150
+            }
+          ];
+          base.Strike = strikeBase;
+          return base;
+        })()
+      }
+    };
+
+    const attacks = {
+      UnArCA1: {
+        preset: 'ComboPUNCH_R',
+        name: 'Unarmed Combo A1',
+        tags: ['combo', 'light', 'unarmed'],
+        sequence: [
+          { move: 'ComboPUNCH_R', startMs: 0 }
+        ],
+        attackData: {
+          damage: { health: 6 },
+          staminaCost: 12,
+          colliders: ['handR'],
+          range: 60,
+          dash: { impulse: 520, duration: 0.18 }
+        }
+      },
+      UnArCA2: {
+        preset: 'ComboKICK_S',
+        name: 'Unarmed Combo A2',
+        tags: ['combo', 'light', 'unarmed'],
+        sequence: [
+          { move: 'ComboKICK_S', startMs: 0 }
+        ],
+        attackData: {
+          damage: { health: 7 },
+          staminaCost: 14,
+          colliders: ['footR'],
+          range: 75,
+          dash: { impulse: 540, duration: 0.2 }
+        }
+      },
+      UnArCA3: {
+        preset: 'ComboPUNCH_L',
+        name: 'Unarmed Combo A3',
+        tags: ['combo', 'light', 'unarmed'],
+        sequence: [
+          { move: 'ComboPUNCH_L', startMs: 0 },
+          { move: 'ComboPUNCH_R', startMs: 160 }
+        ],
+        attackData: {
+          damage: { health: 9 },
+          staminaCost: 16,
+          colliders: ['handL', 'handR'],
+          range: 60,
+          dash: { impulse: 560, duration: 0.18 }
+        }
+      },
+      UnArCA4: {
+        preset: 'ComboKICK_F',
+        name: 'Unarmed Combo A4',
+        tags: ['combo', 'light', 'unarmed'],
+        sequence: [
+          { move: 'ComboKICK_F', startMs: 0 }
+        ],
+        attackData: {
+          damage: { health: 10 },
+          staminaCost: 18,
+          colliders: ['footL'],
+          range: 75,
+          dash: { impulse: 580, duration: 0.2 }
+        }
+      }
+    };
+
+    const weaponCombos = {
+      unarmed: {
+        weapon: 'unarmed',
+        name: 'Unarmed Combo',
+        sequence: ['UnArCA1', 'UnArCA2', 'UnArCA3', 'UnArCA4'],
+        comboWindowMs: 3000,
+        multipliers: { durations: 1 },
+        onHit: window.abilityKnockback?.(8),
+        type: 'blunt'
+      }
+    };
+
+    return { moves, attacks, weaponCombos };
+  };
+
+  window.registerAbility('unarmed_combo_light', ability, buildContent);
+})();

--- a/docs/cosmetic-editor.html
+++ b/docs/cosmetic-editor.html
@@ -123,6 +123,18 @@
     </section>
   </main>
 
+  <script src="./config/abilities/shared.js"></script>
+  <script src="./config/abilities/combo_light.js"></script>
+  <script src="./config/abilities/dagger_swords_combo_light.js"></script>
+  <script src="./config/abilities/greatclub_combo_light.js"></script>
+  <script src="./config/abilities/hatchets_combo_light.js"></script>
+  <script src="./config/abilities/light_greatblade_combo_light.js"></script>
+  <script src="./config/abilities/sarrarru_combo_light.js"></script>
+  <script src="./config/abilities/unarmed_combo_light.js"></script>
+  <script src="./config/abilities/quick_light.js"></script>
+  <script src="./config/abilities/quick_punch.js"></script>
+  <script src="./config/abilities/heavy_hold.js"></script>
+  <script src="./config/abilities/evade_defensive.js"></script>
   <script src="./config/config.js"></script>
   <script type="module" src="./js/cosmetic-library.js?v=1"></script>
   <script type="module" src="./js/cosmetic-profiles.js?v=1"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -575,6 +575,18 @@
   </script>
 
   <!-- In-repo config served same-origin under /docs -->
+  <script src="./config/abilities/shared.js"></script>
+  <script src="./config/abilities/combo_light.js"></script>
+  <script src="./config/abilities/dagger_swords_combo_light.js"></script>
+  <script src="./config/abilities/greatclub_combo_light.js"></script>
+  <script src="./config/abilities/hatchets_combo_light.js"></script>
+  <script src="./config/abilities/light_greatblade_combo_light.js"></script>
+  <script src="./config/abilities/sarrarru_combo_light.js"></script>
+  <script src="./config/abilities/unarmed_combo_light.js"></script>
+  <script src="./config/abilities/quick_light.js"></script>
+  <script src="./config/abilities/quick_punch.js"></script>
+  <script src="./config/abilities/heavy_hold.js"></script>
+  <script src="./config/abilities/evade_defensive.js"></script>
   <script src="./config/config.js"></script>
   <script type="module" src="./js/loadout-stage.js?v=1"></script>
   <script type="module" src="./js/map-bootstrap.js?v=1"></script>

--- a/docs/map-editor.html
+++ b/docs/map-editor.html
@@ -452,6 +452,18 @@
       header { align-items:center; }
     }
   </style>
+  <script src="./config/abilities/shared.js"></script>
+  <script src="./config/abilities/combo_light.js"></script>
+  <script src="./config/abilities/dagger_swords_combo_light.js"></script>
+  <script src="./config/abilities/greatclub_combo_light.js"></script>
+  <script src="./config/abilities/hatchets_combo_light.js"></script>
+  <script src="./config/abilities/light_greatblade_combo_light.js"></script>
+  <script src="./config/abilities/sarrarru_combo_light.js"></script>
+  <script src="./config/abilities/unarmed_combo_light.js"></script>
+  <script src="./config/abilities/quick_light.js"></script>
+  <script src="./config/abilities/quick_punch.js"></script>
+  <script src="./config/abilities/heavy_hold.js"></script>
+  <script src="./config/abilities/evade_defensive.js"></script>
   <script src="./config/config.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- merge ability manifests into the core config so abilities can supply their own moves, attacks, and weapon combo data
- move unarmed and weapon-specific combo definitions into dedicated ability files with unique attack IDs
- load the new combo scripts across the docs pages so the editor and runtime can access their assets

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da6dfd110832692d392990e14fff7)