### PR TITLE
Follow-up: stop fail-safe panel collapse once overlaps are resolved

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -3412,7 +3412,9 @@
     function tryCollapseNonCriticalPanels(rootEl, overlapPolicy, overlaps) {
       const preserve = new Set(overlapPolicy.preserveRegions || []);
       const collapsed = [];
+      let activeOverlaps = Array.isArray(overlaps) ? overlaps : [];
       for (const selector of overlapPolicy.collapseOrder || []) {
+        if (!activeOverlaps.length) break;
         const node = rootEl.querySelector(selector);
         if (!node || node.dataset.layoutCollapsed === 'true') continue;
         const regionEntry = Object.entries(overlapPolicy.criticalRegions || {}).find(([, mappedSelector]) => mappedSelector === selector);
@@ -3422,9 +3424,10 @@
         node.dataset.layoutCollapsed = 'true';
         node.style.setProperty('display', 'none');
         collapsed.push({ selector, regionKey: regionKey || null });
-        if (overlaps.length === 0) break;
+        const updatedRegions = collectCriticalRegionRects(rootEl, overlapPolicy);
+        activeOverlaps = detectCriticalOverlaps(updatedRegions, overlapPolicy.tolerancePx);
       }
-      return collapsed;
+      return { collapsed, overlaps: activeOverlaps };
     }
 
     function fitContainer(rootEl, policy) {
@@ -3537,9 +3540,11 @@
         });
       }
 
-      const collapsed = overlaps.length
+      const collapseResult = overlaps.length
         ? tryCollapseNonCriticalPanels(rootEl, overlapPolicy, overlaps)
-        : [];
+        : { collapsed: [], overlaps };
+      const collapsed = collapseResult.collapsed;
+      overlaps = collapseResult.overlaps;
       if (collapsed.length) {
         regions = collectCriticalRegionRects(rootEl, overlapPolicy);
         overlaps = detectCriticalOverlaps(regions, overlapPolicy.tolerancePx);


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where the fail-safe collapse path hid every panel because overlaps were not recomputed after each collapse, causing unnecessary UI removals on constrained screens.
- Ensure the staged layout fallback preserves critical regions and stops collapsing once conflicts are resolved so the UI remains usable on small viewports.

### Description
- Recomputed overlap state inside `tryCollapseNonCriticalPanels` after each panel is hidden and short-circuited the loop when no overlaps remain to avoid hiding additional panels. 
- Changed `tryCollapseNonCriticalPanels` to return a structured result `{ collapsed, overlaps }` instead of only returning `collapsed` so callers receive the updated overlap state. 
- Updated `fitContainer` to consume the new collapse result and propagate the post-collapse `overlaps` into the final overlap diagnostics and snapshot.

### Testing
- Ran `npm run lint` which failed due to a pre-existing unrelated lint error in `src/map/builderConversion.js` (`resolveGridUnit` is not defined), so lint did not pass but the failure is unrelated to these changes. 
- No automated UI/browser screenshot tests were executed in this environment; the change is covered by the overlap diagnostics emitted to the debug snapshot for manual verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df71e28e9883269dcc91142702b0fe)