### PR TITLE
Add portrait opacity mask support to species editor and render chain

### DIFF
--- a/docs/character-tools.html
+++ b/docs/character-tools.html
@@ -1083,6 +1083,41 @@ details.diag-details[open] > summary::after { content: '▼'; }
       </div>
     </div>
 
+    <!-- Portrait opacity mask placer -->
+    <div class="cos-section">
+      <h2>Portrait Opacity Mask Placer</h2>
+      <div style="font-size:11px;color:var(--muted);margin-bottom:8px">
+        Adjust the species portrait opacity mask transform used in final destination-out compositing.
+      </div>
+      <label>Mask Sprite URL</label>
+      <input type="text" id="spe-mask-url" readonly>
+      <div class="cos-slider-row">
+        <label>ax</label>
+        <input type="range" id="spe-mask-ax" min="-5" max="5" step="0.01" value="0">
+        <input type="number" id="spe-mask-ax-n" min="-5" max="5" step="0.01" value="0">
+      </div>
+      <div class="cos-slider-row">
+        <label>ay</label>
+        <input type="range" id="spe-mask-ay" min="-5" max="5" step="0.01" value="0">
+        <input type="number" id="spe-mask-ay-n" min="-5" max="5" step="0.01" value="0">
+      </div>
+      <div class="cos-slider-row">
+        <label>scaleX</label>
+        <input type="range" id="spe-mask-sx" min="0.1" max="10" step="0.01" value="1">
+        <input type="number" id="spe-mask-sx-n" min="0.1" max="10" step="0.01" value="1">
+      </div>
+      <div class="cos-slider-row">
+        <label>scaleY</label>
+        <input type="range" id="spe-mask-sy" min="0.1" max="10" step="0.01" value="1">
+        <input type="number" id="spe-mask-sy-n" min="0.1" max="10" step="0.01" value="1">
+      </div>
+      <div class="cos-slider-row">
+        <label>rotDeg</label>
+        <input type="range" id="spe-mask-rot" min="-180" max="180" step="1" value="0">
+        <input type="number" id="spe-mask-rot-n" min="-180" max="180" step="1" value="0">
+      </div>
+    </div>
+
     <!-- Export -->
     <div class="cos-section">
       <h2>Export</h2>
