### PR TITLE
Make claim-cluster shells transparent and add configurable tabletop background

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -134,6 +134,7 @@
       --layout-claim-cluster-width: 78;
       --layout-claim-cluster-height: 48;
       --layout-claim-cluster-scale: 1;
+      --layout-ui-tabletop-url: none;
       --layout-table-card-container-scale: 1.25;
       --layout-table-card-content-scale: 0.8;
       --layout-claim-avatar-container-scale: 1.25;
@@ -144,8 +145,28 @@
       --layout-turn-spotlight-offset-y: 10px;
     }
     * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
-    html, body { margin: 0; background: radial-gradient(circle at top, #30211d 0%, var(--bg) 42%, #0f0c0b 100%); color: var(--text); font-family: 'Khymeryyanroman4', Inter, system-ui, sans-serif; letter-spacing: 0.10em; height: 100%; }
-    body { overscroll-behavior: none; overflow: hidden; display: grid; place-items: center; }
+    html, body { margin: 0; background: transparent; color: var(--text); font-family: 'Khymeryyanroman4', Inter, system-ui, sans-serif; letter-spacing: 0.10em; height: 100%; }
+    body {
+      overscroll-behavior: none;
+      overflow: hidden;
+      display: grid;
+      place-items: center;
+      position: relative;
+      isolation: isolate;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+      background-image:
+        var(--layout-ui-tabletop-url),
+        radial-gradient(circle at top, #30211d 0%, var(--bg) 42%, #0f0c0b 100%);
+      background-position: center center, center center;
+      background-repeat: no-repeat, no-repeat;
+      background-size: cover, cover;
+    }
     button, select, input { font: inherit; }
     #authoredRoot {
       width: 100vw;
@@ -243,6 +264,13 @@
       background: transparent !important;
       border: none !important;
       box-shadow: none !important;
+    }
+    .claimCluster,
+    .claimCluster > .floatingTransparentShell,
+    .claimCluster > .floatingTransparentShell * {
+      background: transparent !important;
+      box-shadow: none !important;
+      border-color: transparent !important;
     }
     .claimRankBox,
     .claimTimesBoxLeft,
@@ -1844,6 +1872,9 @@
             heightScale: rawGameConfig.layout?.controls?.heightScale ?? 0.5,
           },
           allowChallengeOverflow: rawGameConfig.layout?.allowChallengeOverflow ?? true,
+          background: {
+            tabletopImageSrc: rawGameConfig.layout?.background?.tabletopImageSrc ?? './docs/assets/hud/tabletop.png',
+          },
           fitter: rawGameConfig.layout?.fitter ?? null,
           projectionMapping: rawGameConfig.layout?.projectionMapping ?? {},
         },
@@ -3868,6 +3899,7 @@
       const viewportLayout = layout.viewport || {};
       const handLayout = layout.hand || {};
       const tableViewLayout = layout.tableView || {};
+      const backgroundLayout = layout.background || {};
       const cardBaseScale = clampNumber(Number(layoutCards.baseScale) || 0.25, 0.1, 0.75);
       const desiredHeightFrac = clampNumber(Number(handLayout.desiredHeightFrac) || 0.20, 0.08, 0.60);
       const handHeightScale = clampNumber(Number(handLayout.heightScale) || 0.5, 0.2, 0.75);
@@ -3926,6 +3958,8 @@
       const claimAvatarContainerScale = clampNumber(Number(tableVisualFit.claimAvatarContainerScale) || 1.25, 0.75, 2.25);
       const claimAvatarContentScale = clampNumber(Number(tableVisualFit.claimAvatarContentScale) || 0.8, 0.45, 1);
       const avatarAdditiveZoomScale = clampNumber(Number(tableVisualFit.avatarAdditiveZoomScale) || 1.2, 0.8, 1.6);
+      const tabletopImageSrcRaw = String(backgroundLayout.tabletopImageSrc || '').trim();
+      const tabletopImageSrc = tabletopImageSrcRaw.replace(/["\\]/g, '');
       const handCardMinWidthPx = clampNumber(Number(layoutSizing.handCardMinWidthPx) || 74, 48, 180);
       const handCardMaxWidthPx = clampNumber(Number(layoutSizing.handCardMaxWidthPx) || 104, handCardMinWidthPx, 220);
       const handCardMinHeightPx = clampNumber(Number(layoutSizing.handCardMinHeightPx) || 146, 88, 280);
@@ -3968,6 +4002,7 @@
       setCssVar('--layout-claim-avatar-container-scale', claimAvatarContainerScale.toFixed(3));
       setCssVar('--layout-claim-avatar-content-scale', claimAvatarContentScale.toFixed(3));
       setCssVar('--layout-fit-additive-avatar-zoom', avatarAdditiveZoomScale.toFixed(3));
+      setCssVar('--layout-ui-tabletop-url', tabletopImageSrc ? `url("${tabletopImageSrc}")` : 'none');
       setCssVar('--layout-table-dominance-frac', tableMinDominanceFrac.toFixed(3));
       setCssVar('--layout-action-column-height-scale', actionColumnHeightScale.toFixed(3));
       setCssVar('--layout-controls-height-scale', controlsHeightScale.toFixed(3));

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -211,6 +211,9 @@ window.SCRATCHBONES_CONFIG = {
         "heightScale": 0.5
       },
       "allowChallengeOverflow": true,
+      "background": {
+        "tabletopImageSrc": "./docs/assets/hud/tabletop.png"
+      },
       "fitter": {
         "enabled": true,
         "reflowDebounceMs": 90,


### PR DESCRIPTION
### Motivation
- Ensure the claim cluster does not render opaque backing behind its elements and allow a tabletop artwork to appear behind the whole UI by moving the tabletop source into configuration and rendering it as a backdrop.

### Description
- Added a new layout config key `layout.background.tabletopImageSrc` with default `./docs/assets/hud/tabletop.png` in `docs/config/scratchbones-config.js` so the tabletop image is configurable.
- Introduced a CSS variable `--layout-ui-tabletop-url` and a `body::before` full-screen layer in `ScratchbonesBluffGame.html` to render the tabletop image behind the UI while keeping the original gradient as a fallback.
- Threaded the new config through layout normalization and `applyLayoutContract(...)` in `ScratchbonesBluffGame.html`, sanitizing the path and setting `--layout-ui-tabletop-url` at runtime.
- Strengthened claim-cluster transparency by forcing `background`, `box-shadow`, and `border-color` to `transparent` for floating shells and their descendants so no opaque panels appear behind cluster items.

### Testing
- Ran code-style/whitespace/diff checks (no whitespace or patch-format issues found) and inspected the working tree to confirm the intended files were modified; checks passed.
- Reviewed the produced diff to ensure the config, CSS and runtime wiring are consistent; review passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40d902348832682e5012e1dd6255a)