### PR TITLE
Fix authored overlay pointer-capture InvalidStateError

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -1902,6 +1902,8 @@
     const authoredEditorState = {
       selectedId: null,
       pointerDrag: null,
+      pointerCaptureTarget: null,
+      pointerCaptureId: null,
       mode: 'none',
       lastChange: 'Editor idle.',
       gridEnabled: false,
@@ -4885,7 +4887,7 @@
       if (!overlay) return false;
       const boxId = overlay.dataset.boxId;
       if (!boxId) return false;
-      selectAuthoredBox(boxId);
+      if (authoredEditorState.selectedId !== boxId) selectAuthoredBox(boxId);
       const authored = getScratchbonesAuthoredConfig();
       const box = authored.boxes[boxId];
       if (!box) return false;
@@ -4902,7 +4904,16 @@
         startBox: { ...box },
         scale,
       };
-      overlay.setPointerCapture(event.pointerId);
+      authoredEditorState.pointerCaptureTarget = overlay;
+      authoredEditorState.pointerCaptureId = event.pointerId;
+      if (typeof overlay.setPointerCapture === 'function') {
+        try {
+          overlay.setPointerCapture(event.pointerId);
+        } catch {
+          authoredEditorState.pointerCaptureTarget = null;
+          authoredEditorState.pointerCaptureId = null;
+        }
+      }
       event.preventDefault();
       return true;
     }
@@ -4922,11 +4933,14 @@
       updateAuthoredBox(drag.boxId, next);
       updateEditorStatus(`Updated ${drag.boxId}: x=${Math.round(next.x)} y=${Math.round(next.y)} w=${Math.round(next.width)} h=${Math.round(next.height)}`);
     }
-    function finishAuthoredPointer(event) {
+    function finishAuthoredPointer() {
       if (!authoredEditorState.pointerDrag) return;
-      const overlay = event.target.closest('.authoredBoxOverlay');
-      if (overlay?.hasPointerCapture?.(event.pointerId)) overlay.releasePointerCapture(event.pointerId);
+      const captureTarget = authoredEditorState.pointerCaptureTarget;
+      const captureId = authoredEditorState.pointerCaptureId;
+      if (captureId != null && captureTarget?.hasPointerCapture?.(captureId)) captureTarget.releasePointerCapture(captureId);
       authoredEditorState.pointerDrag = null;
+      authoredEditorState.pointerCaptureTarget = null;
+      authoredEditorState.pointerCaptureId = null;
     }
     (function initProjMap() {
       const btn = document.getElementById('projMapBtn');
@@ -5067,6 +5081,7 @@
         } else tip.style.display = 'none';
       });
       document.addEventListener('pointerup', finishAuthoredPointer);
+      document.addEventListener('pointercancel', finishAuthoredPointer);
       document.addEventListener('click', (event) => {
         if (!projectionUiState.active) return;
         if (event.target.closest('#projMapBtn,#projVarBtn,#projVarPanel,#projExportBtn')) return;


### PR DESCRIPTION
### Motivation
- A `pointerdown` on an `.authoredBoxOverlay` could trigger a rerender/select that invalidated the element before `setPointerCapture` ran, causing an uncaught `InvalidStateError` during drag start.
- Pointer-capture ownership was not tracked, so releases relied on the event target which could be different from the element that actually had capture.

### Description
- Add `pointerCaptureTarget` and `pointerCaptureId` to `authoredEditorState` to track capture ownership independently of event targets.
- Prevent unnecessary re-selection rerenders by skipping `selectAuthoredBox(boxId)` when the box is already selected so the overlay element remains stable during drag start.
- Guard `setPointerCapture` with a feature check and `try/catch` so failures no longer throw an uncaught `InvalidStateError`, and clear capture metadata if capture fails.
- Release capture from the tracked element/id on drag end and also handle `pointercancel`, and clear capture/drag state; remove the unused `event` parameter from `finishAuthoredPointer`.

### Testing
- No automated tests were run for this standalone HTML interaction fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e17f63f85c8326ad6e13d9a0a8ab68)