### PR TITLE
Add per-species hidden portrait opacity mask layer

### DIFF
--- a/docs/config/species/mao-ao.json
+++ b/docs/config/species/mao-ao.json
@@ -204,7 +204,18 @@
           "rotDeg": 0
         }
       }
-    ]
+    ],
+    "portraitOpacityMaskLayer": {
+      "id": "opacityMask",
+      "url": "hud/spriteopacitymask_cloud.png",
+      "xform": {
+        "ax": -0.085,
+        "ay": -0.06,
+        "scaleX": 2.55,
+        "scaleY": 2.55,
+        "rotDeg": 0
+      }
+    }
   },
   "female": {
     "headSprite": "fightersprites/mao-ao-f/head.png",
@@ -434,6 +445,17 @@
           "rotDeg": 0
         }
       }
-    ]
+    ],
+    "portraitOpacityMaskLayer": {
+      "id": "opacityMask",
+      "url": "hud/spriteopacitymask_cloud.png",
+      "xform": {
+        "ax": -0.085,
+        "ay": -0.06,
+        "scaleX": 2.55,
+        "scaleY": 2.55,
+        "rotDeg": 0
+      }
+    }
   }
 }

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -64,12 +64,19 @@ function normalizePortraitLayerXform(layer) {
   return next;
 }
 
+function normalizePortraitMaskLayer(maskLayer) {
+  if (!maskLayer || typeof maskLayer !== 'object') return null;
+  return normalizePortraitLayerXform(maskLayer);
+}
+
 function normalizedFighterPortrait(fighter) {
   if (!fighter || typeof fighter !== 'object') return fighter;
-  if (!Array.isArray(fighter.bodyLayers)) return fighter;
   return {
     ...fighter,
-    bodyLayers: fighter.bodyLayers.map(normalizePortraitLayerXform),
+    bodyLayers: Array.isArray(fighter.bodyLayers)
+      ? fighter.bodyLayers.map(normalizePortraitLayerXform)
+      : fighter.bodyLayers,
+    opacityMaskLayer: normalizePortraitMaskLayer(fighter.opacityMaskLayer),
   };
 }
 
@@ -167,11 +174,24 @@ function drawPortraitLayer(ctx, img, xform, cssFilter) {
   ctx.restore();
 }
 
+function applyPortraitOpacityMask(ctx, img, xform) {
+  const { ax, ay, sx, sy } = xform;
+  const h  = PORTRAIT_L * sy;
+  const w  = (img.naturalWidth / img.naturalHeight) * PORTRAIT_L * sx;
+  const cx = PORTRAIT_CW / 2 + ay * PORTRAIT_L;
+  const cy = PORTRAIT_CH / 2 - ax * PORTRAIT_L;
+  ctx.save();
+  ctx.globalCompositeOperation = 'destination-out';
+  ctx.drawImage(img, cx - w / 2, cy - h / 2, w, h);
+  ctx.restore();
+}
+
 // ── Rendering ──────────────────────────────────────────────
 
 async function renderProfile(canvas, profile) {
   const { fighter, hair, hairFront, hairBack, hairSide, eyes, facialHair, hat, torsoCosmetic, armCosmetic, bodyColors } = profile;
   const headXform = fighter?.headXform || HEAD_XFORM;
+  const opacityMaskLayer = fighter?.opacityMaskLayer || null;
   const ctx = canvas.getContext('2d');
   ctx.clearRect(0, 0, PORTRAIT_CW, PORTRAIT_CH);
 
@@ -214,6 +234,7 @@ async function renderProfile(canvas, profile) {
     ...backLayers.map(({ layer }) => layer.url),
     ...frontLayers.map(({ layer }) => layer.url),
     ...bodyFrontLayers.map(({ layer }) => layer.url),
+    ...(opacityMaskLayer?.url ? [opacityMaskLayer.url] : []),
   ]);
 
   let imgMap;
@@ -251,6 +272,10 @@ async function renderProfile(canvas, profile) {
   for (const { layer, filter } of bodyFrontLayers) {
     const img = imgMap.get(layer.url);
     if (img) drawPortraitLayer(ctx, img, composeXform(headXform, layer), filter);
+  }
+  if (opacityMaskLayer?.url) {
+    const maskImg = imgMap.get(opacityMaskLayer.url);
+    if (maskImg) applyPortraitOpacityMask(ctx, maskImg, composeXform(headXform, opacityMaskLayer));
   }
 }
 
@@ -459,6 +484,9 @@ async function loadPortraitCosmetics(configBase) {
               ...(genderData.headXform ? { headXform: genderData.headXform } : {}),
               ...(Array.isArray(genderData.portraitBodyLayers) ? {
                 bodyLayers: genderData.portraitBodyLayers.map(normalizePortraitLayerXform)
+              } : {}),
+              ...(genderData.portraitOpacityMaskLayer ? {
+                opacityMaskLayer: normalizePortraitMaskLayer(genderData.portraitOpacityMaskLayer)
               } : {})
             };
             if (genderData.allowedCosmetics) {


### PR DESCRIPTION
### Motivation
- Provide an art-authored, per-species portrait mask that invisibly cuts alpha from the already-rendered portrait so the bottom edge can be faded by an artist-supplied PNG rather than complex programmatic masking.

### Description
- Added support for an optional per-fighter `opacityMaskLayer` in the portrait pipeline and a helper `normalizePortraitMaskLayer` to normalize its transform like other portrait layers in `docs/js/portrait-utils.js`.
- Preload the mask with the portrait asset set and apply it after all portrait layers are drawn by a new `applyPortraitOpacityMask` function which uses canvas compositing (`globalCompositeOperation = 'destination-out'`) so the mask image itself remains hidden while removing alpha from the portrait beneath it.
- Wired species JSON ingestion to accept `portraitOpacityMaskLayer` in species files and map it into the fighter portrait overrides so each species/gender can have its own mask configuration.
- Set the default mask for the Mao-ao species (male and female) in `docs/config/species/mao-ao.json` to `hud/spriteopacitymask_cloud.png` and reused the same `xform` values as the torso/arm portrait layers.

### Testing
- Ran `npm run lint`; it failed due to a pre‑existing unrelated lint error (`resolveGridUnit` undefined in `src/map/builderConversion.js`).
- Ran `npm run test:unit`; the test suite executed but failed due to multiple unrelated pre-existing test failures in the repo baseline (several suites reported failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddb4d14d64832698c47647097fa1d8)