### PR TITLE
Fix hand card art scaling so PNGs shrink to fit card UI

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -583,7 +583,7 @@
       align-items: stretch;
       justify-content: stretch;
       position: relative;
-      overflow: visible;
+      overflow: hidden;
       isolation: isolate;
     }
 
@@ -607,7 +607,8 @@
     .cardArt {
       width: 100%;
       height: 100%;
-      object-fit: cover;
+      object-fit: contain;
+      object-position: center;
       display: block;
       border-radius: 0;
       pointer-events: none;


### PR DESCRIPTION
### Motivation
- Card art PNGs were being cropped or visually spilling outside the UI because the card container allowed visible overflow and the image used `object-fit: cover`, so images didn't reliably scale to the card bounds.

### Description
- Updated CSS in `ScratchbonesBluffGame.html` to set `.card { overflow: hidden; }` and change `.cardArt` from `object-fit: cover` to `object-fit: contain` with `object-position: center`, ensuring PNGs shrink to fit and are centered inside each card.

### Testing
- Ran `npm run -s test -- tests/no-conflicts.test.js` which failed due to a pre-existing lint error unrelated to this change (`src/map/builderConversion.js: resolveGridUnit is not defined`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa705a5208326ad7965ac3a3df57d)