### PR TITLE
Fix clamp fallback and scene3d path handling

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -5416,7 +5416,7 @@ function renderBottles(ctx) {
     const pos = inst.position;
     const scaleX = inst.scale?.x || 1;
     const scaleY = inst.scale?.y || scaleX;
-    const rotRad = (inst.rotationDeg || 0) * Math.PI / 180;
+    const rotRad = degToRad(inst.rotationDeg || 0);
 
     // Get first part with a propTemplate
     const part = prefab.parts.find(p => p?.propTemplate);
@@ -6201,10 +6201,10 @@ window.addEventListener('mousemove', (e) => {
   }
 });
 
-// ============================================================================
+// ---------------------------------------------------------------------------
 // 3D / Runtime Debug Panel
 // TODO: See docs/renderer-README.md for renderer module documentation
-// ============================================================================
+// ---------------------------------------------------------------------------
 
 // State for debug panel
 let gameDebugPanelInitialized = false;

--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -769,9 +769,10 @@ export function makeCombat(G, C, options = {}){
   }
 
   function runAttackTimeline({ segments, context, onComplete, resetMirrorBeforeStance=false, sequenceSteps=[] }){
+    const mirrorTarget = context?.poseTarget || poseTarget || 'player';
     const ordered = Array.isArray(segments) ? segments.slice() : [];
     if (!ordered.length){
-      resetMirror(poseTarget);
+      resetMirror(mirrorTarget);
       if (typeof onComplete === 'function') onComplete();
       return;
     }
@@ -809,7 +810,7 @@ export function makeCombat(G, C, options = {}){
     const runSegmentAt = (idx) => {
       if (idx >= ordered.length){
         if (!mirrorCleared){
-          resetMirror(poseTarget);
+          resetMirror(mirrorTarget);
           mirrorCleared = true;
         }
         timelineState.active = false;
@@ -819,7 +820,7 @@ export function makeCombat(G, C, options = {}){
       }
       const segment = ordered[idx];
       if (resetMirrorBeforeStance && !stanceReset && segment.phase === 'Stance'){
-        resetMirror(poseTarget);
+        resetMirror(mirrorTarget);
         stanceReset = true;
         mirrorCleared = true;
       }

--- a/docs/js/physics.js
+++ b/docs/js/physics.js
@@ -292,9 +292,11 @@ function clampFighterToBounds(fighter, config) {
   const bounds = resolveHorizontalBounds(config);
   fighter.pos.x = clamp(fighter.pos.x, bounds.minX, bounds.maxX);
 
-  let groundY = resolveSharedGroundY(config);
-  if (!fighter.ragdoll && fighter.pos.y > groundY) {
-    fighter.pos.y = groundY;
+  const resolvedGroundY = typeof resolveSharedGroundY === 'function'
+    ? resolveSharedGroundY(config)
+    : (Number.isFinite(config?.groundY) ? config.groundY : 0);
+  if (!fighter.ragdoll && fighter.pos.y > resolvedGroundY) {
+    fighter.pos.y = resolvedGroundY;
   }
 }
 

--- a/src/map/scene3d.js
+++ b/src/map/scene3d.js
@@ -98,7 +98,7 @@ export function resolveScene3dUrl(sceneUrl, opts = {}) {
     return sceneUrl;
   }
 
-  const defaultBase = '/docs/config/maps/visualsmaps/';
+  const defaultBase = '/config/maps/visualsmaps/';
   let locationBase;
   if (typeof window !== 'undefined' && window.location?.href) {
     try {
@@ -113,16 +113,15 @@ export function resolveScene3dUrl(sceneUrl, opts = {}) {
     basePath,
     typeof window !== 'undefined' && window.location?.href ? window.location.href : 'http://localhost/',
   );
-  const docsRoot = baseUrl.pathname.replace(/config\/maps\/visualsmaps\/?$/, '');
 
   // Already absolute URL (http/https)
   if (sceneUrl.startsWith('http://') || sceneUrl.startsWith('https://')) {
     return sceneUrl;
   }
 
-  // Paths starting at /config/ should be anchored under the docs root when present
+  // Paths starting at /config/ should be returned unchanged to honor config-rooted assets
   if (sceneUrl.startsWith('/config/')) {
-    return docsRoot + sceneUrl.replace(/^\//, '');
+    return sceneUrl;
   }
 
   // Relative path starting with './' - strip and resolve


### PR DESCRIPTION
## Summary
- prevent ground clamping from crashing when helper functions are unavailable
- ensure scene3d URLs under /config/ stay unchanged and relative paths resolve from the correct base
- replace inline degree conversion and remove conflict-like separators in app debug panel

## Testing
- node --test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd6008b04832698645f10d5e0d644)