### PR TITLE
Make Scratchbones hand render fully visible by default

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -369,16 +369,20 @@
     }
 
     .handScroll {
-      display: flex;
-      gap: 10px;
-      overflow-x: auto;
+      --hand-card-min: clamp(74px, 14vw, 104px);
+      --hand-card-gap: clamp(8px, 1.6vw, 12px);
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(var(--hand-card-min), 1fr));
+      gap: var(--hand-card-gap);
+      align-content: start;
+      overflow: visible;
       padding-bottom: 4px;
-      scroll-snap-type: x proximity;
     }
 
     .card {
-      min-width: 69px;
-      min-height: 178px;
+      width: 100%;
+      min-width: 0;
+      min-height: clamp(146px, 20vh, 186px);
       padding: 0;
       background: transparent;
       color: var(--card-text);
@@ -388,7 +392,6 @@
       display: flex;
       align-items: stretch;
       justify-content: stretch;
-      scroll-snap-align: start;
       position: relative;
       overflow: hidden;
       isolation: isolate;
@@ -409,6 +412,24 @@
       display: block;
       border-radius: inherit;
       pointer-events: none;
+    }
+
+    @media (max-width: 430px) {
+      .handScroll {
+        display: flex;
+        gap: 10px;
+        overflow-x: auto;
+        scroll-snap-type: x proximity;
+        padding-bottom: 6px;
+      }
+
+      .card {
+        width: auto;
+        min-width: 94px;
+        min-height: 176px;
+        scroll-snap-align: start;
+        flex: 0 0 auto;
+      }
     }
 
     .eventLog {


### PR DESCRIPTION
### Motivation
- The player's hand currently relies on horizontal scrolling which hides cards in normal play; the goal is to show the complete hand by default while preserving touch targets and selection affordance.
- Keep game logic untouched by preserving the existing data path (`selectedCards()` / `state.players[0].hand` and the template rendering via `${player.hand.map(...)}`).
- Provide a compact fallback for very narrow screens to avoid layout breakage on tiny devices.

### Description
- Replaced the single-row `.handScroll` flex layout with a responsive CSS grid using `repeat(auto-fit, minmax(...))` and new CSS variables `--hand-card-min` and `--hand-card-gap` so the hand adapts to viewport width.
- Updated `.card` sizing to use `width: 100%` and an adaptive `min-height: clamp(...)` so cards remain large enough for touch while fitting into the grid cells.
- Preserved the `.card.selected` visual affordance and other interactions unchanged, and left the hand data source untouched (`state.players[0].hand` / `player.hand`).
- Added an explicit compact fallback `@media (max-width: 430px)` that restores horizontal scroll + snap behavior for very narrow screens.

### Testing
- No automated tests were run for this HTML/CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfab252548326bc652a38008553ef)