### PR TITLE
Allow retreating NPCs to slip past allies

### DIFF
--- a/docs/js/physics.js
+++ b/docs/js/physics.js
@@ -249,6 +249,19 @@ function resolveCollisionShare(fighter) {
   return fighter.isPlayer ? 0.55 : 0.5;
 }
 
+function isRetreatingNpc(fighter) {
+  if (!fighter || fighter.isPlayer) return false;
+  if (fighter.mode !== 'retreat') return false;
+  const aggression = fighter.aggression || {};
+  return !!aggression.active;
+}
+
+function shouldIgnoreAllyCollision(fighterA, fighterB) {
+  if (!fighterA || !fighterB) return false;
+  if (fighterA.isPlayer || fighterB.isPlayer) return false;
+  return isRetreatingNpc(fighterA) || isRetreatingNpc(fighterB);
+}
+
 const DEFAULT_HORIZONTAL_MARGIN = 40;
 const DEFAULT_CANVAS_WIDTH = 720;
 const DEFAULT_PLAYABLE_SPAN = DEFAULT_CANVAS_WIDTH - DEFAULT_HORIZONTAL_MARGIN * 2;
@@ -698,6 +711,7 @@ export function resolveFighterBodyCollisions(fighters, config, { iterations = 2 
         const b = entries[j];
         const fighterB = b.fighter;
         if (!fighterB || fighterB.ragdoll) continue;
+        if (shouldIgnoreAllyCollision(fighterA, fighterB)) continue;
         const ax = fighterA.pos.x;
         const ay = fighterA.pos.y;
         const bx = fighterB.pos.x;


### PR DESCRIPTION
## Summary
- add helper to skip body collision resolution when a retreating NPC in combat meets an ally
- ensure retreating movement no longer triggers ally pushes that caused obstruction jumping

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e12947924832697f0f4d4e9b7bb83)