### PR TITLE
Fix ScratchbonesBluffGame CSS grid-template-areas for responsive layouts

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -164,10 +164,10 @@
         minmax(0, min(var(--layout-action-column-max-height), calc((1 - var(--layout-table-dominance-frac)) * 100dvh)))
         minmax(0, min(var(--layout-log-max-row-height), calc((1 - var(--layout-table-dominance-frac)) * 100dvh)));
       grid-template-areas:
-        "topbar   sidebar"
-        "panel    sidebar"
-        "context  human"
-        "log      human";
+        "topbar  topbar  sidebar"
+        "panel   panel   sidebar"
+        "context context human"
+        "log     log     human";
       gap: var(--layout-app-gap);
       padding: var(--layout-app-padding) var(--layout-app-padding) calc(var(--layout-app-padding) + var(--safe));
     }
@@ -883,6 +883,11 @@
     @container (max-width: 980px) {
       #app {
         grid-template-columns: minmax(0, 1fr) minmax(120px, 0.42fr);
+        grid-template-areas:
+          "topbar  sidebar"
+          "panel   sidebar"
+          "context human"
+          "log     human";
       }
       .handScroll {
         --hand-card-min: clamp(72px, 18vw, 92px);
@@ -895,7 +900,6 @@
         grid-template-rows:
           auto
           minmax(0, calc(var(--layout-table-dominance-frac) * 1fr))
-          minmax(0, auto)
           minmax(0, auto)
           minmax(0, auto)
           minmax(0, var(--layout-action-column-max-height))


### PR DESCRIPTION
### Motivation
- Correct CSS grid-template area mismatches that caused the desktop layout to parse incorrectly and drop named grid placements.
- Ensure each responsive breakpoint has a valid `grid-template-areas` map that matches the defined columns/rows so components place reliably.

### Description
- Updated `ScratchbonesBluffGame.html` to declare three columns in the default `#app` `grid-template-areas`, so `topbar`, `panel`, `context`, `log`, `sidebar`, and `human` placements map correctly.
- Added an explicit two-column `grid-template-areas` override for the `@container (max-width: 980px)` breakpoint to keep named areas valid when columns reduce.
- Fixed the `@container (max-width: 760px)` breakpoint by removing an extra `grid-template-rows` entry so the row count matches the `grid-template-areas` declarations.
- No gameplay logic was changed; this is a layout-only fix to the HTML/CSS structure in `ScratchbonesBluffGame.html`.

### Testing
- Ran `npm run lint`; lint finished but overall script returned non-zero due to a pre-existing unrelated lint error in `src/map/builderConversion.js` (`resolveGridUnit` is not defined), so no new lint errors were introduced by this change.
- Verified the edited `ScratchbonesBluffGame.html` now contains consistent `grid-template-areas` for desktop and the two responsive breakpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00e64ac708326963245c1a8504045)