### PR TITLE
Add portrait sprite xform debug logging and cosmetic re-read button

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2708,6 +2708,7 @@
       rand = mulberry32(state.seed);
       dealFreshHands();
       for (const p of state.players) p.profile = generatePlayerProfile(p);
+      for (const p of state.players) logPlayerPortraitXforms(p);
       state.leaderIndex = rngInt(0, state.players.length - 1);
       state.currentTurn = state.leaderIndex;
       setBanner(state.currentTurn === 0 ? SCRATCHBONES_GAME.uiText.yourLeadBanner : `${seatLabel(state.currentTurn)} opens the round.`);
@@ -5024,6 +5025,26 @@
                         : player.gender === 'female' ? FIGHTERS.filter(f => fighterGender(f) === 'female')
                         : FIGHTERS;
       return randomProfileSeeded(rng, fighterPool.length ? fighterPool : FIGHTERS, hairFrontOptions, hairBackOptions, hairSideOptions, eyesOptions, facialHairOptions, bodyColorRangesByGender, allowedCosmeticsByFighter, hatOptions, cosmeticWeightsByFighter, torsoPortraitOptions, armPortraitOptions, forcedCosmeticsByFighter, conditionalCosmeticsByFighter);
+    }
+    function logPlayerPortraitXforms(player) {
+      if (!player?.profile || !window.getProfileSpriteXforms) return;
+      const rows = getProfileSpriteXforms(player.profile).map((entry, index) => {
+        const xf = entry.xform || {};
+        return {
+          sprite: index + 1,
+          part: entry.part || '',
+          group: entry.group || '',
+          id: entry.id || '',
+          pos: entry.pos || '',
+          renderOrder: entry.renderOrder || '',
+          url: entry.url || '',
+          ax: Number(xf.ax ?? 0).toFixed(3),
+          ay: Number(xf.ay ?? 0).toFixed(3),
+          sx: Number(xf.sx ?? 1).toFixed(3),
+          sy: Number(xf.sy ?? 1).toFixed(3),
+        };
+      });
+      console.debug(`[portrait-xform] ${seatLabel(player)} initial portrait sprites`, rows);
     }
     function renderSeatPortraits() {
       const root = document.getElementById('app');

--- a/docs/character-tools.html
+++ b/docs/character-tools.html
@@ -934,6 +934,7 @@ details.diag-details[open] > summary::after { content: '▼'; }
 
       <details style="margin-top:8px">
         <summary style="cursor:pointer;font-size:12px;color:var(--muted)">Debug render log</summary>
+        <button id="cos-rereadXformsBtn" style="width:100%;margin-top:6px">↻ Reread sprite xforms</button>
         <pre id="cos-debugLog" style="margin-top:6px;max-height:180px;overflow:auto;background:#0b1020;border:1px solid #21304d;border-radius:8px;padding:8px;font-size:11px;color:#b9d3ff;white-space:pre-wrap">No debug data yet.</pre>
       </details>
     </div>
@@ -1425,6 +1426,26 @@ function makeLabel(profile) {
   return parts.join('\n');
 }
 
+function logPortraitCardXforms(profile, label) {
+  if (!window.getProfileSpriteXforms) return;
+  const rows = getProfileSpriteXforms(profile).map((entry, index) => {
+    const xf = entry.xform || {};
+    return {
+      sprite: index + 1,
+      part: entry.part || '',
+      group: entry.group || '',
+      pos: entry.pos || '',
+      renderOrder: entry.renderOrder || '',
+      url: entry.url || '',
+      ax: Number(xf.ax ?? 0).toFixed(3),
+      ay: Number(xf.ay ?? 0).toFixed(3),
+      sx: Number(xf.sx ?? 1).toFixed(3),
+      sy: Number(xf.sy ?? 1).toFixed(3),
+    };
+  });
+  console.debug(`[portrait-xform] ${label}`, rows);
+}
+
 function createCard(profile) {
   const card   = document.createElement('div');
   card.className = 'portrait-card loading';
@@ -1449,6 +1470,7 @@ function createCard(profile) {
   });
 
   label.textContent = makeLabel(profile);
+  logPortraitCardXforms(profile, label.textContent.replace(/\s+/g, ' ').trim() || 'portrait');
   renderProfile(canvas, profile).finally(() => card.classList.remove('loading'));
 
   return card;
@@ -2058,6 +2080,7 @@ async function cosLoadSelectedCosmetic() {
   slot.loadedJson    = json;
   slot.currentLayers = cosExtractLayers(json);
   cosPopulateLayerSelect();
+  cosRereadSpriteXforms('loaded cosmetic JSON');
   await cosLoadAssets();
 }
 
@@ -2088,6 +2111,29 @@ function cosUpdateDebugLog(reason = '') {
     ...cosLastUrLayers.map((mid, i) => `  ur[${i}] ${mid.url || '(no-url)'} renderOrder=${mid.renderOrder || 'normal'}`),
   ];
   out.textContent = lines.join('\n');
+}
+
+function cosRereadSpriteXforms(reason = 'manual reread') {
+  const out = document.getElementById('cos-debugLog');
+  if (!out) return;
+  const lines = [`[cos-xform] ${reason}`];
+  for (const def of SLOT_DEFS) {
+    const slot = SLOTS[def.key];
+    if (!slot.loadedJson) {
+      lines.push(`${def.label}: no loaded cosmetic JSON`);
+      continue;
+    }
+    const layers = cosExtractLayers(slot.loadedJson);
+    lines.push(`${def.label}: ${slot.cosEntryId || '(none)'} layers=${layers.length}`);
+    layers.forEach((layer, index) => {
+      const xf = layer.xform || {};
+      lines.push(
+        `  [${index}] ${layer.name || `layer${index + 1}`} ax=${Number(xf.ax ?? 0).toFixed(3)} ay=${Number(xf.ay ?? 0).toFixed(3)} scaleX=${Number(xf.scaleX ?? 1).toFixed(3)} scaleY=${Number(xf.scaleY ?? 1).toFixed(3)} url=${layer.url || '(none)'}`
+      );
+    });
+  }
+  out.textContent = lines.join('\n');
+  console.debug('[cos-xform] reread sprite xforms', lines);
 }
 
 /** Set xform sliders/baseline from a specific layer index in the active slot's currentLayers. */
