### PR TITLE
Fix authored-mode box alignment by locking #app to authored design size

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2003,6 +2003,8 @@
       const scale = computeAuthoredScale(liveWidth, liveHeight, authoredConfig.designWidthPx, authoredConfig.designHeightPx);
       const translatedX = Math.round((liveWidth - (authoredConfig.designWidthPx * scale)) / 2);
       const translatedY = Math.round((liveHeight - (authoredConfig.designHeightPx * scale)) / 2);
+      app.style.width = `${Math.round(authoredConfig.designWidthPx)}px`;
+      app.style.height = `${Math.round(authoredConfig.designHeightPx)}px`;
       app.style.transform = `translate(${translatedX}px, ${translatedY}px) scale(${scale.toFixed(5)})`;
       app.style.transformOrigin = 'top left';
       const mapped = new Map();
@@ -4355,6 +4357,8 @@
         applyAuthoredLayoutMode(app, getScratchbonesAuthoredConfig());
         state.layoutFitStages = {};
       } else {
+        app.style.width = '';
+        app.style.height = '';
         app.style.transform = '';
         app.style.transformOrigin = '';
         applyResponsiveFit(app);


### PR DESCRIPTION
### Motivation
- Authored-mode overlays and draggable boxes used authored.designWidthPx/designHeightPx for projection math, but `#app` could remain sized to the viewport, producing a second coordinate space and misaligned/hidden elements.
- The change ensures the editor overlays and the DOM elements they control share the same coordinate system so draggable boxes align with their targets.

### Description
- In `applyAuthoredLayoutMode()` set `#app` inline `width` and `height` to `authored.designWidthPx`/`authored.designHeightPx` before applying the translate+scale transform so projection math and element sizing use the same base dimensions.
- When leaving authored mode, explicit inline `width`/`height` are cleared so responsive behavior is unchanged.
- This change is scoped to the authored-mode layout application and the responsive-mode reset path and does not change any config schemas or authored box data.

### Testing
- No automated unit tests were executed for this change in this environment.
- Verified the edit via repository inspection commands including `git status --short` and `git show --stat --oneline -1` and confirmed the diff updates `applyAuthoredLayoutMode()` and the authored/responsive paths.
- Manual code review validated that transforms and overlay rendering continue to use the authored design dimensions and that width/height overrides are removed when not in authored mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e17614979c8326b132644b8519b1f5)