@@ -1497,6 +1532,7 @@ function getBuilderProfile() {
   const gData     = bGetCurrentSpeciesData();
   const speciesId = document.getElementById('b-species') ? document.getElementById('b-species').value : '';
   const gender    = document.getElementById('b-gender')  ? document.getElementById('b-gender').value  : 'male';
+  const fallbackFighter = FIGHTERS.find(f => f.headUrl === gData?.headSprite) || FIGHTERS[0];
   const fighter = gData
     ? {
         id:       speciesId + '-' + gender,
@@ -1505,8 +1541,15 @@ function getBuilderProfile() {
                     : speciesId) + ' (' + gender + ')',
         headUrl:  gData.headSprite,
         urLayers: gData.headUrLayers || [],
+        headXform: gData.headXform || fallbackFighter?.headXform || HEAD_XFORM,
+        bodyLayers: Array.isArray(gData.portraitBodyLayers) && gData.portraitBodyLayers.length
+          ? gData.portraitBodyLayers.map(normalizePortraitLayerXform)
+          : (fallbackFighter?.bodyLayers || []),
+        opacityMaskLayer: gData.portraitOpacityMaskLayer
+          ? normalizePortraitMaskLayer(gData.portraitOpacityMaskLayer)
+          : (fallbackFighter?.opacityMaskLayer ? normalizePortraitMaskLayer(fallbackFighter.opacityMaskLayer) : null),
       }
-    : FIGHTERS[0];
+    : fallbackFighter;
   const hair       = HAIR_OPTIONS.find(o => o.id === document.getElementById('b-hair').value) ?? HAIR_OPTIONS[0];
   const eyes       = EYES_OPTIONS.find(o => o.id === document.getElementById('b-eyes').value) ?? EYES_OPTIONS[0];
   const facialHair = FACIAL_HAIR_OPTIONS.find(o => o.id === document.getElementById('b-facial').value) ?? FACIAL_HAIR_OPTIONS[0];
@@ -1524,9 +1567,26 @@ async function renderBuilderPreview() {
 
 function buildRenderChain(profile) {
   const { fighter, hair, eyes, facialHair, bodyColors } = profile;
+  const headXform = fighter?.headXform || HEAD_XFORM;
   const filterFor = (slot) => slot ? makeCSSFilter(bodyColors[slot]) : 'none';
+  const bodyLayers = fighter?.bodyLayers || [];
   const cosGroups = [{ group: hair, category: 'Hair' }, { group: eyes, category: 'Eyes' }, { group: facialHair, category: 'Facial Hair' }];
-  const backEntries = [], frontEntries = [];
+  const backEntries = [], frontEntries = [], bodyBackEntries = [], bodyFrontEntries = [];
+
+  for (let i = 0; i < bodyLayers.length; i++) {
+    const layer = bodyLayers[i];
+    const entry = {
+      category:    `Body Layer ${i + 1} (${layer.pos === 'front' ? 'front' : 'back'})`,
+      optionId:    layer.id || `bodyLayer${i + 1}`,
+      optionLabel: layer.id || `Body Layer ${i + 1}`,
+      tintSlot:    layer.tintSlot || 'A',
+      filter:      filterFor(layer.tintSlot || 'A'),
+      relPath:     layer.url,
+      resolvedUrl: ASSET_BASE + layer.url,
+      transform:   composeXform(headXform, layer),
+    };
+    (layer.pos === 'front' ? bodyFrontEntries : bodyBackEntries).push(entry);
+  }
 
   for (const { group, category } of cosGroups) {
     if (!group || !group.layers.length) continue;
@@ -1541,18 +1601,30 @@ function buildRenderChain(profile) {
         filter:      filterFor(group.tintSlot),
         relPath:     layer.url,
         resolvedUrl: ASSET_BASE + layer.url,
-        transform:   composeXform(HEAD_XFORM, layer),
+        transform:   composeXform(headXform, layer),
       };
       (layer.pos === 'back' ? backEntries : frontEntries).push(entry);
     }
   }
 
-  const chain = [...backEntries];
-  chain.push({ category: 'Head Base', optionId: fighter.id, optionLabel: fighter.label, tintSlot: 'A', filter: filterFor('A'), relPath: fighter.headUrl, resolvedUrl: ASSET_BASE + fighter.headUrl, transform: { ...HEAD_XFORM } });
+  const chain = [...bodyBackEntries, ...backEntries];
+  chain.push({ category: 'Head Base', optionId: fighter.id, optionLabel: fighter.label, tintSlot: 'A', filter: filterFor('A'), relPath: fighter.headUrl, resolvedUrl: ASSET_BASE + fighter.headUrl, transform: { ...headXform } });
   for (const mid of (fighter.urLayers || [])) {
-    chain.push({ category: 'Head Overlay (untinted)', optionId: fighter.id, optionLabel: fighter.label, tintSlot: null, filter: 'none', relPath: mid.url, resolvedUrl: ASSET_BASE + mid.url, transform: { ...(mid.xform || HEAD_XFORM) } });
+    chain.push({ category: 'Head Overlay (untinted)', optionId: fighter.id, optionLabel: fighter.label, tintSlot: null, filter: 'none', relPath: mid.url, resolvedUrl: ASSET_BASE + mid.url, transform: { ...(mid.xform || headXform) } });
   }
-  chain.push(...frontEntries);
+  chain.push(...frontEntries, ...bodyFrontEntries);
+  if (fighter.opacityMaskLayer?.url) {
+    chain.push({
+      category: 'Opacity Mask (destination-out)',
+      optionId: fighter.opacityMaskLayer.id || 'opacityMask',
+      optionLabel: 'Opacity Mask',
+      tintSlot: null,
+      filter: 'none',
+      relPath: fighter.opacityMaskLayer.url,
+      resolvedUrl: ASSET_BASE + fighter.opacityMaskLayer.url,
+      transform: composeXform(headXform, fighter.opacityMaskLayer),
+    });
+  }
   return chain;
 }
 
@@ -2785,7 +2857,9 @@ let speActiveSlot     = 'A';
 let speSelectedStop   = -1;     // index into current slot's stops array
 let speWorkingRanges  = {};     // { male: { A:{...}, B:{...}, C:{...} }, female: {...} }
 let speWorkingPortraitLayers = {}; // { male:[{id,url,tintSlot,pos,xform}], female:[...] }
+let speWorkingOpacityMaskLayer = {}; // { male:{id,url,xform}|null, female:{...}|null }
 let spePortraitLayerImages = {};   // { male:[img|null], female:[...] }
+let speOpacityMaskImages = {};      // { male:img|null, female:img|null }
 let speSelectedBodyLayerIndex = 0;
 let speLoadedJson     = null;   // original (unmodified) species JSON for the current species
 
@@ -2816,6 +2890,11 @@ function speGetCurrentPortraitLayer() {
   return layers[speSelectedBodyLayerIndex] || null;
 }
 
+function speGetCurrentOpacityMaskLayer() {
+  const gender = document.getElementById('spe-gender').value;
+  return speWorkingOpacityMaskLayer[gender] || null;
+}
+
 function speNormalizePortraitBodyLayers(gData) {
   const fallback = (FIGHTERS.find(f => f.headUrl === gData?.headSprite) || {}).bodyLayers || [];
   const src = Array.isArray(gData?.portraitBodyLayers) && gData.portraitBodyLayers.length
@@ -2834,6 +2913,23 @@ function speNormalizePortraitBodyLayers(gData) {
       rotDeg: Number(layer.xform?.rotDeg ?? layer.rotDeg ?? 0),
     },
   }));
