### PR TITLE
Deterministic lower-band two-column HUD layout

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -945,6 +945,9 @@ window.CONFIG = {
     bottomButtons: {
       width: 180,
       height: 100,
+      handHeight: 62,
+      lowerBandGap: 8,
+      challengePaneWidth: 180,
       edgeHeight: 47,
       apexHeight: 70,
       offsetY: 0,

--- a/docs/index.html
+++ b/docs/index.html
@@ -380,15 +380,21 @@
             <div class="joystick-stick" id="joystickStick"></div>
           </div>
 
-          <!-- Action Buttons -->
-          <div class="action-buttons curved-hud" aria-hidden="false">
-            <svg class="action-hud-bg" width="100%" height="100%" viewBox="0 0 360 200" preserveAspectRatio="none" aria-hidden="true" focusable="false">
-              <path class="action-hud-path" d="M0 140 Q180 60 360 140 L360 200 L0 200 Z"></path>
-            </svg>
-            <button type="button" id="btnJump" class="action-btn jump">↑</button>
-            <button type="button" id="btnAttackA" class="action-btn attack-a ability-small">A</button>
-            <button type="button" id="btnAttackB" class="action-btn attack-b ability-small">B</button>
-            <button type="button" id="btnAttackC" class="action-btn attack-c">C</button>
+          <div class="lower-band" id="lowerBand">
+            <div class="action-stack" id="actionStack">
+              <!-- Action Buttons -->
+              <div class="action-buttons curved-hud" aria-hidden="false">
+                <svg class="action-hud-bg" width="100%" height="100%" viewBox="0 0 360 200" preserveAspectRatio="none" aria-hidden="true" focusable="false">
+                  <path class="action-hud-path" d="M0 140 Q180 60 360 140 L360 200 L0 200 Z"></path>
+                </svg>
+                <button type="button" id="btnJump" class="action-btn jump">↑</button>
+                <button type="button" id="btnAttackA" class="action-btn attack-a ability-small">A</button>
+                <button type="button" id="btnAttackB" class="action-btn attack-b ability-small">B</button>
+                <button type="button" id="btnAttackC" class="action-btn attack-c">C</button>
+              </div>
+              <div class="hand-card-container" id="handCardContainer" aria-live="polite"></div>
+            </div>
+            <div class="challenge-prompt-pane is-empty" id="challengePromptPane" aria-live="polite"></div>
           </div>
         </div>
       </div>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -2017,6 +2017,7 @@ const fullscreenBtn = $$('#btnFullscreen');
 const actionButtonsContainer = document.querySelector('.controls-overlay .action-buttons');
 const actionHudSvg = actionButtonsContainer?.querySelector('.action-hud-bg');
 const actionHudPath = actionButtonsContainer?.querySelector('.action-hud-path');
+const challengePromptPane = document.getElementById('challengePromptPane');
 const actionButtonRefs = {
   jump: document.getElementById('btnJump'),
   attackA: document.getElementById('btnAttackA'),
@@ -2033,6 +2034,17 @@ const hudLayout = createHudLayoutController({
 });
 const playerStatsEvents = window.GAME.playerStatsEvents || new EventTarget();
 window.GAME.playerStatsEvents = playerStatsEvents;
+
+function setChallengePromptPane(content = '') {
+  if (!challengePromptPane) return;
+  const hasContent = typeof content === 'string' && content.trim().length > 0;
+  challengePromptPane.textContent = hasContent ? content.trim() : '';
+  challengePromptPane.classList.toggle('is-empty', !hasContent);
+}
+
+window.GAME.ui = window.GAME.ui || {};
+window.GAME.ui.setChallengePromptPane = setChallengePromptPane;
+setChallengePromptPane('');
 let resourceBarConfig = hudLayout.getResourceBarConfig();
 resourceBarLayer.setBars(resourceBarConfig);
 const fpsHud = $$('#fpsHud');

--- a/docs/js/hud-layout.js
+++ b/docs/js/hud-layout.js
@@ -17,6 +17,9 @@ export const DEFAULT_BOTTOM_BUTTON_ACTIONS = {
 export const DEFAULT_BOTTOM_HUD_CONFIG = {
   width: 360,
   height: 200,
+  handHeight: 124,
+  lowerBandGap: 14,
+  challengePaneWidth: 300,
   edgeHeight: 90,
   apexHeight: 140,
   offsetY: 0,
@@ -143,6 +146,9 @@ export function computeBottomHudConfig(raw = null, defaults = DEFAULT_BOTTOM_HUD
   const src = raw || window.CONFIG?.hud?.bottomButtons || {};
   const width = clampNumber(coerceNumber(src.width, defaults.width), 220, 720);
   const height = clampNumber(coerceNumber(src.height, defaults.height), 140, 320);
+  const handHeight = clampNumber(coerceNumber(src.handHeight, defaults.handHeight), 60, 360);
+  const lowerBandGap = clampNumber(coerceNumber(src.lowerBandGap, defaults.lowerBandGap), 0, 60);
+  const challengePaneWidth = clampNumber(coerceNumber(src.challengePaneWidth, defaults.challengePaneWidth), 120, 640);
   const edgeHeight = clampNumber(coerceNumber(src.edgeHeight, defaults.edgeHeight), 24, height);
   const apexHeight = clampNumber(coerceNumber(src.apexHeight, defaults.apexHeight), edgeHeight + 8, height + 220);
   const offsetY = coerceNumber(src.offsetY, defaults.offsetY) || 0;
@@ -150,7 +156,20 @@ export function computeBottomHudConfig(raw = null, defaults = DEFAULT_BOTTOM_HUD
   const scaleWithActor = src.scaleWithActor !== false;
   const buttons = normalizeButtonLayout(src.buttons || src.buttonLayout || {}, defaults.buttons);
   const actions = { ...defaults.actions, ...(src.actions || {}) };
-  return { width, height, edgeHeight, apexHeight, offsetY, scale, scaleWithActor, buttons, actions };
+  return {
+    width,
+    height,
+    handHeight,
+    lowerBandGap,
+    challengePaneWidth,
+    edgeHeight,
+    apexHeight,
+    offsetY,
+    scale,
+    scaleWithActor,
+    buttons,
+    actions,
+  };
 }
 
 export function applyBottomHudCss(config, rootElement = typeof document !== 'undefined' ? document.documentElement : null) {
@@ -158,6 +177,9 @@ export function applyBottomHudCss(config, rootElement = typeof document !== 'und
   const root = rootElement.style;
   root.setProperty('--hud-panel-width', `${config.width}px`);
   root.setProperty('--hud-panel-height', `${config.height}px`);
+  root.setProperty('--hud-hand-height', `${config.handHeight}px`);
+  root.setProperty('--hud-lower-band-gap', `${config.lowerBandGap}px`);
+  root.setProperty('--challenge-pane-width', `${config.challengePaneWidth}px`);
   root.setProperty('--hud-panel-offset-y', `${config.offsetY}px`);
   const buttonSize = Math.max(54, config.height * 0.45);
   root.setProperty('--hud-button-diameter', `${buttonSize}px`);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -10,9 +10,22 @@
   --actor-scale:1;
   --hud-panel-scale:1;
   --control-scale-base:clamp(0.62,2.4vw,0.85);
-  --control-scale:calc(var(--control-scale-base) * var(--actor-scale) * var(--hud-panel-scale));
+  --controls-scale-base:var(--control-scale-base);
+  --controls-scale: max(
+    calc(var(--controls-scale-base) * 0.5),
+    calc(var(--controls-scale-base) * var(--actor-scale) * var(--hud-panel-scale))
+  );
+  --hand-scale-base:1;
+  --hand-scale: max(
+    calc(var(--hand-scale-base) * 0.5),
+    calc(var(--hand-scale-base) * var(--actor-scale) * var(--hud-panel-scale))
+  );
+  --control-scale:var(--controls-scale);
   --hud-panel-width:360px;
   --hud-panel-height:200px;
+  --hud-hand-height:124px;
+  --hud-lower-band-gap:14px;
+  --challenge-pane-width:clamp(220px, 24vw, 360px);
   --hud-panel-offset-y:0px;
   --hud-button-diameter:82px;
   --resource-bar-bg:rgba(5,7,11,0.78);
@@ -852,18 +865,72 @@ canvas#game{
 }
 
 .action-buttons{
-  position:absolute;
+  position:relative;
   display:none;
   width:var(--hud-panel-width);
   height:var(--hud-panel-height);
   pointer-events:none;
 }
 
-.curved-hud{
+.lower-band{
+  position:absolute;
   left:50%;
   bottom:calc(var(--stage-bottom-offset) + var(--hud-panel-offset-y));
-  transform:translateX(-50%) scale(var(--control-scale));
+  transform:translateX(-50%);
+  display:none;
+  grid-template-columns:auto minmax(0, var(--challenge-pane-width));
+  gap:var(--hud-lower-band-gap);
+  align-items:end;
+  z-index:5;
+  pointer-events:none;
+}
+
+.action-stack{
+  width:calc(var(--hud-panel-width) * var(--controls-scale));
+  display:grid;
+  grid-template-rows:calc(var(--hud-panel-height) * var(--controls-scale)) calc(var(--hud-hand-height) * var(--hand-scale));
+  justify-items:center;
+  align-items:end;
+}
+
+.action-stack .action-buttons{
+  width:var(--hud-panel-width);
+  height:var(--hud-panel-height);
+  transform:scale(var(--controls-scale));
   transform-origin:bottom center;
+}
+
+.hand-card-container{
+  width:calc(var(--hud-panel-width) * var(--controls-scale));
+  min-height:calc(var(--hud-hand-height) * var(--hand-scale));
+  border-radius:14px;
+  border:1px dashed rgba(148,163,184,0.22);
+  background:rgba(9,11,18,0.35);
+  backdrop-filter:blur(6px);
+}
+
+.challenge-prompt-pane{
+  width:100%;
+  min-height:calc((var(--hud-panel-height) * var(--controls-scale)) + (var(--hud-hand-height) * var(--hand-scale)));
+  border-radius:14px;
+  border:1px solid rgba(148,163,184,0.24);
+  background:linear-gradient(160deg, rgba(15,23,42,0.62), rgba(2,6,23,0.42));
+  box-shadow:0 14px 30px rgba(0,0,0,0.28);
+  padding:12px;
+}
+
+.challenge-prompt-pane.is-empty{
+  padding:0;
+}
+
+.lower-band > *{
+  pointer-events:auto;
+}
+
+.curved-hud{
+  left:auto;
+  bottom:auto;
+  transform:none;
   z-index:5;
 }
 
@@ -942,8 +1009,7 @@ canvas#game{
 
 .interact-btn:active{transform:scale(0.95);background:rgba(34,197,94,0.36);}
 
-.controls-overlay .joystick-area{left:0;bottom:0;transform:scale(var(--control-scale));transform-origin:center;}
-.controls-overlay .action-buttons{left:50%;right:auto;bottom:calc(var(--stage-bottom-offset) + var(--hud-panel-offset-y));transform:translateX(-50%) scale(var(--control-scale));transform-origin:bottom center;}
+.controls-overlay .joystick-area{left:0;bottom:0;transform:scale(var(--controls-scale));transform-origin:center;}
 .controls-overlay .interact-btn{right:var(--controls-gap);bottom:calc(var(--stage-bottom-offset) + var(--hud-panel-offset-y) + (var(--hud-panel-height) * var(--control-scale)) + (var(--interact-gap) * var(--control-scale)));transform:scale(var(--control-scale));transform-origin:bottom right;}
 
 @supports not (bottom:calc(10px * 0.5)){
@@ -951,7 +1017,7 @@ canvas#game{
 }
 
 @supports (padding:max(0px)){
-  .controls-overlay .action-buttons{
+  .controls-overlay .lower-band{
     bottom:calc(var(--stage-bottom-offset) + var(--hud-panel-offset-y) + env(safe-area-inset-bottom,0px));
   }
   .controls-overlay .interact-btn{
@@ -962,10 +1028,12 @@ canvas#game{
 /* Touch visibility helpers */
 @media (hover:none), (max-width:768px){
   .joystick-area{display:block;}
+  .lower-band{display:grid;}
   .action-buttons{display:block;}
   .interact-btn{display:block;}
 }
 .is-touch .joystick-area{display:block;}
+.is-touch .lower-band{display:grid;}
 .is-touch .action-buttons{display:block;}
 .is-touch .interact-btn{display:block;}
 


### PR DESCRIPTION
### Motivation
- Provide a deterministic, config-driven two-column HUD band that groups action controls and a challenge/prompt pane to prevent layout shifts and make sizing predictable.
- Tie visual sizes to contract variables so controls and hand/card areas scale with actor/hud scales while enforcing a minimum to avoid collapse.

### Description
- Added a new `lower-band` structure in `docs/index.html` containing a left `action-stack` (`action-buttons` over `hand-card-container`) and a right `challenge-prompt-pane` placeholder to keep footprint stable when inactive.
- Introduced clamped contract vars `--controls-scale` and `--hand-scale` (alias `--control-scale` preserved) and used them to size the action area and hand card so both share the same parent width constraints in `docs/styles.css`.
- Extended HUD config plumbing in `docs/js/hud-layout.js` with `handHeight`, `lowerBandGap`, and `challengePaneWidth` and applied those as CSS variables via `applyBottomHudCss` so layout is configurable from `window.CONFIG.hud.bottomButtons`.
- Added an app API `window.GAME.ui.setChallengePromptPane()` in `docs/js/app.js` which toggles the `.is-empty` state while preserving the empty pane footprint to avoid visual shifts.

### Testing
- Ran `node --check docs/js/hud-layout.js` which completed without errors.
- Ran `node --check docs/js/app.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df1aeac2f0832682c5c3abe734a312)