### PR TITLE
Isolate Scratchbones runtime to SCRATCHBONES_CONFIG.game

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -34,7 +34,6 @@
   })();
   </script>
 
-  <script src="docs/config/portrait-config.js"></script>
   <script src="docs/config/scratchbones-config.js"></script>
   <script src="docs/js/portrait-utils.js"></script>
   <style>
@@ -1662,168 +1661,201 @@
     const DEBUG_ENABLED = true;
 
     const scratchbonesRootConfig = window.SCRATCHBONES_CONFIG || {};
-    const scratchbonesGameConfig = scratchbonesRootConfig.game || {};
-    const scratchbonesLegacyGameplayConfig = scratchbonesRootConfig.gameplay || {};
 
-    const SCRATCHBONES_GAME = {
-      deck: {
-        rankCount: scratchbonesGameConfig.deck?.rankCount ?? scratchbonesLegacyGameplayConfig.deckRankCount ?? 10,
-        copiesPerRank: scratchbonesGameConfig.deck?.copiesPerRank ?? scratchbonesLegacyGameplayConfig.deckCopiesPerRank ?? 4,
-        handSize: scratchbonesGameConfig.deck?.handSize ?? scratchbonesLegacyGameplayConfig.startHandSize ?? 10,
-        wildCount: scratchbonesGameConfig.deck?.wildCount ?? scratchbonesLegacyGameplayConfig.wildCount ?? 10,
-        playerCount: scratchbonesGameConfig.deck?.playerCount ?? scratchbonesLegacyGameplayConfig.playerCount ?? 4,
-        humanNames: scratchbonesGameConfig.deck?.humanNames ?? scratchbonesLegacyGameplayConfig.playerNames ?? ['You'],
-      },
-      chips: {
-        startingChips: scratchbonesGameConfig.chips?.starting ?? scratchbonesLegacyGameplayConfig.startingChips ?? 12,
-        challengeBaseTransfer: scratchbonesGameConfig.chips?.challengeBaseTransfer ?? scratchbonesLegacyGameplayConfig.challengeBaseTransfer ?? 1,
-        concedeRoundChipLoss: scratchbonesGameConfig.chips?.concedeRoundChipLoss ?? scratchbonesLegacyGameplayConfig.concedeRoundChipLoss ?? 1,
-        maxRaiseAmount: scratchbonesGameConfig.chips?.raise?.maxAmount ?? scratchbonesLegacyGameplayConfig.maxRaiseAmount ?? 3,
-        maxRaisesPerPlayer: scratchbonesGameConfig.chips?.raise?.maxPerPlayer ?? scratchbonesLegacyGameplayConfig.maxRaisesPerPlayer ?? 3,
-        clearBonusBase: scratchbonesGameConfig.chips?.clearReward?.base ?? scratchbonesLegacyGameplayConfig.clearBonusBase ?? 1,
-        clearBonusIncrement: scratchbonesGameConfig.chips?.clearReward?.increment ?? scratchbonesLegacyGameplayConfig.clearBonusIncrement ?? 1,
-        maxChallengeBet: scratchbonesGameConfig.chips?.maxChallengeBet ?? scratchbonesLegacyGameplayConfig.maxChallengeBet ?? 13,
-      },
-      timers: {
-        challengeTimerSecs: scratchbonesGameConfig.timers?.challengeSeconds ?? scratchbonesLegacyGameplayConfig.challengeTimerSecs ?? 8,
-        aiThinkMs: scratchbonesGameConfig.timers?.aiThinkMs ?? scratchbonesLegacyGameplayConfig.aiThinkMs ?? 650,
-      },
-      layout: {
-        viewport: {
-          widthPx: scratchbonesGameConfig.layout?.viewport?.widthPx,
-          heightPx: scratchbonesGameConfig.layout?.viewport?.heightPx,
+    function reportScratchbonesConfigError(message) {
+      const fullMessage = `[scratchbones config] ${message}`;
+      console.error(fullMessage);
+      const debugBody = document.getElementById('_dbgBody');
+      if (debugBody) {
+        const row = document.createElement('div');
+        row.className = '_dl _dl-error';
+        row.textContent = fullMessage;
+        debugBody.appendChild(row);
+      }
+      const appRoot = document.getElementById('app');
+      if (appRoot) {
+        appRoot.innerHTML = `<div style="padding:16px;background:#2a1414;border:1px solid #c85a5a;border-radius:12px;color:#ffdede;">${escapeHtml(fullMessage)}</div>`;
+      }
+      return fullMessage;
+    }
+
+    function validateScratchbonesGameConfig(rootConfig) {
+      const hasGameConfig = rootConfig && typeof rootConfig.game === 'object' && rootConfig.game !== null;
+      if (hasGameConfig) return true;
+      const message = reportScratchbonesConfigError('Missing required window.SCRATCHBONES_CONFIG.game object from docs/config/scratchbones-config.js.');
+      if (DEBUG_ENABLED) throw new Error(message);
+      return false;
+    }
+
+    function normalizeScratchbonesGameConfig(rawGameConfig = {}) {
+      return {
+        deck: {
+          rankCount: rawGameConfig.deck?.rankCount ?? 10,
+          copiesPerRank: rawGameConfig.deck?.copiesPerRank ?? 4,
+          handSize: rawGameConfig.deck?.handSize ?? 10,
+          wildCount: rawGameConfig.deck?.wildCount ?? 10,
+          playerCount: rawGameConfig.deck?.playerCount ?? 4,
+          humanNames: rawGameConfig.deck?.humanNames ?? ['You'],
         },
-        cards: {
-          baseScale: scratchbonesGameConfig.layout?.cards?.baseScale ?? 0.25,
+        chips: {
+          startingChips: rawGameConfig.chips?.starting ?? 12,
+          challengeBaseTransfer: rawGameConfig.chips?.challengeBaseTransfer ?? 1,
+          concedeRoundChipLoss: rawGameConfig.chips?.concedeRoundChipLoss ?? 1,
+          maxRaiseAmount: rawGameConfig.chips?.raise?.maxAmount ?? 3,
+          maxRaisesPerPlayer: rawGameConfig.chips?.raise?.maxPerPlayer ?? 3,
+          clearBonusBase: rawGameConfig.chips?.clearReward?.base ?? 1,
+          clearBonusIncrement: rawGameConfig.chips?.clearReward?.increment ?? 1,
+          maxChallengeBet: rawGameConfig.chips?.maxChallengeBet ?? 13,
         },
-        sizing: {
-          sidebarWidthFrac: scratchbonesGameConfig.layout?.sizing?.sidebarWidthFrac ?? scratchbonesLegacyGameplayConfig.sidebarWidthFrac ?? 0.75,
-          sidebarWidthPx: scratchbonesGameConfig.layout?.sizing?.sidebarWidthPx ?? scratchbonesLegacyGameplayConfig.sidebarWidthPx ?? 280,
-          appGapPx: scratchbonesGameConfig.layout?.sizing?.appGapPx ?? scratchbonesLegacyGameplayConfig.appGapPx ?? 8,
-          appPaddingPx: scratchbonesGameConfig.layout?.sizing?.appPaddingPx ?? scratchbonesLegacyGameplayConfig.appPaddingPx ?? 8,
-          seatAvatarPx: scratchbonesGameConfig.layout?.sizing?.seatAvatarPx ?? scratchbonesLegacyGameplayConfig.seatAvatarPx ?? 132,
-          humanSeatAvatarPx: scratchbonesGameConfig.layout?.sizing?.humanSeatAvatarPx ?? scratchbonesLegacyGameplayConfig.humanSeatAvatarPx ?? 204,
-          cinematicAvatarPx: scratchbonesGameConfig.layout?.sizing?.cinematicAvatarPx ?? scratchbonesLegacyGameplayConfig.cinematicAvatarPx ?? 132,
-          handCardMinWidthPx: scratchbonesGameConfig.layout?.sizing?.handCardMinWidthPx ?? scratchbonesLegacyGameplayConfig.handCardMinWidthPx ?? 74,
-          handCardMaxWidthPx: scratchbonesGameConfig.layout?.sizing?.handCardMaxWidthPx ?? scratchbonesLegacyGameplayConfig.handCardMaxWidthPx ?? 104,
-          handCardMinHeightPx: scratchbonesGameConfig.layout?.sizing?.handCardMinHeightPx ?? scratchbonesLegacyGameplayConfig.handCardMinHeightPx ?? 146,
-          handCardMaxHeightPx: scratchbonesGameConfig.layout?.sizing?.handCardMaxHeightPx ?? scratchbonesLegacyGameplayConfig.handCardMaxHeightPx ?? 186,
-          handCardGapMinPx: scratchbonesGameConfig.layout?.sizing?.handCardGapMinPx ?? scratchbonesLegacyGameplayConfig.handCardGapMinPx ?? 8,
-          handCardGapMaxPx: scratchbonesGameConfig.layout?.sizing?.handCardGapMaxPx ?? scratchbonesLegacyGameplayConfig.handCardGapMaxPx ?? 12,
-          eventLogMaxHeightPx: scratchbonesGameConfig.layout?.sizing?.eventLogMaxHeightPx ?? scratchbonesLegacyGameplayConfig.eventLogMaxHeightPx ?? 78,
-          controlsPaddingYpx: scratchbonesGameConfig.layout?.sizing?.controlsPaddingYpx ?? scratchbonesLegacyGameplayConfig.controlsPaddingYpx ?? 12,
-          controlsPaddingXpx: scratchbonesGameConfig.layout?.sizing?.controlsPaddingXpx ?? scratchbonesLegacyGameplayConfig.controlsPaddingXpx ?? 12,
-          controlsGapPx: scratchbonesGameConfig.layout?.sizing?.controlsGapPx ?? scratchbonesLegacyGameplayConfig.controlsGapPx ?? 10,
-          handWrapPaddingYpx: scratchbonesGameConfig.layout?.sizing?.handWrapPaddingYpx ?? scratchbonesLegacyGameplayConfig.handWrapPaddingYpx ?? 8,
-          handWrapPaddingXpx: scratchbonesGameConfig.layout?.sizing?.handWrapPaddingXpx ?? scratchbonesLegacyGameplayConfig.handWrapPaddingXpx ?? 12,
-          handWrapGapPx: scratchbonesGameConfig.layout?.sizing?.handWrapGapPx ?? scratchbonesLegacyGameplayConfig.handWrapGapPx ?? 6,
-          eventLogPaddingYpx: scratchbonesGameConfig.layout?.sizing?.eventLogPaddingYpx ?? scratchbonesLegacyGameplayConfig.eventLogPaddingYpx ?? 8,
-          eventLogPaddingXpx: scratchbonesGameConfig.layout?.sizing?.eventLogPaddingXpx ?? scratchbonesLegacyGameplayConfig.eventLogPaddingXpx ?? 12,
-          eventLogGapPx: scratchbonesGameConfig.layout?.sizing?.eventLogGapPx ?? scratchbonesLegacyGameplayConfig.eventLogGapPx ?? 6,
-          logItemPaddingYpx: scratchbonesGameConfig.layout?.sizing?.logItemPaddingYpx ?? scratchbonesLegacyGameplayConfig.logItemPaddingYpx ?? 9,
-          logItemPaddingXpx: scratchbonesGameConfig.layout?.sizing?.logItemPaddingXpx ?? scratchbonesLegacyGameplayConfig.logItemPaddingXpx ?? 10,
+        timers: {
+          challengeTimerSecs: rawGameConfig.timers?.challengeSeconds ?? 8,
+          aiThinkMs: rawGameConfig.timers?.aiThinkMs ?? 650,
         },
-        hand: {
-          desiredHeightFrac: scratchbonesGameConfig.layout?.hand?.desiredHeightFrac ?? scratchbonesLegacyGameplayConfig.handDesiredHeightFrac ?? 0.20,
-          heightScale: scratchbonesGameConfig.layout?.hand?.heightScale ?? scratchbonesLegacyGameplayConfig.handHeightScale ?? 0.5,
-          minHeightPx: scratchbonesGameConfig.layout?.hand?.minHeightPx ?? scratchbonesLegacyGameplayConfig.handMinHeightPx ?? 160,
-          maxHeightPx: scratchbonesGameConfig.layout?.hand?.maxHeightPx ?? scratchbonesLegacyGameplayConfig.handMaxHeightPx ?? 360,
-          forceAllVisible: scratchbonesGameConfig.layout?.hand?.forceAllVisible ?? true,
-          compact: {
-            enabled: scratchbonesGameConfig.layout?.hand?.compact?.enabled ?? true,
-            cardMinWidthPx: scratchbonesGameConfig.layout?.hand?.compact?.cardMinWidthPx ?? 64,
-            cardGapPx: scratchbonesGameConfig.layout?.hand?.compact?.cardGapPx ?? 6,
-            cardMinHeightPx: scratchbonesGameConfig.layout?.hand?.compact?.cardMinHeightPx ?? 128,
+        layout: {
+          viewport: {
+            widthPx: rawGameConfig.layout?.viewport?.widthPx,
+            heightPx: rawGameConfig.layout?.viewport?.heightPx,
           },
-        },
-        tableView: {
-          desiredHeightFrac: scratchbonesGameConfig.layout?.tableView?.desiredHeightFrac ?? 0.58,
-          minDominanceFrac: scratchbonesGameConfig.layout?.tableView?.minDominanceFrac ?? scratchbonesLegacyGameplayConfig.tableViewMinDominanceFrac ?? 0.56,
-          minHeightPx: scratchbonesGameConfig.layout?.tableView?.minHeightPx ?? 260,
-          maxHeightPx: scratchbonesGameConfig.layout?.tableView?.maxHeightPx ?? 680,
-          cardVisualMode: scratchbonesGameConfig.layout?.tableView?.cardVisualMode ?? 'faceDown',
-          turnSpotlight: {
-            embedded: scratchbonesGameConfig.layout?.tableView?.turnSpotlight?.embedded ?? true,
-            pinCorner: scratchbonesGameConfig.layout?.tableView?.turnSpotlight?.pinCorner ?? 'top-right',
-            offsetXPx: scratchbonesGameConfig.layout?.tableView?.turnSpotlight?.offsetXPx ?? 10,
-            offsetYPx: scratchbonesGameConfig.layout?.tableView?.turnSpotlight?.offsetYPx ?? 10,
+          cards: {
+            baseScale: rawGameConfig.layout?.cards?.baseScale ?? 0.25,
           },
-          visualFit: {
-            tableCardContainerScale: scratchbonesGameConfig.layout?.tableView?.visualFit?.tableCardContainerScale ?? 1.25,
-            tableCardContentScale: scratchbonesGameConfig.layout?.tableView?.visualFit?.tableCardContentScale ?? 0.8,
-            claimAvatarContainerScale: scratchbonesGameConfig.layout?.tableView?.visualFit?.claimAvatarContainerScale ?? 1.25,
-            claimAvatarContentScale: scratchbonesGameConfig.layout?.tableView?.visualFit?.claimAvatarContentScale ?? 0.8,
+          sizing: {
+            sidebarWidthFrac: rawGameConfig.layout?.sizing?.sidebarWidthFrac ?? 0.75,
+            sidebarWidthPx: rawGameConfig.layout?.sizing?.sidebarWidthPx ?? 280,
+            appGapPx: rawGameConfig.layout?.sizing?.appGapPx ?? 8,
+            appPaddingPx: rawGameConfig.layout?.sizing?.appPaddingPx ?? 8,
+            seatAvatarPx: rawGameConfig.layout?.sizing?.seatAvatarPx ?? 132,
+            humanSeatAvatarPx: rawGameConfig.layout?.sizing?.humanSeatAvatarPx ?? 204,
+            cinematicAvatarPx: rawGameConfig.layout?.sizing?.cinematicAvatarPx ?? 132,
+            handCardMinWidthPx: rawGameConfig.layout?.sizing?.handCardMinWidthPx ?? 74,
+            handCardMaxWidthPx: rawGameConfig.layout?.sizing?.handCardMaxWidthPx ?? 104,
+            handCardMinHeightPx: rawGameConfig.layout?.sizing?.handCardMinHeightPx ?? 146,
+            handCardMaxHeightPx: rawGameConfig.layout?.sizing?.handCardMaxHeightPx ?? 186,
+            handCardGapMinPx: rawGameConfig.layout?.sizing?.handCardGapMinPx ?? 8,
+            handCardGapMaxPx: rawGameConfig.layout?.sizing?.handCardGapMaxPx ?? 12,
+            eventLogMaxHeightPx: rawGameConfig.layout?.sizing?.eventLogMaxHeightPx ?? 78,
+            controlsPaddingYpx: rawGameConfig.layout?.sizing?.controlsPaddingYpx ?? 12,
+            controlsPaddingXpx: rawGameConfig.layout?.sizing?.controlsPaddingXpx ?? 12,
+            controlsGapPx: rawGameConfig.layout?.sizing?.controlsGapPx ?? 10,
+            handWrapPaddingYpx: rawGameConfig.layout?.sizing?.handWrapPaddingYpx ?? 8,
+            handWrapPaddingXpx: rawGameConfig.layout?.sizing?.handWrapPaddingXpx ?? 12,
+            handWrapGapPx: rawGameConfig.layout?.sizing?.handWrapGapPx ?? 6,
+            eventLogPaddingYpx: rawGameConfig.layout?.sizing?.eventLogPaddingYpx ?? 8,
+            eventLogPaddingXpx: rawGameConfig.layout?.sizing?.eventLogPaddingXpx ?? 12,
+            eventLogGapPx: rawGameConfig.layout?.sizing?.eventLogGapPx ?? 6,
+            logItemPaddingYpx: rawGameConfig.layout?.sizing?.logItemPaddingYpx ?? 9,
+            logItemPaddingXpx: rawGameConfig.layout?.sizing?.logItemPaddingXpx ?? 10,
           },
-          cinematic: {
-            enabled: scratchbonesGameConfig.layout?.tableView?.cinematic?.enabled ?? true,
-            showEffects: scratchbonesGameConfig.layout?.tableView?.cinematic?.showEffects ?? true,
+          hand: {
+            desiredHeightFrac: rawGameConfig.layout?.hand?.desiredHeightFrac ?? 0.20,
+            heightScale: rawGameConfig.layout?.hand?.heightScale ?? 0.5,
+            minHeightPx: rawGameConfig.layout?.hand?.minHeightPx ?? 160,
+            maxHeightPx: rawGameConfig.layout?.hand?.maxHeightPx ?? 360,
+            forceAllVisible: rawGameConfig.layout?.hand?.forceAllVisible ?? true,
+            compact: {
+              enabled: rawGameConfig.layout?.hand?.compact?.enabled ?? true,
+              cardMinWidthPx: rawGameConfig.layout?.hand?.compact?.cardMinWidthPx ?? 64,
+              cardGapPx: rawGameConfig.layout?.hand?.compact?.cardGapPx ?? 6,
+              cardMinHeightPx: rawGameConfig.layout?.hand?.compact?.cardMinHeightPx ?? 128,
+            },
           },
-        },
-        regions: {
-          actionFocus: {
-            enabled: scratchbonesGameConfig.layout?.regions?.actionFocus?.enabled ?? false,
-            replaceWithFloatingClaimCluster: scratchbonesGameConfig.layout?.regions?.actionFocus?.replaceWithFloatingClaimCluster ?? true,
+          tableView: {
+            desiredHeightFrac: rawGameConfig.layout?.tableView?.desiredHeightFrac ?? 0.58,
+            minDominanceFrac: rawGameConfig.layout?.tableView?.minDominanceFrac ?? 0.56,
+            minHeightPx: rawGameConfig.layout?.tableView?.minHeightPx ?? 260,
+            maxHeightPx: rawGameConfig.layout?.tableView?.maxHeightPx ?? 680,
+            cardVisualMode: rawGameConfig.layout?.tableView?.cardVisualMode ?? 'faceDown',
+            turnSpotlight: {
+              embedded: rawGameConfig.layout?.tableView?.turnSpotlight?.embedded ?? true,
+              pinCorner: rawGameConfig.layout?.tableView?.turnSpotlight?.pinCorner ?? 'top-right',
+              offsetXPx: rawGameConfig.layout?.tableView?.turnSpotlight?.offsetXPx ?? 10,
+              offsetYPx: rawGameConfig.layout?.tableView?.turnSpotlight?.offsetYPx ?? 10,
+            },
+            visualFit: {
+              tableCardContainerScale: rawGameConfig.layout?.tableView?.visualFit?.tableCardContainerScale ?? 1.25,
+              tableCardContentScale: rawGameConfig.layout?.tableView?.visualFit?.tableCardContentScale ?? 0.8,
+              claimAvatarContainerScale: rawGameConfig.layout?.tableView?.visualFit?.claimAvatarContainerScale ?? 1.25,
+              claimAvatarContentScale: rawGameConfig.layout?.tableView?.visualFit?.claimAvatarContentScale ?? 0.8,
+            },
+            cinematic: {
+              enabled: rawGameConfig.layout?.tableView?.cinematic?.enabled ?? true,
+              showEffects: rawGameConfig.layout?.tableView?.cinematic?.showEffects ?? true,
+            },
           },
-          turnSpotlight: {
-            enabled: scratchbonesGameConfig.layout?.regions?.turnSpotlight?.enabled ?? true,
-            mustStayVisible: scratchbonesGameConfig.layout?.regions?.turnSpotlight?.mustStayVisible ?? true,
-            avatarSizePx: scratchbonesGameConfig.layout?.regions?.turnSpotlight?.avatarSizePx ?? 180,
-            nameBarBelowAvatar: scratchbonesGameConfig.layout?.regions?.turnSpotlight?.nameBarBelowAvatar ?? true,
+          regions: {
+            actionFocus: {
+              enabled: rawGameConfig.layout?.regions?.actionFocus?.enabled ?? false,
+              replaceWithFloatingClaimCluster: rawGameConfig.layout?.regions?.actionFocus?.replaceWithFloatingClaimCluster ?? true,
+            },
+            turnSpotlight: {
+              enabled: rawGameConfig.layout?.regions?.turnSpotlight?.enabled ?? true,
+              mustStayVisible: rawGameConfig.layout?.regions?.turnSpotlight?.mustStayVisible ?? true,
+              avatarSizePx: rawGameConfig.layout?.regions?.turnSpotlight?.avatarSizePx ?? 180,
+              nameBarBelowAvatar: rawGameConfig.layout?.regions?.turnSpotlight?.nameBarBelowAvatar ?? true,
+            },
+            contextBox: {
+              enabled: rawGameConfig.layout?.regions?.contextBox?.enabled ?? true,
+              sharedDeclareAndChallengeSlot: rawGameConfig.layout?.regions?.contextBox?.sharedDeclareAndChallengeSlot ?? true,
+              mustStayVisible: rawGameConfig.layout?.regions?.contextBox?.mustStayVisible ?? true,
+            },
           },
-          contextBox: {
-            enabled: scratchbonesGameConfig.layout?.regions?.contextBox?.enabled ?? true,
-            sharedDeclareAndChallengeSlot: scratchbonesGameConfig.layout?.regions?.contextBox?.sharedDeclareAndChallengeSlot ?? true,
-            mustStayVisible: scratchbonesGameConfig.layout?.regions?.contextBox?.mustStayVisible ?? true,
+          claimCluster: {
+            enabled: rawGameConfig.layout?.claimCluster?.enabled ?? true,
+            anchor: rawGameConfig.layout?.claimCluster?.anchor ?? 'tableView',
+            scaleAsOne: rawGameConfig.layout?.claimCluster?.scaleAsOne ?? true,
+            preserveRelativePositions: rawGameConfig.layout?.claimCluster?.preserveRelativePositions ?? true,
+            mustStayVisible: rawGameConfig.layout?.claimCluster?.mustStayVisible ?? true,
+            transparentShells: rawGameConfig.layout?.claimCluster?.transparentShells ?? true,
+            geometry: {
+              centerXPct: rawGameConfig.layout?.claimCluster?.geometry?.centerXPct ?? 0.50,
+              centerYPct: rawGameConfig.layout?.claimCluster?.geometry?.centerYPct ?? 0.54,
+              widthPctOfTableView: rawGameConfig.layout?.claimCluster?.geometry?.widthPctOfTableView ?? 0.78,
+              heightPctOfTableView: rawGameConfig.layout?.claimCluster?.geometry?.heightPctOfTableView ?? 0.48,
+            },
+            elements: rawGameConfig.layout?.claimCluster?.elements ?? {},
           },
-        },
-        claimCluster: {
-          enabled: scratchbonesGameConfig.layout?.claimCluster?.enabled ?? true,
-          anchor: scratchbonesGameConfig.layout?.claimCluster?.anchor ?? 'tableView',
-          scaleAsOne: scratchbonesGameConfig.layout?.claimCluster?.scaleAsOne ?? true,
-          preserveRelativePositions: scratchbonesGameConfig.layout?.claimCluster?.preserveRelativePositions ?? true,
-          mustStayVisible: scratchbonesGameConfig.layout?.claimCluster?.mustStayVisible ?? true,
-          transparentShells: scratchbonesGameConfig.layout?.claimCluster?.transparentShells ?? true,
-          geometry: {
-            centerXPct: scratchbonesGameConfig.layout?.claimCluster?.geometry?.centerXPct ?? 0.50,
-            centerYPct: scratchbonesGameConfig.layout?.claimCluster?.geometry?.centerYPct ?? 0.54,
-            widthPctOfTableView: scratchbonesGameConfig.layout?.claimCluster?.geometry?.widthPctOfTableView ?? 0.78,
-            heightPctOfTableView: scratchbonesGameConfig.layout?.claimCluster?.geometry?.heightPctOfTableView ?? 0.48,
+          shells: {
+            transparentFloatingBoxes: rawGameConfig.layout?.shells?.transparentFloatingBoxes ?? true,
+            disablePanelChromeForFloatingBoxes: rawGameConfig.layout?.shells?.disablePanelChromeForFloatingBoxes ?? true,
           },
-          elements: scratchbonesGameConfig.layout?.claimCluster?.elements ?? {},
+          controlsToHandRelationship: rawGameConfig.layout?.controlsToHandRelationship ?? 'below',
+          actionColumn: {
+            heightScale: rawGameConfig.layout?.actionColumn?.heightScale ?? 0.25,
+          },
+          controls: {
+            heightScale: rawGameConfig.layout?.controls?.heightScale ?? 0.5,
+          },
+          allowChallengeOverflow: rawGameConfig.layout?.allowChallengeOverflow ?? true,
+          fitter: rawGameConfig.layout?.fitter ?? null,
+          projectionMapping: rawGameConfig.layout?.projectionMapping ?? {},
         },
-        shells: {
-          transparentFloatingBoxes: scratchbonesGameConfig.layout?.shells?.transparentFloatingBoxes ?? true,
-          disablePanelChromeForFloatingBoxes: scratchbonesGameConfig.layout?.shells?.disablePanelChromeForFloatingBoxes ?? true,
+        uiText: {
+          initialBanner: rawGameConfig.uiText?.initialBanner ?? 'Open a round by selecting one or more cards, then declare a number.',
+          yourLeadBanner: rawGameConfig.uiText?.yourLeadBanner ?? 'Your lead. Select cards and declare any number.',
+          pickCardWarning: rawGameConfig.uiText?.pickCardWarning ?? 'Pick at least one card before playing.',
+          challengeTimerLabel: rawGameConfig.uiText?.challengeTimerLabel ?? 'Auto: let it stand',
+          challengePromptTemplate: rawGameConfig.uiText?.challengePromptTemplate ?? '{seat} declared {count} × {rank}. Challenge before the timer runs out, or let it stand.',
+          letStandButton: rawGameConfig.uiText?.letStandButton ?? 'Let it stand',
         },
-        controlsToHandRelationship: scratchbonesGameConfig.layout?.controlsToHandRelationship ?? scratchbonesLegacyGameplayConfig.controlsToHandRelationship ?? 'below',
-        actionColumn: {
-          heightScale: scratchbonesGameConfig.layout?.actionColumn?.heightScale ?? scratchbonesLegacyGameplayConfig.actionColumnHeightScale ?? 0.25,
+        assets: {
+          cardHudBasePath: rawGameConfig.assets?.cards?.hudBasePath ?? './docs/assets/hud/',
+          wildCardSrc: rawGameConfig.assets?.cards?.wild?.src ?? '2DScratchBoneWild.png',
+          wildCardFallbackSrc: rawGameConfig.assets?.cards?.wild?.fallbackSrc ?? '2DScratchBoneWild.png',
+          flippedCardSrc: rawGameConfig.assets?.cards?.flipped?.src ?? '2DScratchboneFlipped.png',
+          flippedCardFallbackSrc: rawGameConfig.assets?.cards?.flipped?.fallbackSrc ?? '2DScratchBoneFlipped.png',
+          rankCardTemplateSrc: rawGameConfig.assets?.cards?.rankTemplate?.src ?? '2DScratchbone{rank}.png',
+          rankCardTemplateFallbackSrc: rawGameConfig.assets?.cards?.rankTemplate?.fallbackSrc ?? '2DScratchbones{rank}.png',
         },
-        controls: {
-          heightScale: scratchbonesGameConfig.layout?.controls?.heightScale ?? scratchbonesLegacyGameplayConfig.controlsHeightScale ?? 0.5,
-        },
-        allowChallengeOverflow: scratchbonesGameConfig.layout?.allowChallengeOverflow ?? scratchbonesLegacyGameplayConfig.allowChallengeOverflow ?? true,
-        fitter: scratchbonesGameConfig.layout?.fitter ?? null,
-        projectionMapping: scratchbonesGameConfig.layout?.projectionMapping ?? {},
-      },
-      uiText: {
-        initialBanner: scratchbonesGameConfig.uiText?.initialBanner ?? scratchbonesLegacyGameplayConfig.initialBanner ?? 'Open a round by selecting one or more cards, then declare a number.',
-        yourLeadBanner: scratchbonesGameConfig.uiText?.yourLeadBanner ?? scratchbonesLegacyGameplayConfig.yourLeadBanner ?? 'Your lead. Select cards and declare any number.',
-        pickCardWarning: scratchbonesGameConfig.uiText?.pickCardWarning ?? scratchbonesLegacyGameplayConfig.pickCardWarning ?? 'Pick at least one card before playing.',
-        challengeTimerLabel: scratchbonesGameConfig.uiText?.challengeTimerLabel ?? scratchbonesLegacyGameplayConfig.challengeTimerLabel ?? 'Auto: let it stand',
-        challengePromptTemplate: scratchbonesGameConfig.uiText?.challengePromptTemplate ?? scratchbonesLegacyGameplayConfig.challengePromptTemplate ?? '{seat} declared {count} × {rank}. Challenge before the timer runs out, or let it stand.',
-        letStandButton: scratchbonesGameConfig.uiText?.letStandButton ?? scratchbonesLegacyGameplayConfig.letStandButton ?? 'Let it stand',
-      },
-      assets: {
-        cardHudBasePath: scratchbonesGameConfig.assets?.cards?.hudBasePath ?? scratchbonesLegacyGameplayConfig.cardsHudBasePath ?? './docs/assets/hud/',
-        wildCardSrc: scratchbonesGameConfig.assets?.cards?.wild?.src ?? scratchbonesLegacyGameplayConfig.wildCardAsset ?? '2DScratchBoneWild.png',
-        wildCardFallbackSrc: scratchbonesGameConfig.assets?.cards?.wild?.fallbackSrc ?? scratchbonesLegacyGameplayConfig.wildCardAssetFallback ?? '2DScratchBoneWild.png',
-        flippedCardSrc: scratchbonesGameConfig.assets?.cards?.flipped?.src ?? scratchbonesLegacyGameplayConfig.flippedCardAsset ?? '2DScratchboneFlipped.png',
-        flippedCardFallbackSrc: scratchbonesGameConfig.assets?.cards?.flipped?.fallbackSrc ?? scratchbonesLegacyGameplayConfig.flippedCardAssetFallback ?? '2DScratchBoneFlipped.png',
-        rankCardTemplateSrc: scratchbonesGameConfig.assets?.cards?.rankTemplate?.src ?? scratchbonesLegacyGameplayConfig.rankCardTemplate ?? '2DScratchbone{rank}.png',
-        rankCardTemplateFallbackSrc: scratchbonesGameConfig.assets?.cards?.rankTemplate?.fallbackSrc ?? scratchbonesLegacyGameplayConfig.rankCardTemplateFallback ?? '2DScratchbones{rank}.png',
-      },
-    };
+      };
+    }
+
+    function getScratchbonesGameConfig() {
+      validateScratchbonesGameConfig(scratchbonesRootConfig);
+      return normalizeScratchbonesGameConfig(scratchbonesRootConfig.game || {});
+    }
+
+    // Most recent config-boundary cleanup: Scratchbones now reads only SCRATCHBONES_CONFIG.game.
+    const SCRATCHBONES_GAME = getScratchbonesGameConfig();
 
     const CHALLENGE_TIMER_SECS = SCRATCHBONES_GAME.timers.challengeTimerSecs;
 
@@ -4434,7 +4466,7 @@
     let _portraitCosmetics = null;
 
     if (window.setPortraitAssetBase && window.loadPortraitCosmetics) {
-      const scratchbonesPortraitConfig = window.SCRATCHBONES_CONFIG?.game?.assets?.portrait || window.SCRATCHBONES_CONFIG?.portrait || null;
+      const scratchbonesPortraitConfig = window.SCRATCHBONES_CONFIG?.game?.assets?.portrait || null;
       if (scratchbonesPortraitConfig && window.setPortraitConfig) {
         setPortraitConfig(scratchbonesPortraitConfig);
       }

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -1,357 +1,614 @@
-window.SCRATCHBONES_CONFIG = window.SCRATCHBONES_CONFIG || {};
-
-const __existingScratchbonesConfig = window.SCRATCHBONES_CONFIG;
-const __legacyGameplayConfig = __existingScratchbonesConfig.gameplay || {};
-const __existingGameConfig = __existingScratchbonesConfig.game || {};
-
-window.SCRATCHBONES_CONFIG.game = {
-  deck: {
-    rankCount: __existingGameConfig.deck?.rankCount ?? __legacyGameplayConfig.deckRankCount ?? 10,
-    copiesPerRank: __existingGameConfig.deck?.copiesPerRank ?? __legacyGameplayConfig.deckCopiesPerRank ?? 4,
-    handSize: __existingGameConfig.deck?.handSize ?? __legacyGameplayConfig.startHandSize ?? 10,
-    wildCount: __existingGameConfig.deck?.wildCount ?? __legacyGameplayConfig.wildCount ?? 10,
-    playerCount: __existingGameConfig.deck?.playerCount ?? __legacyGameplayConfig.playerCount ?? 4,
-    humanNames: __existingGameConfig.deck?.humanNames ?? __legacyGameplayConfig.playerNames ?? ['You'],
-  },
-  chips: {
-    starting: __existingGameConfig.chips?.starting ?? __legacyGameplayConfig.startingChips ?? 12,
-    challengeBaseTransfer: __existingGameConfig.chips?.challengeBaseTransfer ?? __legacyGameplayConfig.challengeBaseTransfer ?? 1,
-    concedeRoundChipLoss: __existingGameConfig.chips?.concedeRoundChipLoss ?? __legacyGameplayConfig.concedeRoundChipLoss ?? 1,
-    maxChallengeBet: __existingGameConfig.chips?.maxChallengeBet ?? __legacyGameplayConfig.maxChallengeBet ?? 13,
-    raise: {
-      maxAmount: __existingGameConfig.chips?.raise?.maxAmount ?? __legacyGameplayConfig.maxRaiseAmount ?? 3,
-      maxPerPlayer: __existingGameConfig.chips?.raise?.maxPerPlayer ?? __legacyGameplayConfig.maxRaisesPerPlayer ?? 3,
+window.SCRATCHBONES_CONFIG = {
+  game: {
+    "deck": {
+      "rankCount": 10,
+      "copiesPerRank": 4,
+      "handSize": 10,
+      "wildCount": 10,
+      "playerCount": 4,
+      "humanNames": [
+        "You"
+      ]
     },
-    clearReward: {
-      base: __existingGameConfig.chips?.clearReward?.base ?? __legacyGameplayConfig.clearBonusBase ?? 1,
-      increment: __existingGameConfig.chips?.clearReward?.increment ?? __legacyGameplayConfig.clearBonusIncrement ?? 1,
-    },
-  },
-  timers: {
-    challengeSeconds: __existingGameConfig.timers?.challengeSeconds ?? __legacyGameplayConfig.challengeTimerSecs ?? 8,
-    aiThinkMs: __existingGameConfig.timers?.aiThinkMs ?? __legacyGameplayConfig.aiThinkMs ?? 650,
-  },
-  layout: {
-    viewport: {
-      widthPx: __existingGameConfig.layout?.viewport?.widthPx ?? 1920,
-      heightPx: __existingGameConfig.layout?.viewport?.heightPx ?? 1080,
-    },
-    cards: {
-      baseScale: __existingGameConfig.layout?.cards?.baseScale ?? 0.25,
-    },
-    sizing: {
-      sidebarWidthFrac: __existingGameConfig.layout?.sizing?.sidebarWidthFrac ?? __legacyGameplayConfig.sidebarWidthFrac ?? 0.15,
-      sidebarWidthPx: __existingGameConfig.layout?.sizing?.sidebarWidthPx ?? __legacyGameplayConfig.sidebarWidthPx ?? 280,
-      appGapPx: __existingGameConfig.layout?.sizing?.appGapPx ?? __legacyGameplayConfig.appGapPx ?? 8,
-      appPaddingPx: __existingGameConfig.layout?.sizing?.appPaddingPx ?? __legacyGameplayConfig.appPaddingPx ?? 8,
-      seatAvatarPx: __existingGameConfig.layout?.sizing?.seatAvatarPx ?? __legacyGameplayConfig.seatAvatarPx ?? 132,
-      humanSeatAvatarPx: __existingGameConfig.layout?.sizing?.humanSeatAvatarPx ?? __legacyGameplayConfig.humanSeatAvatarPx ?? 204,
-      cinematicAvatarPx: __existingGameConfig.layout?.sizing?.cinematicAvatarPx ?? __legacyGameplayConfig.cinematicAvatarPx ?? 132,
-      handCardMinWidthPx: __existingGameConfig.layout?.sizing?.handCardMinWidthPx ?? __legacyGameplayConfig.handCardMinWidthPx ?? 74,
-      handCardMaxWidthPx: __existingGameConfig.layout?.sizing?.handCardMaxWidthPx ?? __legacyGameplayConfig.handCardMaxWidthPx ?? 104,
-      handCardMinHeightPx: __existingGameConfig.layout?.sizing?.handCardMinHeightPx ?? __legacyGameplayConfig.handCardMinHeightPx ?? 146,
-      handCardMaxHeightPx: __existingGameConfig.layout?.sizing?.handCardMaxHeightPx ?? __legacyGameplayConfig.handCardMaxHeightPx ?? 186,
-      handCardGapMinPx: __existingGameConfig.layout?.sizing?.handCardGapMinPx ?? __legacyGameplayConfig.handCardGapMinPx ?? 8,
-      handCardGapMaxPx: __existingGameConfig.layout?.sizing?.handCardGapMaxPx ?? __legacyGameplayConfig.handCardGapMaxPx ?? 12,
-      eventLogMaxHeightPx: __existingGameConfig.layout?.sizing?.eventLogMaxHeightPx ?? __legacyGameplayConfig.eventLogMaxHeightPx ?? 78,
-      controlsPaddingYpx: __existingGameConfig.layout?.sizing?.controlsPaddingYpx ?? __legacyGameplayConfig.controlsPaddingYpx ?? 12,
-      controlsPaddingXpx: __existingGameConfig.layout?.sizing?.controlsPaddingXpx ?? __legacyGameplayConfig.controlsPaddingXpx ?? 12,
-      controlsGapPx: __existingGameConfig.layout?.sizing?.controlsGapPx ?? __legacyGameplayConfig.controlsGapPx ?? 10,
-      handWrapPaddingYpx: __existingGameConfig.layout?.sizing?.handWrapPaddingYpx ?? __legacyGameplayConfig.handWrapPaddingYpx ?? 8,
-      handWrapPaddingXpx: __existingGameConfig.layout?.sizing?.handWrapPaddingXpx ?? __legacyGameplayConfig.handWrapPaddingXpx ?? 12,
-      handWrapGapPx: __existingGameConfig.layout?.sizing?.handWrapGapPx ?? __legacyGameplayConfig.handWrapGapPx ?? 6,
-      eventLogPaddingYpx: __existingGameConfig.layout?.sizing?.eventLogPaddingYpx ?? __legacyGameplayConfig.eventLogPaddingYpx ?? 8,
-      eventLogPaddingXpx: __existingGameConfig.layout?.sizing?.eventLogPaddingXpx ?? __legacyGameplayConfig.eventLogPaddingXpx ?? 12,
-      eventLogGapPx: __existingGameConfig.layout?.sizing?.eventLogGapPx ?? __legacyGameplayConfig.eventLogGapPx ?? 6,
-      logItemPaddingYpx: __existingGameConfig.layout?.sizing?.logItemPaddingYpx ?? __legacyGameplayConfig.logItemPaddingYpx ?? 9,
-      logItemPaddingXpx: __existingGameConfig.layout?.sizing?.logItemPaddingXpx ?? __legacyGameplayConfig.logItemPaddingXpx ?? 10,
-    },
-    hand: {
-      desiredHeightFrac: __existingGameConfig.layout?.hand?.desiredHeightFrac ?? __legacyGameplayConfig.handDesiredHeightFrac ?? 0.20,
-      desiredWidthFrac: __existingGameConfig.layout?.hand?.desiredWidthFrac ?? __legacyGameplayConfig.handDesiredWidthFrac ?? 0.50,
-      heightScale: __existingGameConfig.layout?.hand?.heightScale ?? __legacyGameplayConfig.handHeightScale ?? 0.5,
-      minHeightPx: __existingGameConfig.layout?.hand?.minHeightPx ?? __legacyGameplayConfig.handMinHeightPx ?? 160,
-      maxHeightPx: __existingGameConfig.layout?.hand?.maxHeightPx ?? __legacyGameplayConfig.handMaxHeightPx ?? 360,
-      forceAllVisible: __existingGameConfig.layout?.hand?.forceAllVisible ?? true,
-      compact: {
-        enabled: __existingGameConfig.layout?.hand?.compact?.enabled ?? true,
-        cardMinWidthPx: __existingGameConfig.layout?.hand?.compact?.cardMinWidthPx ?? 64,
-        cardGapPx: __existingGameConfig.layout?.hand?.compact?.cardGapPx ?? 6,
-        cardMinHeightPx: __existingGameConfig.layout?.hand?.compact?.cardMinHeightPx ?? 128,
+    "chips": {
+      "starting": 12,
+      "challengeBaseTransfer": 1,
+      "concedeRoundChipLoss": 1,
+      "maxChallengeBet": 13,
+      "raise": {
+        "maxAmount": 3,
+        "maxPerPlayer": 3
       },
+      "clearReward": {
+        "base": 1,
+        "increment": 1
+      }
     },
-    tableView: {
-      desiredHeightFrac: __existingGameConfig.layout?.tableView?.desiredHeightFrac ?? 0.58,
-      minDominanceFrac: __existingGameConfig.layout?.tableView?.minDominanceFrac ?? __legacyGameplayConfig.tableViewMinDominanceFrac ?? 0.56,
-      minHeightPx: __existingGameConfig.layout?.tableView?.minHeightPx ?? 260,
-      maxHeightPx: __existingGameConfig.layout?.tableView?.maxHeightPx ?? 680,
-      cardVisualMode: __existingGameConfig.layout?.tableView?.cardVisualMode ?? 'faceDown',
-      turnSpotlight: {
-        embedded: __existingGameConfig.layout?.tableView?.turnSpotlight?.embedded ?? true,
-        pinCorner: __existingGameConfig.layout?.tableView?.turnSpotlight?.pinCorner ?? 'top-right',
-        offsetXPx: __existingGameConfig.layout?.tableView?.turnSpotlight?.offsetXPx ?? 10,
-        offsetYPx: __existingGameConfig.layout?.tableView?.turnSpotlight?.offsetYPx ?? 10,
-      },
-      visualFit: {
-        tableCardContainerScale: __existingGameConfig.layout?.tableView?.visualFit?.tableCardContainerScale ?? 1.25,
-        tableCardContentScale: __existingGameConfig.layout?.tableView?.visualFit?.tableCardContentScale ?? 0.8,
-        claimAvatarContainerScale: __existingGameConfig.layout?.tableView?.visualFit?.claimAvatarContainerScale ?? 1.25,
-        claimAvatarContentScale: __existingGameConfig.layout?.tableView?.visualFit?.claimAvatarContentScale ?? 0.8,
-        avatarAdditiveZoomScale: __existingGameConfig.layout?.tableView?.visualFit?.avatarAdditiveZoomScale ?? 1.2,
-      },
-      cinematic: {
-        enabled: __existingGameConfig.layout?.tableView?.cinematic?.enabled ?? true,
-        showEffects: __existingGameConfig.layout?.tableView?.cinematic?.showEffects ?? true,
-      },
+    "timers": {
+      "challengeSeconds": 8,
+      "aiThinkMs": 650
     },
-    regions: {
-      actionFocus: {
-        enabled: __existingGameConfig.layout?.regions?.actionFocus?.enabled ?? false,
-        replaceWithFloatingClaimCluster: __existingGameConfig.layout?.regions?.actionFocus?.replaceWithFloatingClaimCluster ?? true,
+    "layout": {
+      "viewport": {
+        "widthPx": 1920,
+        "heightPx": 1080
       },
-      turnSpotlight: {
-        enabled: __existingGameConfig.layout?.regions?.turnSpotlight?.enabled ?? true,
-        mustStayVisible: __existingGameConfig.layout?.regions?.turnSpotlight?.mustStayVisible ?? true,
-        avatarSizePx: __existingGameConfig.layout?.regions?.turnSpotlight?.avatarSizePx ?? 180,
-        nameBarBelowAvatar: __existingGameConfig.layout?.regions?.turnSpotlight?.nameBarBelowAvatar ?? true,
+      "cards": {
+        "baseScale": 0.25
       },
-      contextBox: {
-        enabled: __existingGameConfig.layout?.regions?.contextBox?.enabled ?? true,
-        sharedDeclareAndChallengeSlot: __existingGameConfig.layout?.regions?.contextBox?.sharedDeclareAndChallengeSlot ?? true,
-        mustStayVisible: __existingGameConfig.layout?.regions?.contextBox?.mustStayVisible ?? true,
+      "sizing": {
+        "sidebarWidthFrac": 0.15,
+        "sidebarWidthPx": 280,
+        "appGapPx": 8,
+        "appPaddingPx": 8,
+        "seatAvatarPx": 132,
+        "humanSeatAvatarPx": 204,
+        "cinematicAvatarPx": 132,
+        "handCardMinWidthPx": 74,
+        "handCardMaxWidthPx": 104,
+        "handCardMinHeightPx": 146,
+        "handCardMaxHeightPx": 186,
+        "handCardGapMinPx": 8,
+        "handCardGapMaxPx": 12,
+        "eventLogMaxHeightPx": 78,
+        "controlsPaddingYpx": 12,
+        "controlsPaddingXpx": 12,
+        "controlsGapPx": 10,
+        "handWrapPaddingYpx": 8,
+        "handWrapPaddingXpx": 12,
+        "handWrapGapPx": 6,
+        "eventLogPaddingYpx": 8,
+        "eventLogPaddingXpx": 12,
+        "eventLogGapPx": 6,
+        "logItemPaddingYpx": 9,
+        "logItemPaddingXpx": 10
       },
-    },
-    claimCluster: {
-      enabled: __existingGameConfig.layout?.claimCluster?.enabled ?? true,
-      anchor: __existingGameConfig.layout?.claimCluster?.anchor ?? 'tableView',
-      scaleAsOne: __existingGameConfig.layout?.claimCluster?.scaleAsOne ?? true,
-      preserveRelativePositions: __existingGameConfig.layout?.claimCluster?.preserveRelativePositions ?? true,
-      mustStayVisible: __existingGameConfig.layout?.claimCluster?.mustStayVisible ?? true,
-      transparentShells: __existingGameConfig.layout?.claimCluster?.transparentShells ?? true,
-      geometry: {
-        centerXPct: __existingGameConfig.layout?.claimCluster?.geometry?.centerXPct ?? 0.50,
-        centerYPct: __existingGameConfig.layout?.claimCluster?.geometry?.centerYPct ?? 0.54,
-        widthPctOfTableView: __existingGameConfig.layout?.claimCluster?.geometry?.widthPctOfTableView ?? 0.78,
-        heightPctOfTableView: __existingGameConfig.layout?.claimCluster?.geometry?.heightPctOfTableView ?? 0.48,
+      "hand": {
+        "desiredHeightFrac": 0.2,
+        "desiredWidthFrac": 0.5,
+        "heightScale": 0.5,
+        "minHeightPx": 160,
+        "maxHeightPx": 360,
+        "forceAllVisible": true,
+        "compact": {
+          "enabled": true,
+          "cardMinWidthPx": 64,
+          "cardGapPx": 6,
+          "cardMinHeightPx": 128
+        }
       },
-      elements: {
-        claimRankBox: __existingGameConfig.layout?.claimCluster?.elements?.claimRankBox ?? { xPct: 0.50, yPct: 0.08, wPct: 0.12, hPct: 0.18 },
-        claimHandBar: __existingGameConfig.layout?.claimCluster?.elements?.claimHandBar ?? { xPct: 0.50, yPct: 0.52, wPct: 0.42, hPct: 0.30 },
-        actorAvatarFloat: __existingGameConfig.layout?.claimCluster?.elements?.actorAvatarFloat ?? { xPct: 0.14, yPct: 0.52, wPct: 0.16, hPct: 0.24 },
-        reactorAvatarFloat: __existingGameConfig.layout?.claimCluster?.elements?.reactorAvatarFloat ?? { xPct: 0.86, yPct: 0.52, wPct: 0.16, hPct: 0.24 },
-        claimTimesBoxLeft: __existingGameConfig.layout?.claimCluster?.elements?.claimTimesBoxLeft ?? { xPct: 0.26, yPct: 0.52, wPct: 0.07, hPct: 0.13 },
-        claimCountBoxLeft: __existingGameConfig.layout?.claimCluster?.elements?.claimCountBoxLeft ?? { xPct: 0.26, yPct: 0.66, wPct: 0.07, hPct: 0.13 },
-        claimTimesBoxRight: __existingGameConfig.layout?.claimCluster?.elements?.claimTimesBoxRight ?? { xPct: 0.74, yPct: 0.52, wPct: 0.07, hPct: 0.13 },
-        claimCountBoxRight: __existingGameConfig.layout?.claimCluster?.elements?.claimCountBoxRight ?? { xPct: 0.74, yPct: 0.66, wPct: 0.07, hPct: 0.13 },
-      },
-    },
-    shells: {
-      transparentFloatingBoxes: __existingGameConfig.layout?.shells?.transparentFloatingBoxes ?? true,
-      disablePanelChromeForFloatingBoxes: __existingGameConfig.layout?.shells?.disablePanelChromeForFloatingBoxes ?? true,
-    },
-    controlsToHandRelationship: __existingGameConfig.layout?.controlsToHandRelationship ?? __legacyGameplayConfig.controlsToHandRelationship ?? 'below',
-    actionColumn: {
-      heightScale: __existingGameConfig.layout?.actionColumn?.heightScale ?? __legacyGameplayConfig.actionColumnHeightScale ?? 0.25,
-    },
-    controls: {
-      heightScale: __existingGameConfig.layout?.controls?.heightScale ?? __legacyGameplayConfig.controlsHeightScale ?? 0.5,
-    },
-    allowChallengeOverflow: __existingGameConfig.layout?.allowChallengeOverflow ?? __legacyGameplayConfig.allowChallengeOverflow ?? true,
-    fitter: {
-      enabled: __existingGameConfig.layout?.fitter?.enabled ?? true,
-      reflowDebounceMs: __existingGameConfig.layout?.fitter?.reflowDebounceMs ?? 90,
-      overflowTolerancePx: __existingGameConfig.layout?.fitter?.overflowTolerancePx ?? 1,
-      minReadableFontScale: __existingGameConfig.layout?.fitter?.minReadableFontScale ?? 0.72,
-      stages: __existingGameConfig.layout?.fitter?.stages ?? [
-        { fontScale: 0.96, imageScale: 0.95, gapScale: 0.94 },
-        { fontScale: 0.92, imageScale: 0.90, gapScale: 0.88 },
-        { fontScale: 0.88, imageScale: 0.86, gapScale: 0.82 },
-        { fontScale: 0.84, imageScale: 0.82, gapScale: 0.76 },
-        { fontScale: 0.80, imageScale: 0.78, gapScale: 0.70 },
-        { fontScale: 0.76, imageScale: 0.74, gapScale: 0.64 },
-      ],
-      targets: __existingGameConfig.layout?.fitter?.targets ?? {
-        tableView: { selector: '.tableView', containmentSelector: '.tableViewCards', maxStage: 4, minReadableFontScale: 0.80 },
-        actionFocus: { selector: '.actionFocus', containmentSelector: '.actionFocusMain', maxStage: 6, minReadableFontScale: 0.72 },
-        actionColumn: { selector: '.actionColumn', maxStage: 4, minReadableFontScale: 0.76 },
-        contextBox: { selector: '.contextBox', maxStage: 5, minReadableFontScale: 0.74 },
-        turnSpotlight: { selector: '.turnSpotlight', maxStage: 5, minReadableFontScale: 0.74 },
-        claimCluster: { selector: '.claimCluster', maxStage: 4, minReadableFontScale: 0.72 },
-        sidebarSeats: { selector: '#aiSidebar', maxStage: 6, minReadableFontScale: 0.72 },
-        handCards: { selector: '.handWrap', containmentSelector: '.handScroll', maxStage: 6, minReadableFontScale: 0.76 },
-        logs: { selector: '.eventLog', maxStage: 4, minReadableFontScale: 0.78 },
-        controls: { selector: '.controls', maxStage: 6, minReadableFontScale: 0.78 },
-      },
-      overlap: __existingGameConfig.layout?.fitter?.overlap ?? {
-        enabled: true,
-        tolerancePx: 0,
-        criticalRegions: {
-          tableView: '.tableView',
-          controls: '.controls',
-          hand: '.handWrap',
-          actionColumn: '.actionColumn',
-          contextBox: '.contextBox',
-          log: '.eventLog',
-          sidebar: '#aiSidebar',
-          turnSpotlight: '.turnSpotlight',
-          claimCluster: '.claimCluster',
-          challenge: '#challengePromptPane',
+      "tableView": {
+        "desiredHeightFrac": 0.58,
+        "minDominanceFrac": 0.56,
+        "minHeightPx": 260,
+        "maxHeightPx": 680,
+        "cardVisualMode": "faceDown",
+        "turnSpotlight": {
+          "embedded": true,
+          "pinCorner": "top-right",
+          "offsetXPx": 10,
+          "offsetYPx": 10
         },
-        collapseOrder: [],
-        preserveRegions: ['tableView', 'controls', 'sidebar', 'turnSpotlight', 'claimCluster', 'contextBox'],
-        minContainerScale: 0.70,
-        containerScaleStep: 0.02,
-      },
-    },
-    projectionMapping: {
-      editor: {
-        step: __existingGameConfig.layout?.projectionMapping?.editor?.step ?? 0.01,
-        panelTitle: __existingGameConfig.layout?.projectionMapping?.editor?.panelTitle ?? 'Projection Vars',
-        sliderClamp: {
-          multiplierMin: __existingGameConfig.layout?.projectionMapping?.editor?.sliderClamp?.multiplierMin ?? 0,
-          multiplierMax: __existingGameConfig.layout?.projectionMapping?.editor?.sliderClamp?.multiplierMax ?? 5,
-          absoluteMin: __existingGameConfig.layout?.projectionMapping?.editor?.sliderClamp?.absoluteMin ?? -2000,
-          absoluteMax: __existingGameConfig.layout?.projectionMapping?.editor?.sliderClamp?.absoluteMax ?? 2000,
+        "visualFit": {
+          "tableCardContainerScale": 1.25,
+          "tableCardContentScale": 0.8,
+          "claimAvatarContainerScale": 1.25,
+          "claimAvatarContentScale": 0.8,
+          "avatarAdditiveZoomScale": 1.2
         },
-        multiplierVarHints: __existingGameConfig.layout?.projectionMapping?.editor?.multiplierVarHints ?? ['scale', 'frac', 'ratio', 'multiplier'],
-        sizePositionVarHints: __existingGameConfig.layout?.projectionMapping?.editor?.sizePositionVarHints ?? ['width', 'height', 'size', 'scale', 'gap', 'padding', 'min', 'max', 'offset', 'top', 'right', 'bottom', 'left', 'x', 'y', 'row', 'column', 'frac', 'avatar', 'card'],
+        "cinematic": {
+          "enabled": true,
+          "showEffects": true
+        }
       },
-      sharedVars: __existingGameConfig.layout?.projectionMapping?.sharedVars ?? [
-        '--layout-challenge-font-scale',
-        '--layout-challenge-image-scale',
-        '--layout-challenge-gap-scale',
-        '--layout-fit-font-scale',
-        '--layout-fit-image-scale',
-        '--layout-fit-gap-scale',
-      ],
-      varsByProjId: __existingGameConfig.layout?.projectionMapping?.varsByProjId ?? {
-        topbar: ['--layout-app-gap', '--layout-app-padding'],
-        sidebar: ['--layout-sidebar-width', '--layout-sidebar-content-scale', '--layout-seat-avatar-size'],
-        'seat-*': ['--layout-seat-avatar-size', '--layout-sidebar-content-scale'],
-        'avatar-*': ['--layout-seat-avatar-size', '--layout-human-seat-avatar-size', '--layout-cinematic-avatar-size'],
-        'human-seat-zone': ['--layout-human-seat-avatar-size'],
-        'human-seat': ['--layout-human-seat-avatar-size', '--layout-sidebar-content-scale'],
-        panel: ['--layout-table-dominance-frac', '--layout-table-view-height', '--layout-table-view-min-height', '--layout-table-view-max-height'],
-        'table-view': ['--layout-table-view-height', '--layout-table-view-min-height', '--layout-table-view-max-height', '--layout-card-base-scale', '--layout-card-scale', '--layout-card-table-base-width', '--layout-card-table-base-height', '--layout-card-mini-base-width', '--layout-card-mini-base-height', '--layout-table-card-auto-scale', '--layout-fit-additive-avatar-zoom'],
-        cinematic: ['--layout-cinematic-avatar-size'],
-        'action-column': ['--layout-action-column-height-scale', '--layout-action-column-max-height'],
-        controls: ['--layout-controls-height-scale', '--layout-controls-max-height', '--layout-controls-padding-y', '--layout-controls-padding-x', '--layout-controls-gap'],
-        'challenge-prompt': ['--layout-challenge-font-scale', '--layout-challenge-image-scale', '--layout-challenge-gap-scale', '--layout-controls-height-scale', '--layout-controls-max-height', '--layout-controls-padding-y', '--layout-controls-padding-x', '--layout-controls-gap'],
-        hand: [
-          '--hand-height-frac',
-          '--layout-hand-height-scale',
-          '--layout-hand-min-height',
-          '--layout-hand-max-height',
-          '--layout-hand-max-row-height',
-          '--layout-hand-card-min-width',
-          '--layout-hand-card-max-width',
-          '--layout-hand-card-min-height',
-          '--layout-hand-card-max-height',
-          '--layout-hand-card-gap-min',
-          '--layout-hand-card-gap-max',
-          '--layout-hand-wrap-padding-y',
-          '--layout-hand-wrap-padding-x',
-          '--layout-hand-wrap-gap',
-          '--layout-card-base-scale',
-          '--layout-card-hand-scale',
-          '--layout-card-scale',
-          '--layout-card-hit-min-width',
-          '--layout-card-hit-min-height',
-          '--layout-card-label-font-base',
-          '--layout-card-label-gap-base',
-          '--layout-card-label-padding-y-base',
-          '--layout-card-label-padding-x-base',
-          '--layout-card-label-offset-base',
-          '--layout-card-label-radius-base',
+      "regions": {
+        "actionFocus": {
+          "enabled": false,
+          "replaceWithFloatingClaimCluster": true
+        },
+        "turnSpotlight": {
+          "enabled": true,
+          "mustStayVisible": true,
+          "avatarSizePx": 180,
+          "nameBarBelowAvatar": true
+        },
+        "contextBox": {
+          "enabled": true,
+          "sharedDeclareAndChallengeSlot": true,
+          "mustStayVisible": true
+        }
+      },
+      "claimCluster": {
+        "enabled": true,
+        "anchor": "tableView",
+        "scaleAsOne": true,
+        "preserveRelativePositions": true,
+        "mustStayVisible": true,
+        "transparentShells": true,
+        "geometry": {
+          "centerXPct": 0.5,
+          "centerYPct": 0.54,
+          "widthPctOfTableView": 0.78,
+          "heightPctOfTableView": 0.48
+        },
+        "elements": {
+          "claimRankBox": {
+            "xPct": 0.5,
+            "yPct": 0.08,
+            "wPct": 0.12,
+            "hPct": 0.18
+          },
+          "claimHandBar": {
+            "xPct": 0.5,
+            "yPct": 0.52,
+            "wPct": 0.42,
+            "hPct": 0.3
+          },
+          "actorAvatarFloat": {
+            "xPct": 0.14,
+            "yPct": 0.52,
+            "wPct": 0.16,
+            "hPct": 0.24
+          },
+          "reactorAvatarFloat": {
+            "xPct": 0.86,
+            "yPct": 0.52,
+            "wPct": 0.16,
+            "hPct": 0.24
+          },
+          "claimTimesBoxLeft": {
+            "xPct": 0.26,
+            "yPct": 0.52,
+            "wPct": 0.07,
+            "hPct": 0.13
+          },
+          "claimCountBoxLeft": {
+            "xPct": 0.26,
+            "yPct": 0.66,
+            "wPct": 0.07,
+            "hPct": 0.13
+          },
+          "claimTimesBoxRight": {
+            "xPct": 0.74,
+            "yPct": 0.52,
+            "wPct": 0.07,
+            "hPct": 0.13
+          },
+          "claimCountBoxRight": {
+            "xPct": 0.74,
+            "yPct": 0.66,
+            "wPct": 0.07,
+            "hPct": 0.13
+          }
+        }
+      },
+      "shells": {
+        "transparentFloatingBoxes": true,
+        "disablePanelChromeForFloatingBoxes": true
+      },
+      "controlsToHandRelationship": "below",
+      "actionColumn": {
+        "heightScale": 0.25
+      },
+      "controls": {
+        "heightScale": 0.5
+      },
+      "allowChallengeOverflow": true,
+      "fitter": {
+        "enabled": true,
+        "reflowDebounceMs": 90,
+        "overflowTolerancePx": 1,
+        "minReadableFontScale": 0.72,
+        "stages": [
+          {
+            "fontScale": 0.96,
+            "imageScale": 0.95,
+            "gapScale": 0.94
+          },
+          {
+            "fontScale": 0.92,
+            "imageScale": 0.9,
+            "gapScale": 0.88
+          },
+          {
+            "fontScale": 0.88,
+            "imageScale": 0.86,
+            "gapScale": 0.82
+          },
+          {
+            "fontScale": 0.84,
+            "imageScale": 0.82,
+            "gapScale": 0.76
+          },
+          {
+            "fontScale": 0.8,
+            "imageScale": 0.78,
+            "gapScale": 0.7
+          },
+          {
+            "fontScale": 0.76,
+            "imageScale": 0.74,
+            "gapScale": 0.64
+          }
         ],
-        log: ['--layout-event-log-max-height', '--layout-event-log-padding-y', '--layout-event-log-padding-x', '--layout-event-log-gap', '--layout-log-item-padding-y', '--layout-log-item-padding-x', '--layout-log-max-row-height'],
+        "targets": {
+          "tableView": {
+            "selector": ".tableView",
+            "containmentSelector": ".tableViewCards",
+            "maxStage": 4,
+            "minReadableFontScale": 0.8
+          },
+          "actionFocus": {
+            "selector": ".actionFocus",
+            "containmentSelector": ".actionFocusMain",
+            "maxStage": 6,
+            "minReadableFontScale": 0.72
+          },
+          "actionColumn": {
+            "selector": ".actionColumn",
+            "maxStage": 4,
+            "minReadableFontScale": 0.76
+          },
+          "contextBox": {
+            "selector": ".contextBox",
+            "maxStage": 5,
+            "minReadableFontScale": 0.74
+          },
+          "turnSpotlight": {
+            "selector": ".turnSpotlight",
+            "maxStage": 5,
+            "minReadableFontScale": 0.74
+          },
+          "claimCluster": {
+            "selector": ".claimCluster",
+            "maxStage": 4,
+            "minReadableFontScale": 0.72
+          },
+          "sidebarSeats": {
+            "selector": "#aiSidebar",
+            "maxStage": 6,
+            "minReadableFontScale": 0.72
+          },
+          "handCards": {
+            "selector": ".handWrap",
+            "containmentSelector": ".handScroll",
+            "maxStage": 6,
+            "minReadableFontScale": 0.76
+          },
+          "logs": {
+            "selector": ".eventLog",
+            "maxStage": 4,
+            "minReadableFontScale": 0.78
+          },
+          "controls": {
+            "selector": ".controls",
+            "maxStage": 6,
+            "minReadableFontScale": 0.78
+          }
+        },
+        "overlap": {
+          "enabled": true,
+          "tolerancePx": 0,
+          "criticalRegions": {
+            "tableView": ".tableView",
+            "controls": ".controls",
+            "hand": ".handWrap",
+            "actionColumn": ".actionColumn",
+            "contextBox": ".contextBox",
+            "log": ".eventLog",
+            "sidebar": "#aiSidebar",
+            "turnSpotlight": ".turnSpotlight",
+            "claimCluster": ".claimCluster",
+            "challenge": "#challengePromptPane"
+          },
+          "collapseOrder": [],
+          "preserveRegions": [
+            "tableView",
+            "controls",
+            "sidebar",
+            "turnSpotlight",
+            "claimCluster",
+            "contextBox"
+          ],
+          "minContainerScale": 0.7,
+          "containerScaleStep": 0.02
+        }
       },
-      selectorVarsByProjId: __existingGameConfig.layout?.projectionMapping?.selectorVarsByProjId ?? {
-        // NOTE FOR AI/TOOLS: whenever layout vars change, update projectionMapping vars/selectorVars so the in-game vars tool stays in sync.
-        'table-view': {
-          '.tableViewCard, .tableViewCard img': ['--layout-card-base-scale', '--layout-card-scale', '--layout-card-table-base-width', '--layout-card-table-base-height'],
-          '.claimHandBar, .claimHandBar .tableViewCard, .claimHandBar .tableViewCard img': ['--layout-card-mini-base-width', '--layout-card-mini-base-height', '--layout-card-scale'],
-          '.actorAvatarFloat, .reactorAvatarFloat, .actorAvatarFloat canvas, .reactorAvatarFloat canvas, .seatPortrait': ['--layout-seat-avatar-size', '--layout-human-seat-avatar-size', '--layout-cinematic-avatar-size', '--layout-sidebar-content-scale'],
-          '.claimRankBox, .claimCountBoxLeft, .claimCountBoxRight, .turnSpotlightNameBar': ['--layout-challenge-font-scale', '--layout-fit-font-scale'],
+      "projectionMapping": {
+        "editor": {
+          "step": 0.01,
+          "panelTitle": "Projection Vars",
+          "sliderClamp": {
+            "multiplierMin": 0,
+            "multiplierMax": 5,
+            "absoluteMin": -2000,
+            "absoluteMax": 2000
+          },
+          "multiplierVarHints": [
+            "scale",
+            "frac",
+            "ratio",
+            "multiplier"
+          ],
+          "sizePositionVarHints": [
+            "width",
+            "height",
+            "size",
+            "scale",
+            "gap",
+            "padding",
+            "min",
+            "max",
+            "offset",
+            "top",
+            "right",
+            "bottom",
+            "left",
+            "x",
+            "y",
+            "row",
+            "column",
+            "frac",
+            "avatar",
+            "card"
+          ]
         },
-        sidebar: {
-          '.seatAvatarBox, .seatPortrait': ['--layout-seat-avatar-size', '--layout-sidebar-content-scale'],
-          '.seatName, .seatMeta, .seatStatus, .seatSeed, .seatTags': ['--layout-sidebar-content-scale'],
+        "sharedVars": [
+          "--layout-challenge-font-scale",
+          "--layout-challenge-image-scale",
+          "--layout-challenge-gap-scale",
+          "--layout-fit-font-scale",
+          "--layout-fit-image-scale",
+          "--layout-fit-gap-scale"
+        ],
+        "varsByProjId": {
+          "topbar": [
+            "--layout-app-gap",
+            "--layout-app-padding"
+          ],
+          "sidebar": [
+            "--layout-sidebar-width",
+            "--layout-sidebar-content-scale",
+            "--layout-seat-avatar-size"
+          ],
+          "seat-*": [
+            "--layout-seat-avatar-size",
+            "--layout-sidebar-content-scale"
+          ],
+          "avatar-*": [
+            "--layout-seat-avatar-size",
+            "--layout-human-seat-avatar-size",
+            "--layout-cinematic-avatar-size"
+          ],
+          "human-seat-zone": [
+            "--layout-human-seat-avatar-size"
+          ],
+          "human-seat": [
+            "--layout-human-seat-avatar-size",
+            "--layout-sidebar-content-scale"
+          ],
+          "panel": [
+            "--layout-table-dominance-frac",
+            "--layout-table-view-height",
+            "--layout-table-view-min-height",
+            "--layout-table-view-max-height"
+          ],
+          "table-view": [
+            "--layout-table-view-height",
+            "--layout-table-view-min-height",
+            "--layout-table-view-max-height",
+            "--layout-card-base-scale",
+            "--layout-card-scale",
+            "--layout-card-table-base-width",
+            "--layout-card-table-base-height",
+            "--layout-card-mini-base-width",
+            "--layout-card-mini-base-height",
+            "--layout-table-card-auto-scale",
+            "--layout-fit-additive-avatar-zoom"
+          ],
+          "cinematic": [
+            "--layout-cinematic-avatar-size"
+          ],
+          "action-column": [
+            "--layout-action-column-height-scale",
+            "--layout-action-column-max-height"
+          ],
+          "controls": [
+            "--layout-controls-height-scale",
+            "--layout-controls-max-height",
+            "--layout-controls-padding-y",
+            "--layout-controls-padding-x",
+            "--layout-controls-gap"
+          ],
+          "challenge-prompt": [
+            "--layout-challenge-font-scale",
+            "--layout-challenge-image-scale",
+            "--layout-challenge-gap-scale",
+            "--layout-controls-height-scale",
+            "--layout-controls-max-height",
+            "--layout-controls-padding-y",
+            "--layout-controls-padding-x",
+            "--layout-controls-gap"
+          ],
+          "hand": [
+            "--hand-height-frac",
+            "--layout-hand-height-scale",
+            "--layout-hand-min-height",
+            "--layout-hand-max-height",
+            "--layout-hand-max-row-height",
+            "--layout-hand-card-min-width",
+            "--layout-hand-card-max-width",
+            "--layout-hand-card-min-height",
+            "--layout-hand-card-max-height",
+            "--layout-hand-card-gap-min",
+            "--layout-hand-card-gap-max",
+            "--layout-hand-wrap-padding-y",
+            "--layout-hand-wrap-padding-x",
+            "--layout-hand-wrap-gap",
+            "--layout-card-base-scale",
+            "--layout-card-hand-scale",
+            "--layout-card-scale",
+            "--layout-card-hit-min-width",
+            "--layout-card-hit-min-height",
+            "--layout-card-label-font-base",
+            "--layout-card-label-gap-base",
+            "--layout-card-label-padding-y-base",
+            "--layout-card-label-padding-x-base",
+            "--layout-card-label-offset-base",
+            "--layout-card-label-radius-base"
+          ],
+          "log": [
+            "--layout-event-log-max-height",
+            "--layout-event-log-padding-y",
+            "--layout-event-log-padding-x",
+            "--layout-event-log-gap",
+            "--layout-log-item-padding-y",
+            "--layout-log-item-padding-x",
+            "--layout-log-max-row-height"
+          ]
         },
-        'seat-*': {
-          '.seatAvatarBox, .seatPortrait': ['--layout-seat-avatar-size', '--layout-sidebar-content-scale'],
-          '.seatName, .seatMeta, .seatStatus, .seatSeed, .seatTags': ['--layout-sidebar-content-scale'],
+        "selectorVarsByProjId": {
+          "table-view": {
+            ".tableViewCard, .tableViewCard img": [
+              "--layout-card-base-scale",
+              "--layout-card-scale",
+              "--layout-card-table-base-width",
+              "--layout-card-table-base-height"
+            ],
+            ".claimHandBar, .claimHandBar .tableViewCard, .claimHandBar .tableViewCard img": [
+              "--layout-card-mini-base-width",
+              "--layout-card-mini-base-height",
+              "--layout-card-scale"
+            ],
+            ".actorAvatarFloat, .reactorAvatarFloat, .actorAvatarFloat canvas, .reactorAvatarFloat canvas, .seatPortrait": [
+              "--layout-seat-avatar-size",
+              "--layout-human-seat-avatar-size",
+              "--layout-cinematic-avatar-size",
+              "--layout-sidebar-content-scale"
+            ],
+            ".claimRankBox, .claimCountBoxLeft, .claimCountBoxRight, .turnSpotlightNameBar": [
+              "--layout-challenge-font-scale",
+              "--layout-fit-font-scale"
+            ]
+          },
+          "sidebar": {
+            ".seatAvatarBox, .seatPortrait": [
+              "--layout-seat-avatar-size",
+              "--layout-sidebar-content-scale"
+            ],
+            ".seatName, .seatMeta, .seatStatus, .seatSeed, .seatTags": [
+              "--layout-sidebar-content-scale"
+            ]
+          },
+          "seat-*": {
+            ".seatAvatarBox, .seatPortrait": [
+              "--layout-seat-avatar-size",
+              "--layout-sidebar-content-scale"
+            ],
+            ".seatName, .seatMeta, .seatStatus, .seatSeed, .seatTags": [
+              "--layout-sidebar-content-scale"
+            ]
+          },
+          "human-seat": {
+            ".seatAvatarBox, .seatPortrait": [
+              "--layout-human-seat-avatar-size"
+            ],
+            ".seatName, .seatMeta, .seatStatus, .humanSeatChipBadge": [
+              "--layout-sidebar-content-scale"
+            ]
+          },
+          "hand": {
+            ".card, .cardArt": [
+              "--layout-card-base-scale",
+              "--layout-card-hand-scale",
+              "--layout-card-scale",
+              "--layout-hand-card-min-width",
+              "--layout-hand-card-max-width",
+              "--layout-hand-card-min-height",
+              "--layout-hand-card-max-height",
+              "--layout-card-hit-min-width",
+              "--layout-card-hit-min-height"
+            ],
+            ".cardLabel, .cardGlyph, .cardText": [
+              "--layout-card-label-font-base",
+              "--layout-card-label-gap-base",
+              "--layout-card-label-padding-y-base",
+              "--layout-card-label-padding-x-base",
+              "--layout-card-label-offset-base",
+              "--layout-card-label-radius-base",
+              "--layout-card-scale"
+            ],
+            ".handScroll": [
+              "--layout-hand-card-gap-min",
+              "--layout-hand-card-gap-max"
+            ]
+          }
         },
-        'human-seat': {
-          '.seatAvatarBox, .seatPortrait': ['--layout-human-seat-avatar-size'],
-          '.seatName, .seatMeta, .seatStatus, .humanSeatChipBadge': ['--layout-sidebar-content-scale'],
-        },
-        hand: {
-          '.card, .cardArt': ['--layout-card-base-scale', '--layout-card-hand-scale', '--layout-card-scale', '--layout-hand-card-min-width', '--layout-hand-card-max-width', '--layout-hand-card-min-height', '--layout-hand-card-max-height', '--layout-card-hit-min-width', '--layout-card-hit-min-height'],
-          '.cardLabel, .cardGlyph, .cardText': ['--layout-card-label-font-base', '--layout-card-label-gap-base', '--layout-card-label-padding-y-base', '--layout-card-label-padding-x-base', '--layout-card-label-offset-base', '--layout-card-label-radius-base', '--layout-card-scale'],
-          '.handScroll': ['--layout-hand-card-gap-min', '--layout-hand-card-gap-max'],
-        },
-      },
-      fallbackVars: __existingGameConfig.layout?.projectionMapping?.fallbackVars ?? [
-        '--layout-app-gap',
-        '--layout-app-padding',
-        '--layout-sidebar-width',
-        '--layout-sidebar-content-scale',
-        '--layout-table-view-height',
-        '--layout-table-view-min-height',
-        '--layout-table-view-max-height',
-        '--layout-table-dominance-frac',
-        '--layout-action-column-height-scale',
-        '--layout-action-column-max-height',
-        '--layout-controls-height-scale',
-        '--layout-controls-max-height',
-        '--layout-hand-height-scale',
-        '--layout-card-base-scale',
-        '--layout-card-hand-scale',
-        '--layout-hand-min-height',
-        '--layout-hand-max-height',
-        '--layout-hand-card-min-width',
-        '--layout-hand-card-max-width',
-        '--layout-hand-card-min-height',
-        '--layout-hand-card-max-height',
-        '--layout-hand-wrap-padding-y',
-        '--layout-hand-wrap-padding-x',
-        '--layout-hand-wrap-gap',
-        '--layout-event-log-max-height',
-        '--layout-log-max-row-height',
-      ],
-
+        "fallbackVars": [
+          "--layout-app-gap",
+          "--layout-app-padding",
+          "--layout-sidebar-width",
+          "--layout-sidebar-content-scale",
+          "--layout-table-view-height",
+          "--layout-table-view-min-height",
+          "--layout-table-view-max-height",
+          "--layout-table-dominance-frac",
+          "--layout-action-column-height-scale",
+          "--layout-action-column-max-height",
+          "--layout-controls-height-scale",
+          "--layout-controls-max-height",
+          "--layout-hand-height-scale",
+          "--layout-card-base-scale",
+          "--layout-card-hand-scale",
+          "--layout-hand-min-height",
+          "--layout-hand-max-height",
+          "--layout-hand-card-min-width",
+          "--layout-hand-card-max-width",
+          "--layout-hand-card-min-height",
+          "--layout-hand-card-max-height",
+          "--layout-hand-wrap-padding-y",
+          "--layout-hand-wrap-padding-x",
+          "--layout-hand-wrap-gap",
+          "--layout-event-log-max-height",
+          "--layout-log-max-row-height"
+        ]
+      }
     },
-  },
-  uiText: {
-    initialBanner: __existingGameConfig.uiText?.initialBanner ?? __legacyGameplayConfig.initialBanner ?? 'Open a round by selecting one or more cards, then declare a number.',
-    yourLeadBanner: __existingGameConfig.uiText?.yourLeadBanner ?? __legacyGameplayConfig.yourLeadBanner ?? 'Your lead. Select cards and declare any number.',
-    pickCardWarning: __existingGameConfig.uiText?.pickCardWarning ?? __legacyGameplayConfig.pickCardWarning ?? 'Pick at least one card before playing.',
-    challengeTimerLabel: __existingGameConfig.uiText?.challengeTimerLabel ?? __legacyGameplayConfig.challengeTimerLabel ?? 'Auto: let it stand',
-    challengePromptTemplate: __existingGameConfig.uiText?.challengePromptTemplate ?? __legacyGameplayConfig.challengePromptTemplate ?? '{seat} declared {count} × {rank}. Challenge before the timer runs out, or let it stand.',
-    letStandButton: __existingGameConfig.uiText?.letStandButton ?? __legacyGameplayConfig.letStandButton ?? 'Let it stand',
-  },
-  assets: {
-    cards: {
-      hudBasePath: __existingGameConfig.assets?.cards?.hudBasePath ?? __legacyGameplayConfig.cardsHudBasePath ?? './docs/assets/hud/',
-      wild: {
-        src: __existingGameConfig.assets?.cards?.wild?.src ?? __legacyGameplayConfig.wildCardAsset ?? '2DScratchBoneWild.png',
-        fallbackSrc: __existingGameConfig.assets?.cards?.wild?.fallbackSrc ?? __legacyGameplayConfig.wildCardAssetFallback ?? '2DScratchBoneWild.png',
-      },
-      flipped: {
-        src: __existingGameConfig.assets?.cards?.flipped?.src ?? __legacyGameplayConfig.flippedCardAsset ?? '2DScratchboneFlipped.png',
-        fallbackSrc: __existingGameConfig.assets?.cards?.flipped?.fallbackSrc ?? __legacyGameplayConfig.flippedCardAssetFallback ?? '2DScratchBoneFlipped.png',
-      },
-      rankTemplate: {
-        src: __existingGameConfig.assets?.cards?.rankTemplate?.src ?? __legacyGameplayConfig.rankCardTemplate ?? '2DScratchbone{rank}.png',
-        fallbackSrc: __existingGameConfig.assets?.cards?.rankTemplate?.fallbackSrc ?? __legacyGameplayConfig.rankCardTemplateFallback ?? '2DScratchbones{rank}.png',
-      },
+    "uiText": {
+      "initialBanner": "Open a round by selecting one or more cards, then declare a number.",
+      "yourLeadBanner": "Your lead. Select cards and declare any number.",
+      "pickCardWarning": "Pick at least one card before playing.",
+      "challengeTimerLabel": "Auto: let it stand",
+      "challengePromptTemplate": "{seat} declared {count} × {rank}. Challenge before the timer runs out, or let it stand.",
+      "letStandButton": "Let it stand"
     },
-    portrait: {
-      assetBase: __existingGameConfig.assets?.portrait?.assetBase ?? __existingScratchbonesConfig.portrait?.assetBase ?? './docs/assets/',
-      configBase: __existingGameConfig.assets?.portrait?.configBase ?? __existingScratchbonesConfig.portrait?.configBase ?? './docs/config/',
-    },
-  },
+    "assets": {
+      "cards": {
+        "hudBasePath": "./docs/assets/hud/",
+        "wild": {
+          "src": "2DScratchBoneWild.png",
+          "fallbackSrc": "2DScratchBoneWild.png"
+        },
+        "flipped": {
+          "src": "2DScratchboneFlipped.png",
+          "fallbackSrc": "2DScratchBoneFlipped.png"
+        },
+        "rankTemplate": {
+          "src": "2DScratchbone{rank}.png",
+          "fallbackSrc": "2DScratchbones{rank}.png"
+        }
+      },
+      "portrait": {
+        "assetBase": "./docs/assets/",
+        "configBase": "./docs/config/"
+      }
+    }
+  }
 };
 
-window.SCRATCHBONES_CONFIG.portrait = window.SCRATCHBONES_CONFIG.game.assets.portrait;
+// Future Scratchbones-authored UI modes live under SCRATCHBONES_CONFIG.game.layout.
+window.SCRATCHBONES_CONFIG.game.layout.mode = window.SCRATCHBONES_CONFIG.game.layout.mode || 'fitter';
+window.SCRATCHBONES_CONFIG.game.layout.authored = window.SCRATCHBONES_CONFIG.game.layout.authored || {};
+window.SCRATCHBONES_CONFIG.game.layout.fitter = window.SCRATCHBONES_CONFIG.game.layout.fitter || {};
+
+// Most recent config-boundary cleanup: this file is now the authoritative Scratchbones-only config source.


### PR DESCRIPTION
### Motivation
- Prevent Scratchbones from silently inheriting configuration from legacy/shared shapes (e.g. `.gameplay`) and enforce a strict Scratchbones-only config boundary. 
- Make `docs/config/scratchbones-config.js` the single authoritative source for Scratchbones values and prepare a local home for future authored UI layout settings. 

### Description
- Removed legacy/shared fallback bridging in `ScratchbonesBluffGame.html` so the runtime no longer reads from `scratchbonesRootConfig.gameplay` or other sibling legacy keys and now relies only on `window.SCRATCHBONES_CONFIG.game` as its source. 
- Introduced a small Scratchbones-only config layer in `ScratchbonesBluffGame.html` with `reportScratchbonesConfigError()`, `validateScratchbonesGameConfig()`, `normalizeScratchbonesGameConfig(raw)`, and `getScratchbonesGameConfig()` and wired the page to use `const SCRATCHBONES_GAME = getScratchbonesGameConfig()`. 
- Surface config validation failures loudly by logging to console, appending to the in-page debug panel, and rendering an in-page error message so missing/invalid `SCRATCHBONES_CONFIG.game` is visible on mobile and desktop. 
- Removed `docs/config/portrait-config.js` include from the page and restricted portrait config reads to `SCRATCHBONES_CONFIG.game.assets.portrait` only. 
- Rewrote `docs/config/scratchbones-config.js` into a canonical Scratchbones-only object `window.SCRATCHBONES_CONFIG = { game: { ... } }`, populated all Scratchbones-owned values (`deck`, `chips`, `timers`, `layout`, `uiText`, `assets`), and added placeholder fields under `game.layout` (`layout.mode`, `layout.authored`, `layout.fitter`) plus a brief comment noting the recent boundary cleanup. 
- Left runtime behavior intact by migrating any values that previously came from legacy fallbacks into the authoritative `game` shape and preserving existing defaults inside the Scratchbones normalization layer. 

### Testing
- Ran targeted searches to confirm legacy bridge usage was removed: `rg -n "\.gameplay|legacyGameplay|__legacy|SCRATCHBONES_CONFIG\?\.portrait" ScratchbonesBluffGame.html docs/config/scratchbones-config.js` and found no remaining runtime reads of `.gameplay` (success). 
- Executed the config file in a VM and validated the shape with a Node script that checked `window.SCRATCHBONES_CONFIG.game` contains `deck`, `chips`, `timers`, `layout`, `uiText`, and `assets` (success). 
- Verified the page loads only `docs/config/scratchbones-config.js` as its config source by searching for `docs/config/*.config.js` references in `ScratchbonesBluffGame.html` (success). 
- Committed the changes after validation; automated checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03261b1f88326bb541b5caa73dc61)