### PR TITLE
Fix portrait body layer draw order for portraits

### DIFF
--- a/docs/config/portrait-config.js
+++ b/docs/config/portrait-config.js
@@ -12,8 +12,8 @@ window.PORTRAIT_CONFIG = {
       label: 'Mao-ao (M)',
       headUrl: 'fightersprites/mao-ao-m/head_mint.png',
       bodyLayers: [
-        { id: 'torso', url: 'portraitsprites/torso_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
         { id: 'armL', url: 'portraitsprites/arm-L_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
+        { id: 'torso', url: 'portraitsprites/torso_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
         { id: 'armR', url: 'portraitsprites/arm-R_mao-ao_m.png', tintSlot: 'A', pos: 'back' }
       ],
       urLayers: [
@@ -25,8 +25,8 @@ window.PORTRAIT_CONFIG = {
       label: 'Mao-ao (F)',
       headUrl: 'fightersprites/mao-ao-f/head.png',
       bodyLayers: [
-        { id: 'torso', url: 'portraitsprites/torso_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
         { id: 'armL', url: 'portraitsprites/arm-L_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
+        { id: 'torso', url: 'portraitsprites/torso_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
         { id: 'armR', url: 'portraitsprites/arm-R_mao-ao_f.png', tintSlot: 'A', pos: 'back' }
       ],
       urLayers: [

--- a/docs/config/species/mao-ao.json
+++ b/docs/config/species/mao-ao.json
@@ -166,8 +166,8 @@
     },
     "portraitBodyLayers": [
       {
-        "id": "torso",
-        "url": "portraitsprites/torso_mao-ao_m.png",
+        "id": "armL",
+        "url": "portraitsprites/arm-L_mao-ao_m.png",
         "tintSlot": "A",
         "pos": "back",
         "xform": {
@@ -179,8 +179,8 @@
         }
       },
       {
-        "id": "armL",
-        "url": "portraitsprites/arm-L_mao-ao_m.png",
+        "id": "torso",
+        "url": "portraitsprites/torso_mao-ao_m.png",
         "tintSlot": "A",
         "pos": "back",
         "xform": {
@@ -396,8 +396,8 @@
     },
     "portraitBodyLayers": [
       {
-        "id": "torso",
-        "url": "portraitsprites/torso_mao-ao_f.png",
+        "id": "armL",
+        "url": "portraitsprites/arm-L_mao-ao_f.png",
         "tintSlot": "A",
         "pos": "back",
         "xform": {
@@ -409,8 +409,8 @@
         }
       },
       {
-        "id": "armL",
-        "url": "portraitsprites/arm-L_mao-ao_f.png",
+        "id": "torso",
+        "url": "portraitsprites/torso_mao-ao_f.png",
         "tintSlot": "A",
         "pos": "back",
         "xform": {

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -19,8 +19,8 @@ const _PORTRAIT_DEFAULTS = {
       label:   'Mao-ao (M)',
       headUrl: 'fightersprites/mao-ao-m/head_mint.png',
       bodyLayers: [
-        { id: 'torso', url: 'portraitsprites/torso_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
         { id: 'armL', url: 'portraitsprites/arm-L_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
+        { id: 'torso', url: 'portraitsprites/torso_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
         { id: 'armR', url: 'portraitsprites/arm-R_mao-ao_m.png', tintSlot: 'A', pos: 'back' },
       ],
       urLayers: [
@@ -32,8 +32,8 @@ const _PORTRAIT_DEFAULTS = {
       label:   'Mao-ao (F)',
       headUrl: 'fightersprites/mao-ao-f/head.png',
       bodyLayers: [
-        { id: 'torso', url: 'portraitsprites/torso_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
         { id: 'armL', url: 'portraitsprites/arm-L_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
+        { id: 'torso', url: 'portraitsprites/torso_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
         { id: 'armR', url: 'portraitsprites/arm-R_mao-ao_f.png', tintSlot: 'A', pos: 'back' },
       ],
       urLayers: [


### PR DESCRIPTION
### Motivation
- Portrait body layers were configured in an order that produced incorrect stacking when drawn by `renderProfile()` because the renderer draws `bodyBackLayers` in array order before drawing the head. 
- The intended visual stacking is: head on top, then right arm, then torso, then left arm, which requires the `bodyLayers` array to be `armL, torso, armR` so the last-drawn arm becomes visually above the torso and left arm.

### Description
- Reordered default fighter `bodyLayers` in `docs/js/portrait-utils.js` to `armL -> torso -> armR` so runtime defaults match the renderer's draw ordering.
- Updated `docs/config/portrait-config.js` to the same `armL, torso, armR` ordering so the live config uses the corrected stacking.
- Updated species defaults in `docs/config/species/mao-ao.json` for both `male` and `female` `portraitBodyLayers` to preserve consistent ordering for species-driven portrait generation.
- Changes are limited to configuration/data ordering and do not modify the drawing logic in `renderProfile()` itself.

### Testing
- Parsed `docs/config/species/mao-ao.json` with Node using `JSON.parse` to confirm valid JSON and the file parsed successfully. (succeeded)
- Read `docs/config/portrait-config.js` with Node to confirm it is loadable as runtime config. (succeeded)
- Ran a quick `git diff`/status check and committed the changes to verify repository state. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd997388c08326b11f79a4236d29ab)