### PR TITLE
Move tabletop background image from body::before to #app and adjust sizing

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -160,12 +160,10 @@
       inset: 0;
       z-index: -1;
       pointer-events: none;
-      background-image:
-        var(--layout-ui-tabletop-url),
-        radial-gradient(circle at top, #30211d 0%, var(--bg) 42%, #0f0c0b 100%);
-      background-position: center center, center center;
-      background-repeat: no-repeat, no-repeat;
-      background-size: cover, cover;
+      background-image: radial-gradient(circle at top, #30211d 0%, var(--bg) 42%, #0f0c0b 100%);
+      background-position: center center;
+      background-repeat: no-repeat;
+      background-size: cover;
     }
     button, select, input { font: inherit; }
     #authoredRoot {
@@ -180,6 +178,10 @@
       max-width: var(--layout-viewport-width);
       max-height: var(--layout-viewport-height);
       overflow: hidden;
+      background-image: var(--layout-ui-tabletop-url);
+      background-position: center center;
+      background-repeat: no-repeat;
+      background-size: 100% 100%;
       display: grid;
       container-type: size;
       grid-template-columns: minmax(0, 1fr) minmax(220px, 0.4fr) var(--layout-sidebar-width);


### PR DESCRIPTION
### Motivation

- Constrain the tabletop UI image to the application viewport instead of the fixed page backdrop so the artwork scales and positions relative to the app container while keeping the page-level radial gradient as the global backdrop.

### Description

- Remove `var(--layout-ui-tabletop-url)` from `body::before` and set the backdrop there to a single radial gradient only.
- Add `background-image: var(--layout-ui-tabletop-url)` plus `background-position`, `background-repeat`, and `background-size: 100% 100%` to the `#app` element so the tabletop image is rendered inside the app container and sized to the app.
- Tidy duplicated background positioning/repeat/size rules by moving them from the body pseudo-element to `#app` where the image now lives.

### Testing

- Ran `npm run build` and the frontend bundle completed successfully.  
- Ran `npm test` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d507f8b88326a3d356748993b231)