### PR TITLE
Fix portrait grid initialization race condition with species loader

### DIFF
--- a/docs/character-tools.html
+++ b/docs/character-tools.html
@@ -1230,6 +1230,10 @@ let FACIAL_HAIR_OPTIONS  = [{ id: 'none', label: 'No Facial Hair', tintSlot: nul
 
 // All appearance:: entries loaded from cosmetics index (unfiltered)
 let portraitIndexEntries = [];
+// Set to true once speLoadSpeciesIndex() finishes (success or failure), so
+// initPortraitCosmetics() knows whether to populate the grid itself or defer
+// to bOnSpeciesChanged() → rerollAll().
+let _portraitSpeciesLoadAttempted = false;
 // Full entry.id → portrait option object (cached to avoid re-fetching)
 const portraitOptionCache = new Map();
 
@@ -2038,14 +2042,22 @@ initBuilder();
   // Always finish init (even on failure, we still show 'none' options)
   preloadCommon();
   populateBuilderDropdowns();
-  const count = parseInt(document.getElementById('portrait-count-select').value, 10) || 6;
-  populateGrid(count);
-  // Re-roll builder to pick from freshly loaded options
-  const p = randomProfile();
-  document.getElementById('b-hair').value   = p.hair.id;
-  document.getElementById('b-eyes').value   = p.eyes.id;
-  document.getElementById('b-facial').value = p.facialHair.id;
-  renderBuilderPreview();
+  // Only populate the grid now if species data is already available or if the
+  // species loader has already finished (including failure).  In the common case
+  // (cosmetics finish loading before species), species data won't be ready yet —
+  // bOnSpeciesChanged() will call rerollAll() once speLoadSpeciesIndex() completes,
+  // generating the grid with correct per-gender cosmetic filtering at that point.
+  if (Object.keys(speAllSpecies).length > 0 || _portraitSpeciesLoadAttempted) {
+    portraitRefreshCosmeticOptions();
+    const count = parseInt(document.getElementById('portrait-count-select').value, 10) || 6;
+    populateGrid(count);
+    // Re-roll builder to pick from freshly loaded options
+    const p = randomProfile();
+    document.getElementById('b-hair').value   = p.hair.id;
+    document.getElementById('b-eyes').value   = p.eyes.id;
+    document.getElementById('b-facial').value = p.facialHair.id;
+    renderBuilderPreview();
+  }
 })();
 
 
@@ -2995,6 +3007,8 @@ async function speLoadSpeciesIndex() {
       speIndexBaseUrl = rawUrl;
     } catch (e2) {
       console.error('[species] Failed to load species index', e2);
+      _portraitSpeciesLoadAttempted = true;
+      bOnSpeciesChanged(); // populate portrait grid with unfiltered fallback options
       return;
     }
   }
@@ -3009,6 +3023,7 @@ async function speLoadSpeciesIndex() {
   }));
 
   // After all JSONs are loaded, trigger initial state for all three modes
+  _portraitSpeciesLoadAttempted = true;
   spePopulateSpeciesDropdowns();
   cosOnSpeciesChanged();
   speOnSpeciesOrGenderChanged();

--- a/docs/config/cosmetics/appearance/mao-ao/circled_eyes_f.json
+++ b/docs/config/cosmetics/appearance/mao-ao/circled_eyes_f.json
@@ -18,10 +18,10 @@
       "spriteStyle": {
         "xform": {
           "head": {
-            "ax": 0.01,
-            "ay": -0.01,
+            "ax": 0,
+            "ay": 0.01,
             "scaleX": 1,
-            "scaleY": 0.9,
+            "scaleY": 1,
             "rotDeg": 0
           }
         }

--- a/docs/config/species/mao-ao.json
+++ b/docs/config/species/mao-ao.json
@@ -103,7 +103,6 @@
     },
     "allowedCosmetics": [
       "appearance::Mao-ao_F::mao-ao_circled_eyes_f",
-      "appearance::Mao-ao_F::mao-ao_circled_eye_L",
       "appearance::Mao-ao_F::mao-ao_shoulder_length_drape",
       "appearance::Mao-ao_F::mao-ao_long_ponytail"
     ],


### PR DESCRIPTION
## Summary
This PR fixes a race condition in the portrait cosmetics initialization where the grid could be populated before species data was available, resulting in unfiltered cosmetic options instead of gender-appropriate ones.

## Key Changes
- Added `_portraitSpeciesLoadAttempted` flag to track whether the species index loader has completed (success or failure)
- Modified `initPortraitCosmetics()` to defer grid population until either:
  - Species data is already loaded (`speAllSpecies` has entries), OR
  - The species loader has finished attempting to load (flag is set)
- When deferring, the grid population is handled by `bOnSpeciesChanged()` → `rerollAll()` once species data is ready
- Updated species loader error handling to set the flag and trigger `bOnSpeciesChanged()` as a fallback when species loading fails
- Set the flag after successful species index load to ensure portrait grid is populated even if species data finishes loading after cosmetics

## Implementation Details
- The fix ensures that `portraitRefreshCosmeticOptions()` is only called when gender-based filtering can be applied
- In the common case where cosmetics load before species, the portrait grid initialization is deferred to avoid populating with unfiltered options
- Error handling in the species loader now properly triggers portrait grid population with fallback unfiltered options if species loading fails

https://claude.ai/code/session_01XgvsMy7gJRMQsxhM8kcNjS