### PR TITLE
Anchor ur-head overlays the same way as Cosmetic Placer

### DIFF
--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -268,7 +268,7 @@ async function renderProfile(canvas, profile) {
   for (const mid of urLayerSource) {
     if (mid.renderOrder === 'topLayer') continue;
     const img = imgMap.get(mid.url);
-    if (img) drawPortraitLayer(ctx, img, mid.xform || headXform, 'none');
+    if (img) drawPortraitLayer(ctx, img, headXform, 'none');
   }
   for (const { layer, filter } of frontLayers) {
     const img = imgMap.get(layer.url);
@@ -277,7 +277,7 @@ async function renderProfile(canvas, profile) {
   for (const mid of urLayerSource) {
     if (mid.renderOrder !== 'topLayer') continue;
     const img = imgMap.get(mid.url);
-    if (img) drawPortraitLayer(ctx, img, mid.xform || headXform, 'none');
+    if (img) drawPortraitLayer(ctx, img, headXform, 'none');
   }
   for (const { layer, filter } of bodyFrontLayers) {
     const img = imgMap.get(layer.url);


### PR DESCRIPTION
## Summary
- keep the existing species-first portrait record resolution from the earlier merged change
- align `ur-head` overlay rendering with Cosmetic Placer by always drawing those overlays at `headXform`
- do not change the rest of the bluffgame portrait pipeline

## Why
We narrowed the remaining mismatch down to the head stack rather than the cosmetic layer stack itself.

Both bluffgame and Cosmetic Placer already compose eyedisks relative to `headXform`, but the shared portrait renderer could still draw `ur-head` overlays using `mid.xform || headXform` while Cosmetic Placer always draws them at plain `headXform`.

That means the apparent mismatch can come from `ur-head` drifting relative to the head and eyedisks, even when the eyedisks transform is correct.

## What changed
In `docs/js/portrait-utils.js`, the shared renderer now draws both normal and `topLayer` `ur-head` overlays at `headXform`, matching Cosmetic Placer's anchoring rule.

## Scope
- no broad bluffgame pipeline rewrite
- no cosmetic placement math changes
- only the `ur-head` anchoring rule was adjusted