### PR TITLE
Restore mobile HUD control scaling breakpoints

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1696,7 +1696,7 @@ canvas#game{
 }
 
 @media (max-width: 960px){
-  :root{--control-scale:clamp(0.58,4vw,0.75);--stage-bottom-offset:clamp(12px,3vw,20px);}
+  :root{--control-scale-base:clamp(0.58,4vw,0.75);--stage-bottom-offset:clamp(12px,3vw,20px);}
 }
 
 @media (max-width: 768px){
@@ -1705,7 +1705,7 @@ canvas#game{
 }
 
 @media (max-width: 520px){
-  :root{--control-scale:0.62;--stage-bottom-offset:clamp(10px,3vh,18px);}
+  :root{--control-scale-base:0.62;--stage-bottom-offset:clamp(10px,3vh,18px);}
   .health-bar,.stamina-bar{width:200px;}
   .top-ui{left:12px;right:auto;}
 }


### PR DESCRIPTION
### Motivation
- Fix a regression where small-screen media queries continued to override `--control-scale` while joystick and lower-band controls now scale from `--controls-scale`, causing oversized controls on narrow viewports in `docs/styles.css`.

### Description
- Updated `docs/styles.css` mobile media queries at `@media (max-width: 960px)` and `@media (max-width: 520px)` to set `--control-scale-base` (the base variable) instead of directly overriding `--control-scale`, which restores expected shrink behavior for `--controls-scale` and the interact button.

### Testing
- Ran `node --check docs/js/hud-layout.js` and `node --check docs/js/app.js`, both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df71e8e6f08326a51b2e2474b6de6f)