+}
+
+function speNormalizePortraitOpacityMaskLayer(gData) {
+  const fallback = (FIGHTERS.find(f => f.headUrl === gData?.headSprite) || {}).opacityMaskLayer || null;
+  const src = gData?.portraitOpacityMaskLayer || fallback;
+  if (!src) return null;
+  return {
+    id: src.id || 'opacityMask',
+    url: String(src.url || '').trim(),
+    xform: {
+      ax: Number(src.xform?.ax ?? src.ax ?? 0),
+      ay: Number(src.xform?.ay ?? src.ay ?? 0),
+      scaleX: Number(src.xform?.scaleX ?? src.xform?.sx ?? src.scaleX ?? src.sx ?? 1),
+      scaleY: Number(src.xform?.scaleY ?? src.xform?.sy ?? src.scaleY ?? src.sy ?? 1),
+      rotDeg: Number(src.xform?.rotDeg ?? src.rotDeg ?? 0),
+    },
+  };
 }
 
 function speWriteBodyLayerXformControls() {
@@ -2878,6 +2974,34 @@ function speSetBodyLayerField(field, value) {
   speRenderHeadPreview();
 }
 
+function speWriteOpacityMaskXformControls() {
+  const layer = speGetCurrentOpacityMaskLayer();
+  document.getElementById('spe-mask-url').value = layer ? (layer.url || '') : '';
+  const disabled = !layer;
+  const fields = [
+    ['ax', 'spe-mask-ax', 'spe-mask-ax-n'],
+    ['ay', 'spe-mask-ay', 'spe-mask-ay-n'],
+    ['scaleX', 'spe-mask-sx', 'spe-mask-sx-n'],
+    ['scaleY', 'spe-mask-sy', 'spe-mask-sy-n'],
+    ['rotDeg', 'spe-mask-rot', 'spe-mask-rot-n'],
+  ];
+  for (const [key, sliderId, numId] of fields) {
+    const val = Number(layer?.xform?.[key] ?? (key.includes('scale') ? 1 : 0));
+    document.getElementById(sliderId).value = val;
+    document.getElementById(numId).value = val;
+    document.getElementById(sliderId).disabled = disabled;
+    document.getElementById(numId).disabled = disabled;
+  }
+}
+
+function speSetOpacityMaskField(field, value) {
+  const layer = speGetCurrentOpacityMaskLayer();
+  if (!layer) return;
+  layer.xform[field] = value;
+  speWriteOpacityMaskXformControls();
+  speRenderHeadPreview();
+}
+
 async function speLoadPortraitLayerImagesForGender(gender) {
   const layers = speWorkingPortraitLayers[gender] || [];
   spePortraitLayerImages[gender] = new Array(layers.length).fill(null);
@@ -2895,6 +3019,20 @@ async function speLoadPortraitLayerImagesForGender(gender) {
       console.warn('[spe] portrait body layer load failed:', url, e);
     }
   }));
