### PR TITLE
Fix table auto-fit downscaling in Scratchbones layout

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -4501,7 +4501,7 @@
       const availableHeight = Math.max(1, cardsContainer.clientHeight);
       const gap = Number.parseFloat(getComputedStyle(cardsContainer).gap) || 0;
       const cardCount = cards.length;
-      let bestScale = 1;
+      let bestScale = 0;
       for (let rows = 1; rows <= cardCount; rows++) {
         const cols = Math.ceil(cardCount / rows);
         const requiredWidth = cols * cardWidth + Math.max(0, cols - 1) * gap;


### PR DESCRIPTION
### Motivation
- The table auto-fit logic could never choose a scale below `1.0` because `bestScale` was initialized to `1`, so overflow cases were ignored and cards could still overflow in small viewports or large piles.

### Description
- In `ScratchbonesBluffGame.html` I changed `updateTableCardAutoScale` to initialize `bestScale` to `0` (allowing the loop to pick a shrink candidate) and preserved the existing clamp of `0.35` to `1` when writing `--layout-table-card-auto-scale`.

### Testing
- Ran `git diff --check` to validate the patch formatting and it returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00d8aa61483269a58d24a9b842313)