### PR TITLE
Fix cosmetic placer species-switch load flow and add render debug log

### DIFF
--- a/docs/character-tools.html
+++ b/docs/character-tools.html
@@ -2823,10 +2823,13 @@ async function cosOnSpeciesChanged() {
   // Sync species/gender dropdowns to Species Editor (prevent circular call with flag)
   if (!_speciesSyncInProgress) {
     _speciesSyncInProgress = true;
-    document.getElementById('spe-species').value = document.getElementById('cos-species').value;
-    document.getElementById('spe-gender').value  = document.getElementById('cos-gender').value;
-    speOnSpeciesOrGenderChanged();
-    _speciesSyncInProgress = false;
+    try {
+      document.getElementById('spe-species').value = document.getElementById('cos-species').value;
+      document.getElementById('spe-gender').value  = document.getElementById('cos-gender').value;
+      await speOnSpeciesOrGenderChanged();
+    } finally {
+      _speciesSyncInProgress = false;
+    }
   }
 }
 
@@ -2872,8 +2875,8 @@ async function speLoadSpeciesIndex() {
   // After all JSONs are loaded, trigger initial state for all three modes
   _portraitSpeciesLoadAttempted = true;
   spePopulateSpeciesDropdowns();
-  cosOnSpeciesChanged();
-  speOnSpeciesOrGenderChanged();
+  await cosOnSpeciesChanged();
+  await speOnSpeciesOrGenderChanged();
   bOnSpeciesChanged();
 }
 
@@ -3474,7 +3477,7 @@ async function speRenderHeadPreview() {
   }
 }
 
