### PR TITLE
Keep authored `turnSpotlight` inside `tableView` to prevent clipping

### DIFF
--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -48,7 +48,7 @@ window.SCRATCHBONES_CONFIG = {
           "hand": { "x": 20, "y": 700, "width": 940, "height": 140 },
           "log": { "x": 20, "y": 850, "width": 1240, "height": 40 },
           "tableView": { "x": 220, "y": 240, "width": 960, "height": 260 },
-          "turnSpotlight": { "x": 790, "y": 10, "width": 160, "height": 180 },
+          "turnSpotlight": { "x": 1010, "y": 250, "width": 160, "height": 180 },
           "claimCluster": { "x": 220, "y": 240, "width": 960, "height": 260 },
           "challengePrompt": { "x": 960, "y": 700, "width": 280, "height": 140 }
         }


### PR DESCRIPTION
### Motivation
- Prevent authored `turnSpotlight` from being clipped by the `.tableView { overflow: hidden }` runtime anchoring when `layout.mode` is `"authored"` by aligning the authored global coordinates with the runtime re-anchor behavior.

### Description
- Updated `docs/config/scratchbones-config.js` authored `boxes.turnSpotlight` from `{ x: 790, y: 10, width: 160, height: 180 }` to `{ x: 1010, y: 250, width: 160, height: 180 }` so that after the runtime re-anchor to `tableView` the local position falls inside the `tableView` bounds.

### Testing
- Loaded the config in Node with `node -e "global.window={}; require('./docs/config/scratchbones-config.js'); console.log(window.SCRATCHBONES_CONFIG.game.layout.authored.boxes.turnSpotlight)"` and verified the authored coordinates are `{ x: 1010, y: 250, width: 160, height: 180 }` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e158f1dd0c83268c334b6ecdea1add)