### PR TITLE
[PR #902 follow-up] Prevent human-seat clipping in fixed-height right-rail row

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -298,7 +298,8 @@
     .humanSeatZone {
       grid-area: human;
       min-height: 0;
-      overflow: hidden;
+      overflow-y: auto;
+      overflow-x: hidden;
       display: flex;
       flex-direction: column;
       justify-content: stretch;
@@ -338,7 +339,6 @@
       border-radius: 8px;
     }
     .humanSeatCard {
-      height: 100%;
       background: linear-gradient(170deg, rgba(67,49,43,0.95), rgba(50,37,33,0.98));
       border: 1px solid rgba(242,208,143,0.28);
       border-radius: 16px;


### PR DESCRIPTION
### Motivation
- Fix a regression where the human-seat card (avatar/chip) could be clipped by the new fixed-height right-column `human` grid row after partitioning the right rail.

### Description
- Updated `.humanSeatZone` in `ScratchbonesBluffGame.html` to `overflow-y: auto` and `overflow-x: hidden` so the human-seat zone can scroll vertically when its content exceeds the capped row height.
- Removed the forced `height: 100%` from `.humanSeatCard` in `ScratchbonesBluffGame.html` so the card sizes to its intrinsic content instead of being compressed by the grid row.

### Testing
- Ran `npm run lint -- ScratchbonesBluffGame.html`, which showed a warning that the HTML file is ignored by the ESLint config and reported a pre-existing lint error in `src/map/builderConversion.js` (`resolveGridUnit` is not defined); no new lint errors were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df71da8a04832698307d5960d3e43c)