### PR TITLE
Fix grid unit resolution in map builder conversion

### DIFF
--- a/src/map/builderConversion.js
+++ b/src/map/builderConversion.js
@@ -9,6 +9,7 @@ import {
 const {
   sourceId: SOURCE_ID,
   fallbackBoxMinWidth: FALLBACK_BOX_MIN_WIDTH,
+  defaultGridUnit: DEFAULT_GRID_UNIT,
   tagInstanceIdMapping: TAG_INSTANCE_ID_MAPPING,
 } = mapBuilderConfig;
 
@@ -187,56 +188,6 @@ function resolveInstanceId(rawInstance, context) {
   return { instanceId, source };
 }
 
-function computeColliderBounds(colliders) {
-  if (!Array.isArray(colliders) || colliders.length === 0) {
-    return null;
-  }
-  let minLeft = Infinity;
-  let maxRight = -Infinity;
-  for (const col of colliders) {
-    if (!col || typeof col !== 'object') continue;
-    const left = Number(col.left);
-    const width = Number(col.width);
-    if (!Number.isFinite(left) || !Number.isFinite(width)) continue;
-    const right = left + width;
-    minLeft = Math.min(minLeft, Math.min(left, right));
-    maxRight = Math.max(maxRight, Math.max(left, right));
-  }
-  if (!Number.isFinite(minLeft) || !Number.isFinite(maxRight) || maxRight <= minLeft) {
-    return null;
-  }
-  return { left: minLeft, right: maxRight };
-}
-
-// eslint-disable-next-line no-unused-vars
-function normalizePlayableBounds(rawBounds, colliders = [], warnings = null) {
-  const addWarning = (message) => {
-    if (Array.isArray(warnings)) warnings.push(message);
-  };
-
-  const safe = rawBounds && typeof rawBounds === 'object' ? rawBounds : null;
-  const left = toNumber(safe?.left ?? safe?.min, NaN);
-  const right = toNumber(safe?.right ?? safe?.max, NaN);
-
-  if (Number.isFinite(left) && Number.isFinite(right) && right > left) {
-    return { left, right, source: PLAYABLE_BOUNDS_SOURCE.LAYOUT };
-  }
-
-  if (safe) {
-    addWarning('playableBounds provided but invalid – expected finite left/right');
-  }
-
-  const colliderBounds = computeColliderBounds(colliders);
-  if (colliderBounds) {
-    return { ...colliderBounds, source: PLAYABLE_BOUNDS_SOURCE.COLLIDERS };
-  }
-
-  if (Array.isArray(colliders) && colliders.length) {
-    addWarning('playableBounds unavailable – no usable colliders to derive bounds');
-  }
-  return null;
-}
-
 function validateExplicitGeometry(playableBounds, colliders, warnings = [], { allowDerivedPlayableBounds = false } = {}) {
   if (!playableBounds) {
     warnings.push('Missing playableBounds – provide explicit bounds for geometry service consumption');
@@ -287,7 +238,7 @@ function normalizeMapEntityType(value) {
   return normalized;
 }
 
-function normalizeMapEntities(rawList = [], { gridUnit = 30 } = {}) {
+function normalizeMapEntities(rawList = [], { gridUnit = DEFAULT_GRID_UNIT } = {}) {
   const list = [];
   const byId = new Map();
   rawList.forEach((raw, index) => {
@@ -349,7 +300,7 @@ function mapEntitiesToPathTargets(mapEntities = [], warnings = []) {
     .filter(Boolean);
 }
 
-function mapEntitiesToDoors(mapEntities = [], { gridUnit = 30 } = {}) {
+function mapEntitiesToDoors(mapEntities = [], { gridUnit = DEFAULT_GRID_UNIT } = {}) {
   const doors = [];
   const doorPois = [];
   for (const entity of mapEntities.filter((entry) => entry.kind === 'door')) {
@@ -976,7 +927,7 @@ function normalizeAreaDescriptor(area, options = {}) {
     }))
     .filter(Boolean);
   const rawEntities = Array.isArray(area.entities) ? area.entities : [];
-  const resolvedGridUnit = resolveGridUnit(area) ?? 30;
+  const resolvedGridUnit = resolveGridUnit(area);
   const mapEntities = normalizeMapEntities(rawEntities, { gridUnit: resolvedGridUnit });
   const mapEntitySpawners = mapEntitiesToSpawnerList(mapEntities.list, warnings);
   const mapEntityPathTargets = mapEntitiesToPathTargets(mapEntities.list, warnings);
@@ -1216,7 +1167,7 @@ export function convertLayoutToArea(layout, options = {}) {
     }))
     .filter(Boolean);
   const rawEntities = Array.isArray(layout.entities) ? layout.entities : [];
-  const gridUnit = toNumber(layout.gridUnit ?? layout.meta?.gridUnit, 30);
+  const gridUnit = resolveGridUnit(layout);
   const mapEntities = normalizeMapEntities(rawEntities, { gridUnit });
   const mapEntitySpawners = mapEntitiesToSpawnerList(mapEntities.list, warnings);
   const mapEntityPathTargets = mapEntitiesToPathTargets(mapEntities.list, warnings);
@@ -1627,6 +1578,18 @@ function computeLayerSlotCenters(instances) {
 function toNumber(value, fallback) {
   const num = Number(value);
   return Number.isFinite(num) ? num : fallback;
+}
+
+function resolveGridUnit(layout) {
+  const layoutUnit = toNumber(layout?.gridUnit, undefined);
+  const metaUnit = toNumber(layout?.meta?.gridUnit, undefined);
+  const globalUnit = toNumber(
+    typeof globalThis !== 'undefined'
+      ? (globalThis.GRID_UNIT_WORLD_SIZE ?? globalThis.CONFIG?.map?.gridUnit)
+      : undefined,
+    undefined,
+  );
+  return layoutUnit ?? metaUnit ?? globalUnit ?? DEFAULT_GRID_UNIT;
 }
 
 function clampScale(value, fallback = 1) {

--- a/src/map/mapBuilderConfig.js
+++ b/src/map/mapBuilderConfig.js
@@ -1,5 +1,6 @@
 const DEFAULT_SOURCE_ID = 'map-builder-layered-v15f';
 const DEFAULT_FALLBACK_BOX_MIN_WIDTH = 18;
+const DEFAULT_GRID_UNIT = 30;
 const DEFAULT_TAG_INSTANCE_ID_MAPPING = new Map([
   ['spawn:player', 'player_spawn'],
   ['spawn:npc', 'npc_spawn'],
@@ -22,6 +23,14 @@ const normalizeFallbackWidth = (value) => {
     return Math.max(4, Math.floor(size));
   }
   return DEFAULT_FALLBACK_BOX_MIN_WIDTH;
+};
+
+const normalizeGridUnit = (value) => {
+  const unit = Number(value);
+  if (Number.isFinite(unit) && unit > 0) {
+    return unit;
+  }
+  return DEFAULT_GRID_UNIT;
 };
 
 const normalizeMapping = (rawMapping) => {
@@ -56,6 +65,7 @@ const readRawConfig = () => {
 export const getDefaultMapBuilderConfig = () => ({
   sourceId: DEFAULT_SOURCE_ID,
   fallbackBoxMinWidth: DEFAULT_FALLBACK_BOX_MIN_WIDTH,
+  defaultGridUnit: DEFAULT_GRID_UNIT,
   tagInstanceIdMapping: cloneDefaultMapping(),
 });
 
@@ -68,6 +78,9 @@ export const loadMapBuilderConfig = (rawConfig = readRawConfig()) => {
     fallbackBoxMinWidth: normalizeFallbackWidth(
       config.fallbackBoxMinWidth ?? config.FALLBACK_BOX_MIN_WIDTH,
     ),
+    defaultGridUnit: normalizeGridUnit(
+      config.defaultGridUnit ?? config.gridUnit ?? config.DEFAULT_GRID_UNIT,
+    ),
     tagInstanceIdMapping: normalizeMapping(
       config.tagInstanceIdMapping ?? config.tagToInstanceIdMapping,
     ),
@@ -76,4 +89,3 @@ export const loadMapBuilderConfig = (rawConfig = readRawConfig()) => {
 };
 
 export const mapBuilderConfig = loadMapBuilderConfig();
-


### PR DESCRIPTION
### Motivation
- Make the grid-unit fallback configurable from a single source so map entity sizing does not rely on scattered hardcoded defaults.
- Restore the `resolveGridUnit` path so both layout- and area-side conversion use the same resolution order (`layout.gridUnit` → `layout.meta.gridUnit` → global config → default).
- Remove dead/unused playable-bounds helpers discovered while tracing the grid-unit flow.

### Description
- Add `DEFAULT_GRID_UNIT` and `defaultGridUnit` support in `src/map/mapBuilderConfig.js` and expose a `normalizeGridUnit` to load a central fallback value.
- Wire `defaultGridUnit` into `mapBuilderConfig` so callers get `defaultGridUnit` via the existing `mapBuilderConfig` export.
- Restore `resolveGridUnit(layout)` in `src/map/builderConversion.js` and use it for both area and layout conversion paths instead of ad-hoc `30` fallbacks.
- Update `normalizeMapEntities` and `mapEntitiesToDoors` to default to the centralized `DEFAULT_GRID_UNIT` and replace inline grid-unit lookups with `resolveGridUnit(layout)`.
- Remove unused helper functions (`computeColliderBounds` and `normalizePlayableBounds`) that were no longer referenced after the refactor.

### Testing
- Ran `npm run lint` and the lint pass completed successfully.
- Ran the unit tests `tests/map/builderConversion.test.js` and `tests/map/map-runtime-fix.test.js` via `npm run test:unit` and both suites passed.
- Ran a broader subset of tests (`tests/exposed-alignment-scale.test.js` and `tests/physics-world-width.test.js`) and observed an existing unrelated failure in `tests/physics-world-width.test.js` with `ReferenceError: resolveHorizontalBounds is not defined`, which appears independent of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0195564c48326815024bbf1019f91)