+  speOpacityMaskImages[gender] = null;
+  const maskLayer = speWorkingOpacityMaskLayer[gender];
+  const maskUrl = String(maskLayer?.url || '').trim();
+  if (!maskUrl) return;
+  try {
+    if (maskUrl.startsWith('http://') || maskUrl.startsWith('https://')) {
+      speOpacityMaskImages[gender] = await cosLoadImageAbsolute(maskUrl);
+    } else {
+      const relPath = maskUrl.startsWith('./assets/') ? maskUrl.slice('./assets/'.length) : maskUrl;
+      speOpacityMaskImages[gender] = await cosLoadImage(relPath);
+    }
+  } catch (e) {
+    console.warn('[spe] portrait opacity mask load failed:', maskUrl, e);
+  }
 }
 
 // ── Loading species into editor ────────────────────────────
@@ -2903,7 +3041,9 @@ function speLoadIntoEditor(json) {
   speLoadedJson    = json;
   speWorkingRanges = {};
   speWorkingPortraitLayers = {};
+  speWorkingOpacityMaskLayer = {};
   spePortraitLayerImages = {};
+  speOpacityMaskImages = {};
   const defaultRange = (minH, maxH) => ({
     minH, maxH, subdivisions: 2,
     stops: [
@@ -2915,6 +3055,7 @@ function speLoadIntoEditor(json) {
     speWorkingRanges[gender] = {};
     const gData = json[gender];
     speWorkingPortraitLayers[gender] = speNormalizePortraitBodyLayers(gData);
+    speWorkingOpacityMaskLayer[gender] = speNormalizePortraitOpacityMaskLayer(gData);
     for (const slot of ['A', 'B', 'C']) {
       const src = gData && gData.bodyColorRanges && gData.bodyColorRanges[slot];
       speWorkingRanges[gender][slot] = src
@@ -2928,6 +3069,7 @@ function speLoadIntoEditor(json) {
     .finally(() => speRenderHeadPreview());
   speRefreshEditorUI();
   speUpdateBodyLayerControls();
+  speWriteOpacityMaskXformControls();
 }
 
 function speRefreshEditorUI() {
@@ -3102,6 +3244,22 @@ function speBuildExportJson() {
         rotDeg: cosRound4(layer.xform.rotDeg || 0),
       },
     }));
+    const opacityMaskLayer = speWorkingOpacityMaskLayer[gender];
+    if (opacityMaskLayer && opacityMaskLayer.url) {
+      result[gender].portraitOpacityMaskLayer = {
+        id: opacityMaskLayer.id || 'opacityMask',
+        url: opacityMaskLayer.url,
+        xform: {
+          ax: cosRound4(opacityMaskLayer.xform?.ax ?? 0),
+          ay: cosRound4(opacityMaskLayer.xform?.ay ?? 0),
+          scaleX: cosRound4(opacityMaskLayer.xform?.scaleX ?? 1),
+          scaleY: cosRound4(opacityMaskLayer.xform?.scaleY ?? 1),
+          rotDeg: cosRound4(opacityMaskLayer.xform?.rotDeg ?? 0),
+        },
+      };
+    } else {
+      delete result[gender].portraitOpacityMaskLayer;
+    }
   }
   return JSON.stringify(result, null, 2);
 }
@@ -3201,6 +3359,22 @@ async function speRenderHeadPreview() {
     }
   }
   drawPortraitLayersAtPos('front');
+
+  const maskLayer = speWorkingOpacityMaskLayer[gender];
+  const maskImg = speOpacityMaskImages[gender];
+  if (maskLayer && maskImg) {
+    const x = maskLayer.xform || {};
+    const d = composeXform(xf, {
+      ax: Number(x.ax ?? 0),
+      ay: Number(x.ay ?? 0),
+      sx: Number(x.scaleX ?? 1),
+      sy: Number(x.scaleY ?? 1),
+    });
+    speCtx.save();
+    speCtx.globalCompositeOperation = 'destination-out';
+    drawLayerFn(maskImg, d.ax, d.ay, d.sx, d.sy, 'none', Number(x.rotDeg ?? 0));
+    speCtx.restore();
+  }
 }
 
 function speOnSpeciesOrGenderChanged() {
@@ -3225,6 +3399,7 @@ document.getElementById('spe-gender').addEventListener('change',  () => {
   speSelectedBodyLayerIndex = 0;
   speRefreshEditorUI();
   speUpdateBodyLayerControls();
+  speWriteOpacityMaskXformControls();
   speRenderHeadPreview();
   // Sync gender to Cosmetic Placer
   if (!_speciesSyncInProgress) {
@@ -3267,6 +3442,28 @@ for (const [key, sliderId, numberId] of SPE_BODY_FIELDS) {
     if (!Number.isFinite(v)) return;
     document.getElementById(sliderId).value = v;
     speSetBodyLayerField(key, v);
+  });
+}
+
+const SPE_MASK_FIELDS = [
+  ['ax', 'spe-mask-ax', 'spe-mask-ax-n'],
+  ['ay', 'spe-mask-ay', 'spe-mask-ay-n'],
+  ['scaleX', 'spe-mask-sx', 'spe-mask-sx-n'],
+  ['scaleY', 'spe-mask-sy', 'spe-mask-sy-n'],
+  ['rotDeg', 'spe-mask-rot', 'spe-mask-rot-n'],
+];
+for (const [key, sliderId, numberId] of SPE_MASK_FIELDS) {
+  document.getElementById(sliderId).addEventListener('input', () => {
+    const v = parseFloat(document.getElementById(sliderId).value);
+    if (!Number.isFinite(v)) return;
+    document.getElementById(numberId).value = v;
+    speSetOpacityMaskField(key, v);
+  });
+  document.getElementById(numberId).addEventListener('input', () => {
+    const v = parseFloat(document.getElementById(numberId).value);
+    if (!Number.isFinite(v)) return;
+    document.getElementById(sliderId).value = v;
+    speSetOpacityMaskField(key, v);
   });
 }
 

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -518,7 +518,8 @@ async function loadPortraitCosmetics(configBase) {
       return normalizedFighterPortrait({
         ...fighter,
         ...(override.headXform ? { headXform: override.headXform } : {}),
-        ...(override.bodyLayers ? { bodyLayers: override.bodyLayers } : {})
+        ...(override.bodyLayers ? { bodyLayers: override.bodyLayers } : {}),
+        ...(override.opacityMaskLayer ? { opacityMaskLayer: override.opacityMaskLayer } : {})
       });
     });
   }


