### PR TITLE
Partition right column into sidebar top and human-seat bottom

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -152,8 +152,8 @@
       grid-template-areas:
         "topbar   sidebar"
         "panel    sidebar"
-        "action   sidebar"
-        "log      sidebar";
+        "action   human"
+        "log      right-gap";
       gap: var(--layout-app-gap);
       padding: var(--layout-app-padding) var(--layout-app-padding) calc(var(--layout-app-padding) + var(--safe));
     }
@@ -289,8 +289,25 @@
       display: flex;
       flex-direction: column;
       gap: 8px;
+      max-height: 100%;
       overflow-y: auto;
+      overflow-x: hidden;
       min-height: 0;
+    }
+
+    .humanSeatZone {
+      grid-area: human;
+      min-height: 0;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      justify-content: stretch;
+    }
+
+    .rightGap {
+      grid-area: right-gap;
+      min-height: 0;
+      pointer-events: none;
     }
 
     .aiSeat {
@@ -321,7 +338,7 @@
       border-radius: 8px;
     }
     .humanSeatCard {
-      margin-top: 8px;
+      height: 100%;
       background: linear-gradient(170deg, rgba(67,49,43,0.95), rgba(50,37,33,0.98));
       border: 1px solid rgba(242,208,143,0.28);
       border-radius: 16px;
@@ -835,15 +852,17 @@
         grid-template-rows:
           auto
           minmax(0, calc(var(--layout-table-dominance-frac) * 1fr))
+          minmax(0, auto)
+          minmax(0, auto)
           minmax(0, var(--layout-action-column-max-height))
-          minmax(0, var(--layout-log-max-row-height))
-          minmax(0, auto);
+          minmax(0, var(--layout-log-max-row-height));
         grid-template-areas:
           "topbar"
           "panel"
+          "sidebar"
+          "human"
           "action"
-          "log"
-          "sidebar";
+          "log";
       }
       .handWrap {
         max-width: 100%;
@@ -1505,6 +1524,7 @@
           baseScale: scratchbonesGameConfig.layout?.cards?.baseScale ?? 0.25,
         },
         sizing: {
+          sidebarWidthFrac: scratchbonesGameConfig.layout?.sizing?.sidebarWidthFrac ?? scratchbonesLegacyGameplayConfig.sidebarWidthFrac ?? 0.75,
           sidebarWidthPx: scratchbonesGameConfig.layout?.sizing?.sidebarWidthPx ?? scratchbonesLegacyGameplayConfig.sidebarWidthPx ?? 280,
           appGapPx: scratchbonesGameConfig.layout?.sizing?.appGapPx ?? scratchbonesLegacyGameplayConfig.appGapPx ?? 8,
           appPaddingPx: scratchbonesGameConfig.layout?.sizing?.appPaddingPx ?? scratchbonesLegacyGameplayConfig.appPaddingPx ?? 8,
@@ -3431,7 +3451,15 @@
       const setCssVar = (name, value) => {
         for (const target of cssTargets) target.style.setProperty(name, value);
       };
-      const sidebarWidthPx = clampNumber(Number(layoutSizing.sidebarWidthPx) || 280, 180, 520);
+      const appWidthPx = Math.max(320, Number(app?.clientWidth) || Number(window?.innerWidth) || 0);
+      const sidebarWidthFracRaw = Number(layoutSizing.sidebarWidthFrac);
+      const sidebarWidthFrac = Number.isFinite(sidebarWidthFracRaw)
+        ? clampNumber(sidebarWidthFracRaw, 0.25, 0.9)
+        : null;
+      const sidebarWidthTargetPx = sidebarWidthFrac !== null
+        ? appWidthPx * sidebarWidthFrac
+        : (Number(layoutSizing.sidebarWidthPx) || 280);
+      const sidebarWidthPx = clampNumber(sidebarWidthTargetPx, 180, Math.max(220, appWidthPx - 140));
       const appGapPx = clampNumber(Number(layoutSizing.appGapPx) || 8, 0, 40);
       const appPaddingPx = clampNumber(Number(layoutSizing.appPaddingPx) || 8, 0, 48);
       const seatAvatarPx = clampNumber(Number(layoutSizing.seatAvatarPx) || 132, 72, 280);
@@ -3697,6 +3725,20 @@
           `).join('')}
         </div>
 
+        <div class="humanSeatZone fit-target fit-0" data-proj-id="human-seat-zone">
+          <div class="humanSeatCard ${player.eliminated ? 'eliminated' : ''}" data-proj-id="human-seat">
+            <div class="seatInfo">
+              <div class="seatName">${seatLabel(player)}</div>
+              <div class="seatMeta">Cards ${player.hand.length} · Clears ${player.clears}</div>
+              <div class="seatStatus">${player.lastAction}</div>
+            </div>
+            <div class="seatAvatarBox" data-proj-id="avatar-human">
+              <canvas class="seatPortrait" data-seat-id="0" width="220" height="220"></canvas>
+            </div>
+            <div class="humanSeatChipBadge">Chips ${player.chips}</div>
+          </div>
+        </div>
+
         <div class="panel" data-proj-id="panel">
           <div class="tableView fit-target fit-0" data-proj-id="table-view">
             <div class="tableViewHeader">
@@ -3799,17 +3841,6 @@
               `;
               }).join('')}
             </div>
