### PR TITLE
Use species head xform in Cosmetic Placer preview

### DIFF
--- a/docs/character-tools.html
+++ b/docs/character-tools.html
@@ -2241,6 +2241,11 @@ function cosDrawLayer(img, ax, ay, sx, sy, filter) {
 function cosRender() {
   cosCtx.clearRect(0, 0, cosCW, cosCH);
 
+  const headPath = document.getElementById('cos-headPath')?.value || '';
+  const speciesData = cosGetCurrentSpeciesData();
+  const fighter = FIGHTERS.find(f => f.headUrl === headPath.trim());
+  const headXform = (speciesData && speciesData.headXform) || fighter?.headXform || HEAD_XFORM;
+
   // Centre cross guide
   cosCtx.save();
   cosCtx.strokeStyle = '#1e2836'; cosCtx.lineWidth = 1;
@@ -2254,22 +2259,22 @@ function cosRender() {
   const drawSlot = (key) => {
     const s = SLOTS[key];
     if (!s.img) return;
-    const d = composeXform(HEAD_XFORM, s.xf);
+    const d = composeXform(headXform, s.xf);
     cosDrawLayer(s.img, d.ax, d.ay, d.sx, d.sy, cosSlotFilter(key));
   };
 
   // Render order: Hair Back → Head → UR overlays → Eyes → Hair Front → UR topLayer overlays
   drawSlot('hairBack');
   if (cosHeadImg) {
-    cosDrawLayer(cosHeadImg, HEAD_XFORM.ax, HEAD_XFORM.ay, HEAD_XFORM.sx, HEAD_XFORM.sy, 'none');
+    cosDrawLayer(cosHeadImg, headXform.ax, headXform.ay, headXform.sx, headXform.sy, 'none');
     for (const urImg of cosUrImgs) {
-      cosDrawLayer(urImg, HEAD_XFORM.ax, HEAD_XFORM.ay, HEAD_XFORM.sx, HEAD_XFORM.sy, 'none');
+      cosDrawLayer(urImg, headXform.ax, headXform.ay, headXform.sx, headXform.sy, 'none');
     }
   }
   drawSlot('eyes');
   drawSlot('hairFront');
   for (const urImg of cosUrImgsTop) {
-    cosDrawLayer(urImg, HEAD_XFORM.ax, HEAD_XFORM.ay, HEAD_XFORM.sx, HEAD_XFORM.sy, 'none');
+    cosDrawLayer(urImg, headXform.ax, headXform.ay, headXform.sx, headXform.sy, 'none');
   }
 
   cosUpdateDiff();


### PR DESCRIPTION
### Motivation
- The Cosmetic Placer composed cosmetic layer transforms against the global `HEAD_XFORM`, causing placements to diverge from the Species Editor which uses a species+gender `headXform`; align the placer with the species-driven transform pipeline.

### Description
- Updated `cosRender()` in `docs/character-tools.html` to resolve a per-render `headXform` in priority order: selected species data (`cosGetCurrentSpeciesData()`), matched fighter `headXform` (via `cos-headPath` → `FIGHTERS` lookup), then fallback to `HEAD_XFORM`.
- Switched slot composition and base head/UR overlay drawing to use the resolved `headXform` (used in `composeXform(...)` and `cosDrawLayer(...)`) instead of the hardcoded `HEAD_XFORM` so the Cosmetic Placer visually matches the Species Editor.

### Testing
- Confirmed the patch was applied and the modified file diffs report the expected edits to `cosRender()` and related draw calls (local diff/status checks succeeded).
- No automated unit or browser-render tests exist for this page; no visual screenshot tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40c703d788326a64a12bd719763ea)