### PR DESCRIPTION
### Motivation
- Provide a way to place and transform a portrait opacity mask used during final `destination-out` compositing so species portraits can mask parts of the head/body cleanly.
- Ensure builder previews and species export/import round-trip include portrait body layers and an optional opacity mask, falling back to fighter defaults when species data is missing.

### Description
- Added a new UI block `Portrait Opacity Mask Placer` to `docs/character-tools.html` with URL display and transform sliders for `ax`, `ay`, `scaleX`, `scaleY`, and `rotDeg`.
- Added editor state and image caches: `speWorkingOpacityMaskLayer` and `speOpacityMaskImages`, normalization helper `speNormalizePortraitOpacityMaskLayer`, and control wiring (`speWriteOpacityMaskXformControls`, `speSetOpacityMaskField`, and `SPE_MASK_FIELDS`).
- Integrated opacity-mask loading in `speLoadPortraitLayerImagesForGender`, rendering in `speRenderHeadPreview` using `globalCompositeOperation = 'destination-out'`, and included mask in export via `speBuildExportJson` as `portraitOpacityMaskLayer`.
- Updated builder/export plumbing: `getBuilderProfile` now populates `bodyLayers`, `headXform` fallbacks, and `opacityMaskLayer`; `buildRenderChain` now composes body layer entries and appends an `Opacity Mask (destination-out)` step; `portrait-utils.js` now respects `override.opacityMaskLayer` when applying `fighterPortraitOverrides`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd6836a608326b50270b9f9daa1d8)