-            <div class="humanSeatCard ${player.eliminated ? 'eliminated' : ''}" data-proj-id="human-seat">
-              <div class="seatInfo">
-                <div class="seatName">${seatLabel(player)}</div>
-                <div class="seatMeta">Cards ${player.hand.length} · Clears ${player.clears}</div>
-                <div class="seatStatus">${player.lastAction}</div>
-              </div>
-              <div class="seatAvatarBox" data-proj-id="avatar-human">
-                <canvas class="seatPortrait" data-seat-id="0" width="220" height="220"></canvas>
-              </div>
-              <div class="humanSeatChipBadge">Chips ${player.chips}</div>
-            </div>
           </div>
         </div>
 
@@ -3817,6 +3848,8 @@
           <div class="sectionTitle">Recent events</div>
           ${recentLogs.map(item => `<div class="logItem">${escapeHtml(item.text)}</div>`).join('')}
         </div>
+
+        <div class="rightGap" aria-hidden="true"></div>
       `;
 
       if (state.declaredRank !== null) {

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -36,6 +36,7 @@ window.SCRATCHBONES_CONFIG.game = {
       baseScale: __existingGameConfig.layout?.cards?.baseScale ?? 0.25,
     },
     sizing: {
+      sidebarWidthFrac: __existingGameConfig.layout?.sizing?.sidebarWidthFrac ?? __legacyGameplayConfig.sidebarWidthFrac ?? 0.75,
       sidebarWidthPx: __existingGameConfig.layout?.sizing?.sidebarWidthPx ?? __legacyGameplayConfig.sidebarWidthPx ?? 280,
       appGapPx: __existingGameConfig.layout?.sizing?.appGapPx ?? __legacyGameplayConfig.appGapPx ?? 8,
       appPaddingPx: __existingGameConfig.layout?.sizing?.appPaddingPx ?? __legacyGameplayConfig.appPaddingPx ?? 8,


### PR DESCRIPTION
### Motivation
- Make the right rail a partitioned column so the AI sidebar scrolls independently above an explicit human-seat bottom zone and align the human-seat height with the action column row.
- Allow layout authors to prefer a fractional sidebar width (75% baseline) instead of a hard px value, and ensure the sidebar ends above the human-seat zone with internal scrolling.

### Description
- Added `layout.sizing.sidebarWidthFrac` (default `0.75`) to both `docs/config/scratchbones-config.js` and the in-page layout bootstrap so the layout can use a fractional sidebar width with a px fallback.
- Updated `applyLayoutContract()` in `ScratchbonesBluffGame.html` to compute `--layout-sidebar-width` from `sidebarWidthFrac` (clamped, with px fallback) using the app width as the reference.
- Reworked `#app` grid areas to partition the right column into `sidebar` (top), `human` (bottom human-seat zone) and a `right-gap` spacer, and added `.humanSeatZone` and `.rightGap` DOM/CSS rules.
- Moved the human seat card out of `.handWrap` into the new `.humanSeatZone` and constrained `#aiSidebar` with `max-height: 100%` and `overflow-y: auto` so only the sidebar scrolls internally.

### Testing
- Ran `node --check docs/config/scratchbones-config.js`, which succeeded.
- Ran `npm run lint -- docs/config/scratchbones-config.js`, which reported a pre-existing repo lint error (failure) in `src/map/builderConversion.js` (`resolveGridUnit` is undefined) and a warning that the config file is ignored by the lint patterns, so the lint run did not pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df25b3ca2c83269f6f5de65f4be3bb)