### PR TITLE
Fix authored layout hand clipping regression on top of #925

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -1884,7 +1884,6 @@
       turnSpotlight: 'tableView',
       claimCluster: 'tableView',
       challengePrompt: 'contextBox',
-      hand: 'contextBox',
     };
     const DEFAULT_AUTHORED_BOXES = {
       topbar: { x: 8, y: 8, width: 1624, height: 120 },


### PR DESCRIPTION
### Motivation
- Fix a high-priority authored-layout bug where the `hand` box was treated as a child of `contextBox`, causing it to be offset and clipped inside `.contextBox` in authored mode.

### Description
- Removed the `hand` entry from `AUTHORED_PARENT_BOX` in `ScratchbonesBluffGame.html` so `hand` is positioned in global authored design space rather than parent-relative to `contextBox`.

### Testing
- Verified the change with `git diff` to confirm only the intended mapping was removed, ran `git commit` which completed successfully, and inspected the file lines with `nl` to confirm `hand` was removed from `AUTHORED_PARENT_BOX` (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0437b35f88326a3cff76be5473a4a)