@@ -2591,6 +2637,10 @@ document.getElementById('cos-copyXformBtn').addEventListener('click', () => {
       setTimeout(() => { status.textContent = ''; }, 2500);
     }
   );
+});
+
+document.getElementById('cos-rereadXformsBtn').addEventListener('click', () => {
+  cosRereadSpriteXforms('manual reread button');
 });
 
 // Paste xform button — apply internal clipboard xform to active slot

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -186,6 +186,46 @@ function applyPortraitOpacityMask(ctx, img, xform) {
   ctx.restore();
 }
 
+function getProfileSpriteXforms(profile) {
+  if (!profile) return [];
+  const { fighter, hair, hairFront, hairBack, hairSide, eyes, facialHair, hat, torsoCosmetic, armCosmetic } = profile;
+  const resolvedFighter = resolvePortraitFighter(fighter) || fighter;
+  const headXform = resolvedFighter?.headXform || fighter?.headXform || HEAD_XFORM;
+  const opacityMaskLayer = resolvedFighter?.opacityMaskLayer || fighter?.opacityMaskLayer || null;
+  const headUrl = resolvedFighter?.headUrl || fighter?.headUrl;
+  const bodyLayerSource = resolvedFighter?.bodyLayers || fighter?.bodyLayers || [];
+  const urLayerSource = resolvedFighter?.urLayers || fighter?.urLayers || [];
+  const toRecord = (part, layer, extra = {}) => ({
+    part,
+    url: layer?.url || null,
+    xform: composeXform(headXform, layer || {}),
+    ...extra,
+  });
+  const records = [];
+  for (const layer of bodyLayerSource) records.push(toRecord('body', layer, { pos: layer.pos || 'back', id: layer.id || null }));
+  for (const group of [torsoCosmetic, armCosmetic]) {
+    if (!group?.layers?.length) continue;
+    for (const layer of group.layers) {
+      records.push(toRecord('bodyCosmetic', layer, { group: group.id || null, pos: layer.pos || 'front' }));
+    }
+  }
+  const allCosmeticGroups = hairFront !== undefined
+    ? [hairBack, hairSide, facialHair, eyes, hairFront, hat]
+    : [hair, facialHair, eyes, hat];
+  for (const group of allCosmeticGroups) {
+    if (!group?.layers?.length) continue;
+    for (const layer of group.layers) {
+      records.push(toRecord('cosmetic', layer, { group: group.id || null, pos: layer.pos || 'front' }));
+    }
+  }
+  if (headUrl) records.push({ part: 'head', url: headUrl, xform: { ...headXform } });
+  for (const layer of urLayerSource) {
+    records.push({ part: 'headOverlay', url: layer.url || null, renderOrder: layer.renderOrder || 'normal', xform: { ...(layer.xform || headXform) } });
+  }
+  if (opacityMaskLayer?.url) records.push(toRecord('opacityMask', opacityMaskLayer));
+  return records;
+}
+
 // ── Rendering ──────────────────────────────────────────────
 
 async function renderProfile(canvas, profile) {


### PR DESCRIPTION
### Motivation
- Make it easy to inspect the composed transforms (xforms) used when rendering portrait sprites both in the game and in the docs/tools UI for debugging cosmetic placement issues.

### Description
- Added a shared extractor `getProfileSpriteXforms(profile)` to `docs/js/portrait-utils.js` that enumerates composed sprite records (body layers, body cosmetics, portrait cosmetics, head, untinted overlays, opacity mask) with their composed xforms.
- In `ScratchbonesBluffGame.html` added `logPlayerPortraitXforms` and invoke it at match start to print every generated player's initial portrait sprite xforms to the console with the tag `[portrait-xform]`.
- In `docs/character-tools.html` added `logPortraitCardXforms` to log each generated portrait card's sprite xforms when cards are created and added a `↻ Reread sprite xforms` button (`#cos-rereadXformsBtn`) to the Cosmetic Placer debug panel.
- Implemented `cosRereadSpriteXforms(reason)` which reads xforms from the loaded cosmetic JSON for each slot and writes a human-readable report into the debug pane and console with the tag `[cos-xform]`, and wired it to run automatically after a cosmetic JSON is loaded and when the new button is pressed.

### Testing
- Ran the repository unit tests with `npm run test:unit`; the test run executed but the suite failed due to pre-existing unrelated failures (examples include angle conversion centralization, attack timeline state, and several cosmetics/editor assertions), so the run did not show regressions specific to these debug additions.
- Verified via static inspection that the new helper and logging calls are present and that the Cosmetic Placer debug button and auto-reread wiring are added and call the new reporter; no browser render/screenshot steps were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71f8448a88326a8dcdb62443dda55)