### PR TITLE
Fix authored turnSpotlight coordinates to prevent clipping

### DIFF
--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -48,7 +48,7 @@ window.SCRATCHBONES_CONFIG = {
           "hand": { "x": 20, "y": 700, "width": 940, "height": 140 },
           "log": { "x": 20, "y": 850, "width": 1240, "height": 40 },
           "tableView": { "x": 220, "y": 240, "width": 960, "height": 260 },
-          "turnSpotlight": { "x": 1220, "y": 20, "width": 160, "height": 180 },
+          "turnSpotlight": { "x": 790, "y": 10, "width": 160, "height": 180 },
           "claimCluster": { "x": 220, "y": 240, "width": 960, "height": 260 },
           "challengePrompt": { "x": 960, "y": 700, "width": 280, "height": 140 }
         }


### PR DESCRIPTION
### Motivation
- With `layout.mode` set to "authored", the `turnSpotlight` box was being re-anchored relative to `tableView` and the previous global coordinates placed the spotlight outside the table view so it was clipped, so the authored coordinates must be adjusted to keep the spotlight visible.

### Description
- Updated `docs/config/scratchbones-config.js` to change `authored.boxes.turnSpotlight` from `{ x: 1220, y: 20, width: 160, height: 180 }` to `{ x: 790, y: 10, width: 160, height: 180 }` so the spotlight remains inside the authored `tableView` bounds while preserving size and top-right placement.

### Testing
- Inspected `docs/config/scratchbones-config.js` to verify the coordinate update and confirmed the spotlight now sits within the authored `tableView` area; no automated tests were executed for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1570f49c48326875ce33151de596e)