### PR TITLE
Fix gameplay-map-editor hit detection to match rendered entity bounds

### DIFF
--- a/docs/GAMEPLAY_MAP_EDITOR_README.md
+++ b/docs/GAMEPLAY_MAP_EDITOR_README.md
@@ -29,6 +29,7 @@ The Gameplay Map Editor now supports loading 3D visual maps as a background refe
 
 4. **Editing**
    - Place gameplay entities (spawners, patrols, colliders) on the 2D canvas
+   - Selection/drag hit detection follows the same world-space bounds shown on canvas (collider rectangles/circles and patrol/door footprint boxes), so dragging an entity from within its rendered box moves the correct record
    - The 3D background helps visualize where these elements fit in the actual environment
    - The 2D canvas is transparent, allowing you to see the 3D scene beneath
 

--- a/docs/gameplay-map-editor.html
+++ b/docs/gameplay-map-editor.html
@@ -682,24 +682,38 @@
     }
 
     function isPointInEntity(wx, wy, entity) {
-      if (entity.type === 'collider') {
+      const normalizedType = normalizeEntityType(entity.type);
+
+      if (normalizedType === 'collider') {
         const shape = entity.meta.shape || 'rectangle';
         if (shape === 'rectangle') {
-          const w = entity.meta.width || 100;
-          const h = entity.meta.height || 100;
-          return wx >= entity.x - w/2 && wx <= entity.x + w/2 &&
-                 wy >= entity.y - h/2 && wy <= entity.y + h/2;
-        } else if (shape === 'circle') {
-          const r = entity.meta.radius || 50;
+          const w = Number(entity.meta.width) || 100;
+          const h = Number(entity.meta.height) || 100;
+          return wx >= entity.x - w / 2 && wx <= entity.x + w / 2 &&
+                 wy >= entity.y - h / 2 && wy <= entity.y + h / 2;
+        }
+        if (shape === 'circle') {
+          const r = Number(entity.meta.radius) || 50;
           const dx = wx - entity.x;
           const dy = wy - entity.y;
-          return Math.sqrt(dx*dx + dy*dy) <= r;
+          return Math.sqrt(dx * dx + dy * dy) <= r;
         }
+      } else if (normalizedType === 'patrolpoint' || normalizedType === 'door') {
+        const scale = entity.meta.scale || {};
+        const scaleX = Number(scale.x) || 1;
+        const scaleY = Number(scale.y) || 1;
+        const heightWorld = (tileSize || 0) * scaleY;
+        const widthWorld = (tileSize || 0) * scaleX;
+        const left = entity.x - (widthWorld / 2);
+        const right = entity.x + (widthWorld / 2);
+        const top = entity.y - heightWorld;
+        const bottom = entity.y;
+        return wx >= left && wx <= right && wy >= top && wy <= bottom;
       } else {
         // Point entities - check within 20 world units
         const dx = wx - entity.x;
         const dy = wy - entity.y;
-        return Math.sqrt(dx*dx + dy*dy) <= 20;
+        return Math.sqrt(dx * dx + dy * dy) <= 20;
       }
       return false;
     }


### PR DESCRIPTION
### Motivation
- The editor's draggable boxes did not line up with the visuals because hit-testing used a generic small point-radius for non-collider entities while `drawEntity` renders patrol and door entities as world-space rectangles.
- I traced input → `screenToWorld` → `findEntityAt` → `isPointInEntity` and confirmed hit testing was the mismatch causing clicks/drags to select the wrong records.

### Description
- Updated `isPointInEntity` in `docs/gameplay-map-editor.html` to call `normalizeEntityType(entity.type)` and to use the same world-space bounds as rendering: colliders use rectangle/circle math with `Number(...)` casting, and `patrolpoint`/`door` use tile-scaled footprint boxes anchored to the same top/bottom semantics used by `drawEntity`.
- Added a short note to `docs/GAMEPLAY_MAP_EDITOR_README.md` stating that selection/drag hit detection follows rendered world-space footprints for colliders, patrol points, and doors.

### Testing
- Ran `npm run lint` (which executes `eslint .`) and it completed successfully.
- Ran `npm run test:unit` to ensure no infra regressions; the test run failed due to multiple unrelated pre-existing test failures in the repository (reported but not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e158c9700883268c414b81c30bb382)