### PR TITLE
Resolve portrait fighter to canonical entry so species transforms apply

### DIFF
--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -627,6 +627,16 @@ function weightedPickRng(arr, weights, rng) {
   return arr[arr.length - 1];
 }
 
+function resolvePortraitFighter(fighter) {
+  if (!fighter) return fighter;
+  const byId = FIGHTERS.find((candidate) => candidate?.id === fighter.id);
+  if (byId) return byId;
+  const byHead = fighter.headUrl
+    ? FIGHTERS.find((candidate) => candidate?.headUrl === fighter.headUrl)
+    : null;
+  return byHead || fighter;
+}
+
 /**
  * Generate a fully deterministic random profile using a provided rng() function.
  * All option arrays must be supplied by the caller.
@@ -636,12 +646,13 @@ function weightedPickRng(arr, weights, rng) {
  */
 function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, hairSideOptions, eyesOptions, facialHairOptions, bodyColorRangesByGender, allowedCosmeticsByFighter, hatOptions, cosmeticWeightsByFighter, torsoPortraitOptions, armPortraitOptions, forcedCosmeticsByFighter, conditionalCosmeticsByFighter) {
   const pickRng   = (arr) => arr[Math.floor(rng() * arr.length)];
-  const fighter   = pickRng(fighters);
-  const fighterEntry = allowedCosmeticsByFighter?.[fighter.id];
+  const fighterInput = pickRng(fighters);
+  const fighter = resolvePortraitFighter(fighterInput);
+  const fighterEntry = allowedCosmeticsByFighter?.[fighter.id] ?? allowedCosmeticsByFighter?.[fighterInput?.id];
   const allowed   = fighterEntry instanceof Set ? fighterEntry : (fighterEntry?.set ?? null);
   const disallowedCombos = (fighterEntry instanceof Set ? [] : (fighterEntry?.disallowedCombos ?? []));
   const filterArr = (arr) => arr && allowed ? arr.filter(o => o.id === 'none' || allowed.has(o.id)) : arr;
-  const weights   = cosmeticWeightsByFighter?.[fighter.id] ?? null;
+  const weights   = cosmeticWeightsByFighter?.[fighter.id] ?? cosmeticWeightsByFighter?.[fighterInput?.id] ?? null;
 
   const filteredHairFront  = filterArr(hairFrontOptions)  ?? [];
   const filteredHairBack   = filterArr(hairBackOptions)   ?? [];
@@ -701,7 +712,7 @@ function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, h
   const armCosmetic   = weightedPickRng(filteredArm.length   ? filteredArm   : [{ id: 'none', label: 'No Arm Clothing',   tintSlot: null, layers: [] }], null, rng);
 
   // Apply forced cosmetics — species-level slots that always override random selection.
-  const forced = forcedCosmeticsByFighter?.[fighter.id];
+  const forced = forcedCosmeticsByFighter?.[fighter.id] ?? forcedCosmeticsByFighter?.[fighterInput?.id];
   if (forced) {
     const filteredBySlot = { eyes: filteredEyes, facialHair: filteredFacialHair, hairFront: filteredHairFront, hairBack: filteredHairBack, hairSide: filteredHairSide, hat: filteredHat };
     for (const [slot, id] of Object.entries(forced)) {
@@ -717,7 +728,7 @@ function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, h
   }
 
   // Apply conditional cosmetics — rules that fire based on current slot state and clothing tags.
-  const conditionals = conditionalCosmeticsByFighter?.[fighter.id];
+  const conditionals = conditionalCosmeticsByFighter?.[fighter.id] ?? conditionalCosmeticsByFighter?.[fighterInput?.id];
   if (conditionals) {
     const curSlots = { hairFront, hairBack, hairSide, eyes, facialHair, hat };
     const filteredBySlot = { eyes: filteredEyes, facialHair: filteredFacialHair, hairFront: filteredHairFront, hairBack: filteredHairBack, hairSide: filteredHairSide, hat: filteredHat };
@@ -738,7 +749,7 @@ function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, h
     }
   }
 
-  const bodyColors = randomBodyColorsSeeded(rng, bodyColorRangesByGender?.[fighter.id]);
+  const bodyColors = randomBodyColorsSeeded(rng, bodyColorRangesByGender?.[fighter.id] ?? bodyColorRangesByGender?.[fighterInput?.id]);
   if (hat && hat.colorRange) bodyColors.HAT = randomColorFromRangeSeeded(hat.colorRange, rng);
   if (torsoCosmetic?.colorRange) bodyColors.CLOTH = randomColorFromRangeSeeded(torsoCosmetic.colorRange, rng);
   return { fighter, hairFront, hairBack, hairSide, eyes, facialHair, hat, torsoCosmetic, armCosmetic, bodyColors };


### PR DESCRIPTION
### Motivation
- Cosmetic layers (e.g. Kenkari eye disks) were aligned correctly in the cosmetic placer but misaligned in the game because profile generation could use caller-provided fighter objects that lacked the species-enriched portrait data (`headXform`, `bodyLayers`, `headUrLayers`, forced/conditional cosmetics, etc.).
- The intent is to ensure the same canonical fighter entries (the ones populated by `loadPortraitCosmetics`) are used when building random profiles so species transforms and constraints remain attached.

### Description
- Added `resolvePortraitFighter(fighter)` to `docs/js/portrait-utils.js` which resolves a passed fighter to the canonical `FIGHTERS` entry by `id` and then by `headUrl`.
- Updated `randomProfileSeeded(...)` in `docs/js/portrait-utils.js` to pick `fighterInput` then call `resolvePortraitFighter(fighterInput)` and to use fallbacks keyed by both the resolved fighter id and the original input id for lookups of `allowedCosmeticsByFighter`, `cosmeticWeightsByFighter`, `forcedCosmeticsByFighter`, `conditionalCosmeticsByFighter`, and `bodyColorRangesByGender`.
- This preserves species-provided `headXform`, `bodyLayers`, untinted overlays and cosmetic constraints even when callers pass fighter objects from other sources.

### Testing
- Ran the full unit suite with `npm run test:unit` which completed, reporting `339` tests run with `310` passing and `29` failing; the run shows failing suites including `angle-conversion`, `attack-timeline-state`, `cosmetic-editor-app`, and `cosmetics-system` which appear to be pre-existing repository issues. 
- The test run completed without runtime errors from the changed file and produced the above failing/passing summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62af224b08326b1877050467165e6)