### PR TITLE
Lock gameplay stage to 16:9 with uniform viewport fit

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1604,9 +1604,9 @@ if (cv) cv.style.background = 'transparent';
 // - Canvas element's width and height attributes
 // This ensures aspect ratio consistency across config, CSS, and canvas.
 (function syncCanvasDimensions() {
-  // Default fallback values (matching original hardcoded values)
-  const DEFAULT_WIDTH = 720;
-  const DEFAULT_HEIGHT = 460;
+  // Default fallback values (matches CONFIG.canvas default 16:9 gameplay layout)
+  const DEFAULT_WIDTH = 1280;
+  const DEFAULT_HEIGHT = 720;
   
   // Read dimensions from CONFIG.canvas
   let canvasWidth = DEFAULT_WIDTH;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -441,7 +441,7 @@ main.stack{
   padding:var(--pad);
 }
 
-/* In landscape orientation: lock to container width, maintain aspect ratio */
+/* In landscape orientation: hide non-game widgets for focused gameplay */
 @media (orientation: landscape) {
   :root{
     --control-scale-base:clamp(0.75,2.8vw,1.0);
@@ -473,10 +473,13 @@ main.stack{
   }
 
   .stage{
-    /* Lock width to 100vw to match container, calculate height from aspect ratio */
-    width:100vw !important;
+    /*
+      Keep a fixed aspect ratio and uniformly scale to fit the screen.
+      This avoids stretching/cropping when viewport aspect is not equal to game aspect.
+    */
+    width:min(100vw,calc(100vh * var(--stage-aspect-width) / var(--stage-aspect-height))) !important;
     max-width:100vw !important;
-    height:calc(100vw * var(--stage-aspect-height) / var(--stage-aspect-width)) !important;
+    height:auto !important;
     max-height:100vh !important;
     margin:0 !important;
     border-radius:0;
@@ -502,8 +505,8 @@ main.stack{
 
 .stage{
   /* Default fallback values - dynamically overridden by app.js from CONFIG.canvas */
-  --stage-aspect-width:720;
-  --stage-aspect-height:460;
+  --stage-aspect-width:1280;
+  --stage-aspect-height:720;
   /* Max height allows stage to scale responsively while maintaining aspect ratio */
   --stage-max-height:min(96vh,1200px);
   position:relative;
@@ -520,13 +523,11 @@ main.stack{
   place-items:center;
 }
 
-/* In fullscreen, use all available space */
+/* In fullscreen, preserve fixed aspect ratio and uniformly fit viewport */
 .stage:fullscreen{
-  --stage-max-height:100vh;
-  width:100vw !important;
+  width:min(100vw,calc(100vh * var(--stage-aspect-width) / var(--stage-aspect-height))) !important;
   max-width:100vw !important;
-  height:100vh !important;
-  aspect-ratio:auto !important;
+  max-height:100vh !important;
   border-radius:0;
   outline:none;
 }


### PR DESCRIPTION
### Motivation
- Ensure the game viewport always preserves a 16:9 gameplay layout and scales uniformly to fit the device screen without stretching or cropping.
- Make default in-repo fallbacks consistent with the game's intended 16:9 canvas size so CSS and JS defaults match runtime `CONFIG.canvas`.

### Description
- Updated `.stage` sizing in `docs/styles.css` so the stage uses a uniform fit: `width: min(100vw, calc(100vh * aspect))` and `height: auto`, preserving aspect ratio instead of forcing `100vw` first.
- Changed landscape media-query comment and behavior to hide non-game widgets while using the fixed-aspect fit instead of the previous width-first calculation.
- Preserved the same fixed-aspect fit behavior for fullscreen in `docs/styles.css` so fullscreen uniformly fits without arbitrary stretching.
- Aligned JS fallback canvas defaults in `docs/js/app.js` to `1280x720` (16:9) so `syncCanvasDimensions()` and CSS defaults are consistent with `CONFIG.canvas`.

### Testing
- Ran `npm run lint`; the command failed due to a pre-existing unrelated lint error in `src/map/builderConversion.js` (`resolveGridUnit` is not defined), so no clean lint pass was obtained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0106f6f988326b41353daf2e8cb6b)