-function speOnSpeciesOrGenderChanged() {
+async function speOnSpeciesOrGenderChanged() {
   const speciesId = document.getElementById('spe-species').value;
   if (!speciesId || !speAllSpecies[speciesId]) return;
   speUpdateGenderAvailability(speciesId);
@@ -3484,15 +3487,20 @@ function speOnSpeciesOrGenderChanged() {
   // Sync species/gender dropdowns to Cosmetic Placer (prevent circular call with flag)
   if (!_speciesSyncInProgress) {
     _speciesSyncInProgress = true;
-    document.getElementById('cos-species').value = document.getElementById('spe-species').value;
-    document.getElementById('cos-gender').value  = document.getElementById('spe-gender').value;
-    cosOnSpeciesChanged();
-    _speciesSyncInProgress = false;
+    try {
+      document.getElementById('cos-species').value = document.getElementById('spe-species').value;
+      document.getElementById('cos-gender').value  = document.getElementById('spe-gender').value;
+      await cosOnSpeciesChanged();
+    } finally {
+      _speciesSyncInProgress = false;
+    }
   }
 }
 
-document.getElementById('spe-species').addEventListener('change', speOnSpeciesOrGenderChanged);
-document.getElementById('spe-gender').addEventListener('change',  () => {
+document.getElementById('spe-species').addEventListener('change', () => {
+  speOnSpeciesOrGenderChanged();
+});
+document.getElementById('spe-gender').addEventListener('change', async () => {
   speSelectedStop = -1;
   speSelectedBodyLayerIndex = 0;
   speRefreshEditorUI();
@@ -3502,9 +3510,12 @@ document.getElementById('spe-gender').addEventListener('change',  () => {
   // Sync gender to Cosmetic Placer
   if (!_speciesSyncInProgress) {
     _speciesSyncInProgress = true;
-    document.getElementById('cos-gender').value = document.getElementById('spe-gender').value;
-    cosOnSpeciesChanged();
-    _speciesSyncInProgress = false;
+    try {
+      document.getElementById('cos-gender').value = document.getElementById('spe-gender').value;
+      await cosOnSpeciesChanged();
+    } finally {
+      _speciesSyncInProgress = false;
+    }
   }
 });
 document.getElementById('spe-slot').addEventListener('change', () => {

--- a/docs/character-tools.html
+++ b/docs/character-tools.html
@@ -931,6 +931,11 @@ details.diag-details[open] > summary::after { content: '▼'; }
       <button id="cos-copyFullBtn" class="btn-accent" style="width:100%">⎘ Copy full cosmetic JSON</button>
       <button id="cos-copyCombinedBtn" style="width:100%;margin-top:4px">⎘ Copy combined appearance JSON</button>
       <div id="cosCopyStatus"></div>
+
+      <details style="margin-top:8px">
+        <summary style="cursor:pointer;font-size:12px;color:var(--muted)">Debug render log</summary>
+        <pre id="cos-debugLog" style="margin-top:6px;max-height:180px;overflow:auto;background:#0b1020;border:1px solid #21304d;border-radius:8px;padding:8px;font-size:11px;color:#b9d3ff;white-space:pre-wrap">No debug data yet.</pre>
+      </details>
     </div>
 
   </aside>
@@ -1883,6 +1888,8 @@ let cosCW = 300, cosCH = 300, cosL = 80;
 let cosHeadImg    = null;
 let cosUrImgs     = [];   // UR overlay images drawn BEFORE front cosmetics
 let cosUrImgsTop  = [];   // UR overlay images drawn AFTER front cosmetics (renderOrder:'topLayer')
+let cosLastUrLayers = [];
+let cosLastUrLayerSource = 'unknown';
 
 // ── Slot state ─────────────────────────────────────────────
 
@@ -2032,7 +2039,7 @@ async function cosLoadSelectedCosmetic() {
   slot.cosEntryId = entryId;
   if (!entryId) return;
   const entry = cosIndexEntries.find(e => e.id === entryId);
-  if (!entry) return;
+  if (!entry) { cosUpdateDebugLog('cosLoadSelectedCosmetic: entry not found'); return; }
 
   const cosJsonUrl = new URL(entry.path, cosIndexBaseUrl).toString();
   let json;
@@ -2045,6 +2052,7 @@ async function cosLoadSelectedCosmetic() {
     slot.loadedJson    = null;
     slot.currentLayers = [];
     cosPopulateLayerSelect();
+    cosUpdateDebugLog('cosLoadSelectedCosmetic: json load failed');
     return;
   }
   slot.loadedJson    = json;
@@ -2058,6 +2066,28 @@ function cosGetCurrentLayerUrl() {
   const slot  = SLOTS[cosActiveSlotKey];
   const layer = slot.currentLayers[slot.layerIdx];
   return layer ? layer.url : null;
+}
+
+function cosUpdateDebugLog(reason = '') {
+  const out = document.getElementById('cos-debugLog');
+  if (!out) return;
+  const species = document.getElementById('cos-species')?.value || '(none)';
+  const gender = document.getElementById('cos-gender')?.value || '(none)';
+  const slot = SLOTS[cosActiveSlotKey];
+  const itemSel = document.getElementById('cos-cosSelect');
+  const selectedOptionLabel = itemSel?.selectedOptions?.[0]?.textContent || '(none)';
+  const layer = slot.currentLayers[slot.layerIdx] || null;
+  const layerUrl = layer?.url || '(none)';
+  const lines = [
+    `[cos-debug] ${reason || 'state update'}`,
+    `species=${species} gender=${gender} activeSlot=${slot.key}`,
+    `selectedCosmetic=${slot.cosEntryId || '(none)'} label=${selectedOptionLabel}`,
+    `layerIdx=${slot.layerIdx} layerCount=${slot.currentLayers.length} layerUrl=${layerUrl}`,
+    `head=${document.getElementById('cos-headPath')?.value || '(none)'}`,
+    `urSource=${cosLastUrLayerSource} urCount=${cosLastUrLayers.length}`,
+    ...cosLastUrLayers.map((mid, i) => `  ur[${i}] ${mid.url || '(no-url)'} renderOrder=${mid.renderOrder || 'normal'}`),
+  ];
+  out.textContent = lines.join('\n');
 }
 
 /** Set xform sliders/baseline from a specific layer index in the active slot's currentLayers. */
@@ -2201,9 +2231,13 @@ async function cosLoadAssets() {
   cosUrImgs    = [];
   cosUrImgsTop = [];
   try { cosHeadImg = await cosLoadImage(headPath); } catch (e) { console.warn(e); }
-  // Use species-defined headUrLayers when available; fall back to FIGHTERS-based lookup
+  // Match game portrait rendering: prefer fighter.urLayers when the head sprite maps to a fighter.
+  // Fall back to species headUrLayers for species that are not present in portrait-config.
   const speciesData = cosGetCurrentSpeciesData();
-  const urLayers = speciesData ? (speciesData.headUrLayers || []) : getFighterUrLayers(headPath);
+  const fighterUrLayers = getFighterUrLayers(headPath);
+  const urLayers = fighterUrLayers.length ? fighterUrLayers : (speciesData ? (speciesData.headUrLayers || []) : []);
+  cosLastUrLayers = urLayers;
+  cosLastUrLayerSource = fighterUrLayers.length ? 'portrait-config fighter.urLayers' : 'species.headUrLayers';
   for (const mid of urLayers) {
     try {
       const img = await cosLoadImage(mid.url);
@@ -2214,6 +2248,7 @@ async function cosLoadAssets() {
   if (cosUrl) {
     try { slot.img = await cosLoadImageAbsolute(cosUrl); } catch (e) { console.warn(e); }
   }
+  cosUpdateDebugLog('cosLoadAssets');
   cosRender();
 }
 
@@ -2700,6 +2735,7 @@ function cosActivateSlot(newKey) {
   document.getElementById('cos-tintS').value = slot.tint.s;
   document.getElementById('cos-tintV').value = slot.tint.v;
 
+  cosUpdateDebugLog('cosActivateSlot');
   cosRender();
 }
 
@@ -2767,15 +2803,23 @@ function speGetCurrentSpeciesData() {
  * Called when the species or gender dropdown in the Cosmetic Placer changes.
  * Updates the hidden head-path input, re-filters cosmetics, and reloads assets.
  */
-function cosOnSpeciesChanged() {
+async function cosOnSpeciesChanged() {
   const speciesId = document.getElementById('cos-species')?.value;
   if (speciesId) speUpdateGenderAvailability(speciesId);
   const data = cosGetCurrentSpeciesData();
+  const activeSlot = SLOTS[cosActiveSlotKey];
   if (data && data.headSprite) {
     document.getElementById('cos-headPath').value = data.headSprite;
   }
   cosPopulateItemSelect();
-  cosLoadAssets();
+  const itemSel = document.getElementById('cos-cosSelect');
+  if (activeSlot.cosEntryId && Array.from(itemSel.options).some(o => o.value === activeSlot.cosEntryId)) {
+    itemSel.value = activeSlot.cosEntryId;
+  } else if (itemSel.options.length) {
+    itemSel.value = itemSel.options[0].value;
+  }
+  await cosLoadSelectedCosmetic();
+  cosUpdateDebugLog('cosOnSpeciesChanged');
   // Sync species/gender dropdowns to Species Editor (prevent circular call with flag)
   if (!_speciesSyncInProgress) {
     _speciesSyncInProgress = true;


### PR DESCRIPTION
### Motivation
- Cosmetic Placer showed a mismatch with the game rendering path (Kenkari eye-disks appeared to be occluded in the placer but rendered correctly in the game), indicating divergent UR-layer sourcing and a species-switch state-sync bug. 
- The change aims to align Cosmetic Placer's UR-layer selection and loading behavior with the portrait/game path and add an in-app debug surface to make such render-order issues diagnosable.

### Description
- Restored the intended Kenkari config by re-adding `renderOrder: "topLayer"` to `docs/config/species/kenkari.json` so species metadata remains authoritative.  
- Cosmetic Placer now prefers mapped `fighter.urLayers` (portrait-config) when the head sprite maps to a fighter, falling back to `species.headUrLayers` otherwise; the chosen UR list is tracked in `cosLastUrLayers`/`cosLastUrLayerSource`.  
- Fixed species/gender swap flow by making `cosOnSpeciesChanged()` async, restoring a valid cosmetic selection (or choosing the first) and calling `await cosLoadSelectedCosmetic()` so the cosmetic JSON/layers are actually reloaded after the dropdown is rebuilt.  
- Added an in-app Debug render log (UI panel + `cosUpdateDebugLog()`), and wired debug log updates in key places (`cosLoadAssets`, `cosActivateSlot`, error paths in `cosLoadSelectedCosmetic`) to surface species/gender, active slot, selected cosmetic/layer, head path, UR source and per-UR `renderOrder` at runtime.

### Testing
- ✅ Validated `docs/config/species/kenkari.json` parses as JSON with `node -e "JSON.parse(require('fs').readFileSync('docs/config/species/kenkari.json','utf8'))"`.  
- ✅ Verified `docs/character-tools.html` contains the updated species-change handler (`cosOnSpeciesChanged`) and debug log wiring via a small Node check that reads the HTML file.  
- No full unit test suite was run as part of this change; previous runs of the repository unit tests contain unrelated pre-existing failures, so only targeted file/feature checks were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e279bbcc8326a8f9807a40274386)