### PR TITLE
Fix portrait body layer stacking order

### DIFF
--- a/docs/config/portrait-config.js
+++ b/docs/config/portrait-config.js
@@ -12,8 +12,8 @@ window.PORTRAIT_CONFIG = {
       label: 'Mao-ao (M)',
       headUrl: 'fightersprites/mao-ao-m/head_mint.png',
       bodyLayers: [
-        { id: 'torso', url: 'portraitsprites/torso_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
         { id: 'armL', url: 'portraitsprites/arm-L_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
+        { id: 'torso', url: 'portraitsprites/torso_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
         { id: 'armR', url: 'portraitsprites/arm-R_mao-ao_m.png', tintSlot: 'A', pos: 'back' }
       ],
       urLayers: [
@@ -25,8 +25,8 @@ window.PORTRAIT_CONFIG = {
       label: 'Mao-ao (F)',
       headUrl: 'fightersprites/mao-ao-f/head.png',
       bodyLayers: [
-        { id: 'torso', url: 'portraitsprites/torso_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
         { id: 'armL', url: 'portraitsprites/arm-L_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
+        { id: 'torso', url: 'portraitsprites/torso_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
         { id: 'armR', url: 'portraitsprites/arm-R_mao-ao_f.png', tintSlot: 'A', pos: 'back' }
       ],
       urLayers: [

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -19,8 +19,8 @@ const _PORTRAIT_DEFAULTS = {
       label:   'Mao-ao (M)',
       headUrl: 'fightersprites/mao-ao-m/head_mint.png',
       bodyLayers: [
-        { id: 'torso', url: 'portraitsprites/torso_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
         { id: 'armL', url: 'portraitsprites/arm-L_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
+        { id: 'torso', url: 'portraitsprites/torso_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
         { id: 'armR', url: 'portraitsprites/arm-R_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
       ],
       urLayers: [
@@ -32,8 +32,8 @@ const _PORTRAIT_DEFAULTS = {
       label:   'Mao-ao (F)',
       headUrl: 'fightersprites/mao-ao-f/head.png',
       bodyLayers: [
-        { id: 'torso', url: 'portraitsprites/torso_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
         { id: 'armL', url: 'portraitsprites/arm-L_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
+        { id: 'torso', url: 'portraitsprites/torso_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
         { id: 'armR', url: 'portraitsprites/arm-R_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
       ],
       urLayers: [


### PR DESCRIPTION
### Motivation
- Portrait back-layer stacking used `fighter.bodyLayers` array order which placed torso and arms incorrectly, producing the wrong visual overlap; the correct visible stack should be head above right arm above torso above left arm.
- Adjusting the source order of `bodyLayers` makes the compositor render the limbs and torso with the intended overlap without touching draw logic.

### Description
- Reordered `bodyLayers` from `torso, armL, armR` to `armL, torso, armR` in the runtime defaults in `docs/js/portrait-utils.js` for both Mao-ao variants.
- Applied the same ordering change to `docs/config/portrait-config.js` so the config matches runtime behavior.
- Only the ordering data was changed; the portrait compositor still draws back layers, then the head, then front layers (no draw-path changes).

### Testing
- `npx eslint --no-ignore docs/js/portrait-utils.js docs/config/portrait-config.js` completed successfully on the modified files.
- `npm run lint` was run and failed due to a pre-existing unrelated lint error in `src/map/builderConversion.js` (`resolveGridUnit` is not defined).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd997388c08326b11f79a4236d29ab)