### PR TITLE
Scratchbones: unify board/hand card sizing and add config-driven audio with faded BGM transitions

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2202,6 +2202,8 @@
       let bgmAudio = null;
       let bgmPlaylistIndex = 0;
       let challengeBgmActive = false;
+      const failedPlaylistTracks = new Set();
+      let playlistExhausted = false;
 
       function buildAudio(url, volume) {
         if (!cfg.enabled || !isUrl(url)) return null;
@@ -2253,7 +2255,10 @@
         if (!next) return;
         next.loop = !!loop;
         next.addEventListener('error', () => {
-          if (!challengeBgmActive) playNextPlaylistTrack();
+          if (!challengeBgmActive && !loop) {
+            failedPlaylistTracks.add(url);
+            playNextPlaylistTrack();
+          }
         }, { once: true });
         safePlay(next);
         bgmAudio = next;
@@ -2267,14 +2272,25 @@
       }
       function playNextPlaylistTrack() {
         const playlist = cfg.bgm?.playlist || [];
-        if (!cfg.enabled || challengeBgmActive || !playlist.length) return;
+        if (!cfg.enabled || challengeBgmActive || !playlist.length || playlistExhausted) return;
+        const availableTracks = playlist.filter((url) => isUrl(url) && !failedPlaylistTracks.has(url));
+        if (!availableTracks.length) {
+          playlistExhausted = true;
+          if (bgmAudio) {
+            bgmAudio.pause();
+            bgmAudio.src = '';
+            bgmAudio = null;
+          }
+          console.warn('[scratchbones audio] Disabling playlist BGM after all configured tracks failed to load.');
+          return;
+        }
         let attempts = playlist.length;
         while (attempts > 0) {
           const idx = bgmPlaylistIndex % playlist.length;
           bgmPlaylistIndex += 1;
           attempts -= 1;
           const url = playlist[idx];
-          if (!isUrl(url)) continue;
+          if (!isUrl(url) || failedPlaylistTracks.has(url)) continue;
           setTrack(url, { loop: false });
           if (bgmAudio) {
             bgmAudio.onended = () => {

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -343,8 +343,8 @@
       padding: 2px;
     }
     .claimHandBar .tableViewCard {
-      width: calc(var(--layout-card-mini-base-width) * var(--layout-card-scale) * var(--layout-table-card-container-scale));
-      height: calc(var(--layout-card-mini-base-height) * var(--layout-card-scale) * var(--layout-table-card-container-scale));
+      width: calc(clamp(var(--layout-hand-card-min-width), 14vw, var(--layout-hand-card-max-width)) * var(--layout-challenge-image-scale) * var(--layout-fit-image-scale) * var(--layout-table-card-container-scale) * var(--layout-table-card-auto-scale));
+      height: calc(clamp(var(--layout-hand-card-min-height), 20vh, var(--layout-hand-card-max-height)) * var(--layout-challenge-image-scale) * var(--layout-fit-image-scale) * var(--layout-table-card-container-scale) * var(--layout-table-card-auto-scale));
       margin-left: -8px;
     }
     .claimHandBar .tableViewCard:first-child {
@@ -389,8 +389,8 @@
       min-height: 0;
     }
     .tableViewCard {
-      width: calc(var(--layout-card-table-base-width) * var(--layout-card-scale) * var(--layout-challenge-image-scale) * var(--layout-fit-image-scale) * var(--layout-table-card-container-scale) * var(--layout-table-card-auto-scale));
-      height: calc(var(--layout-card-table-base-height) * var(--layout-card-scale) * var(--layout-challenge-image-scale) * var(--layout-fit-image-scale) * var(--layout-table-card-container-scale) * var(--layout-table-card-auto-scale));
+      width: calc(clamp(var(--layout-hand-card-min-width), 14vw, var(--layout-hand-card-max-width)) * var(--layout-challenge-image-scale) * var(--layout-fit-image-scale) * var(--layout-table-card-container-scale) * var(--layout-table-card-auto-scale));
+      height: calc(clamp(var(--layout-hand-card-min-height), 20vh, var(--layout-hand-card-max-height)) * var(--layout-challenge-image-scale) * var(--layout-fit-image-scale) * var(--layout-table-card-container-scale) * var(--layout-table-card-auto-scale));
       border-radius: 0;
       border: 0;
       background: transparent;
@@ -2002,6 +2002,18 @@
           flippedCardFallbackSrc: rawGameConfig.assets?.cards?.flipped?.fallbackSrc ?? '2DScratchBoneFlipped.png',
           rankCardTemplateSrc: rawGameConfig.assets?.cards?.rankTemplate?.src ?? '2DScratchbone{rank}.png',
           rankCardTemplateFallbackSrc: rawGameConfig.assets?.cards?.rankTemplate?.fallbackSrc ?? '2DScratchbones{rank}.png',
+          audio: {
+            enabled: rawGameConfig.assets?.audio?.enabled !== false,
+            sfxVolume: rawGameConfig.assets?.audio?.sfxVolume ?? 0.92,
+            bgmVolume: rawGameConfig.assets?.audio?.bgmVolume ?? 0.48,
+            musicFadeMs: rawGameConfig.assets?.audio?.musicFadeMs ?? 280,
+            movement: rawGameConfig.assets?.audio?.movement || {},
+            challenge: rawGameConfig.assets?.audio?.challenge || {},
+            bgm: {
+              playlist: Array.isArray(rawGameConfig.assets?.audio?.bgm?.playlist) ? rawGameConfig.assets.audio.bgm.playlist : [],
+              challenge: rawGameConfig.assets?.audio?.bgm?.challenge || '',
+            },
+          },
         },
       };
     }
@@ -2183,6 +2195,120 @@
       }
     }
     const CHALLENGE_TIMER_SECS = SCRATCHBONES_GAME.timers.challengeTimerSecs;
+    const SCRATCHBONES_AUDIO = (() => {
+      const cfg = SCRATCHBONES_GAME.assets?.audio || {};
+      const clamp = (value, min, max) => Math.min(max, Math.max(min, Number(value) || 0));
+      const isUrl = (value) => typeof value === 'string' && value.trim().length > 0;
+      let bgmAudio = null;
+      let bgmPlaylistIndex = 0;
+      let challengeBgmActive = false;
+
+      function buildAudio(url, volume) {
+        if (!cfg.enabled || !isUrl(url)) return null;
+        try {
+          const audio = new Audio(url);
+          audio.preload = 'auto';
+          audio.volume = clamp(volume, 0, 1);
+          return audio;
+        } catch (error) {
+          console.warn('[scratchbones audio] Failed to construct audio element.', error);
+          return null;
+        }
+      }
+      function safePlay(audio) {
+        if (!audio) return;
+        const p = audio.play?.();
+        if (p && typeof p.catch === 'function') p.catch(() => {});
+      }
+      function playSfx(entry) {
+        if (!cfg.enabled || !entry || !isUrl(entry.url)) return;
+        const playbackRate = clamp((Number(entry.pitch) || 1) * (Number(entry.tempo) || 1), 0.5, 2);
+        const baseVolume = clamp(cfg.sfxVolume ?? 1, 0, 1);
+        const volume = clamp(baseVolume * (Number(entry.volume) || 1), 0, 1);
+        const audio = buildAudio(entry.url, volume);
+        if (!audio) return;
+        audio.playbackRate = playbackRate;
+        safePlay(audio);
+      }
+      function fadeTo(audio, targetVolume, durationMs, onDone) {
+        if (!audio) { onDone?.(); return; }
+        const duration = Math.max(1, Number(durationMs) || 1);
+        const start = performance.now();
+        const from = Number(audio.volume) || 0;
+        const to = clamp(targetVolume, 0, 1);
+        function tick(now) {
+          const t = clamp((now - start) / duration, 0, 1);
+          audio.volume = from + (to - from) * t;
+          if (t < 1) requestAnimationFrame(tick);
+          else onDone?.();
+        }
+        requestAnimationFrame(tick);
+      }
+      function setTrack(url, { loop = false } = {}) {
+        if (!cfg.enabled || !isUrl(url)) return;
+        const fadeMs = Math.max(40, Number(cfg.musicFadeMs) || 280);
+        const targetVolume = clamp(cfg.bgmVolume ?? 0.45, 0, 1);
+        const old = bgmAudio;
+        const next = buildAudio(url, 0);
+        if (!next) return;
+        next.loop = !!loop;
+        next.addEventListener('error', () => {
+          if (!challengeBgmActive) playNextPlaylistTrack();
+        }, { once: true });
+        safePlay(next);
+        bgmAudio = next;
+        fadeTo(next, targetVolume, fadeMs);
+        if (old) {
+          fadeTo(old, 0, fadeMs, () => {
+            old.pause();
+            old.src = '';
+          });
+        }
+      }
+      function playNextPlaylistTrack() {
+        const playlist = cfg.bgm?.playlist || [];
+        if (!cfg.enabled || challengeBgmActive || !playlist.length) return;
+        let attempts = playlist.length;
+        while (attempts > 0) {
+          const idx = bgmPlaylistIndex % playlist.length;
+          bgmPlaylistIndex += 1;
+          attempts -= 1;
+          const url = playlist[idx];
+          if (!isUrl(url)) continue;
+          setTrack(url, { loop: false });
+          if (bgmAudio) {
+            bgmAudio.onended = () => {
+              if (!challengeBgmActive) playNextPlaylistTrack();
+            };
+          }
+          return;
+        }
+      }
+      function startPlaylist() {
+        if (!cfg.enabled || challengeBgmActive) return;
+        if (bgmAudio && !bgmAudio.paused) return;
+        playNextPlaylistTrack();
+      }
+      function startChallengeMusic() {
+        const url = cfg.bgm?.challenge;
+        if (!cfg.enabled || !isUrl(url)) return;
+        challengeBgmActive = true;
+        setTrack(url, { loop: true });
+      }
+      function stopChallengeMusic() {
+        if (!cfg.enabled) return;
+        challengeBgmActive = false;
+        playNextPlaylistTrack();
+      }
+      return {
+        playMovement(type) { playSfx(cfg.movement?.[type]); },
+        playChallengeStart() { playSfx(cfg.challenge?.start); },
+        playChallengeEnd() { playSfx(cfg.challenge?.end); },
+        startPlaylist,
+        startChallengeMusic,
+        stopChallengeMusic,
+      };
+    })();
     const MAO_AO_CULTURE = {
       id: "mao_ao",
       displayName: "Mao-ao",
@@ -2691,6 +2817,7 @@
       }
     }
     function startGame() {
+      SCRATCHBONES_AUDIO.startPlaylist();
       clearChallengeTimer();
       state.players = makePlayers();
       state.selectedCardIds.clear();
@@ -2955,6 +3082,8 @@
     function startChallenge(challengerIndex, challengedIndex) {
       if (!state.challengeWindow || state.gameOver || state.betting) return;
       clearChallengeTimer();
+      SCRATCHBONES_AUDIO.playChallengeStart();
+      SCRATCHBONES_AUDIO.startChallengeMusic();
       const play = state.challengeWindow.lastPlay;
       addLog(`${seatLabel(challengerIndex)} challenges ${seatLabel(challengedIndex)}.`);
       state.betting = {
@@ -3179,6 +3308,8 @@
     }
     function finalizeChallengeByFold(winnerId, loserId, reason) {
       if (!state.betting || state.gameOver) return;
+      SCRATCHBONES_AUDIO.playChallengeEnd();
+      SCRATCHBONES_AUDIO.stopChallengeMusic();
       const winner = state.players[winnerId];
       const loser = state.players[loserId];
       let award = challengePotTotal();
@@ -3201,6 +3332,8 @@
     }
     function revealChallenge() {
       if (!state.betting || state.gameOver) return;
+      SCRATCHBONES_AUDIO.playChallengeEnd();
+      SCRATCHBONES_AUDIO.stopChallengeMusic();
       const play = state.betting.play;
       const challengerId = state.betting.challengerId;
       const challengedId = state.betting.challengedId;
@@ -4528,6 +4661,7 @@
               const isClaimOrTable = containerType === 'claim' || containerType === 'table';
               if (actorRect && isClaimOrTable) {
                 // Opponent card: fly from cluster avatar center, start tiny
+                SCRATCHBONES_AUDIO.playMovement('opponentToTable');
                 const staggerDelay = opponentCardIdx * OPPONENT_STAGGER_MS;
                 opponentCardIdx++;
                 const existing = activeClones.get(id);
@@ -4567,6 +4701,7 @@
                 }, staggerDelay);
               } else {
                 // Normal fade-in for new cards with no prior position
+                SCRATCHBONES_AUDIO.playMovement('fadeIn');
                 img.style.opacity = '0';
                 requestAnimationFrame(() => {
                   img.style.transition = `opacity ${FADE_MS}ms ease`;
@@ -4578,6 +4713,15 @@
             }
 
             if (snapshot.containerType === containerType) return;
+            const movementType =
+              snapshot.containerType === 'hand' && (containerType === 'table' || containerType === 'claim')
+                ? 'handToTable'
+                : (snapshot.containerType === 'table' && containerType === 'claim')
+                  ? 'tableToClaim'
+                  : ((snapshot.containerType === 'claim' || snapshot.containerType === 'table') && containerType === 'hand')
+                    ? 'claimToHand'
+                    : 'fadeIn';
+            SCRATCHBONES_AUDIO.playMovement(movementType);
             const existing = activeClones.get(id);
             if (existing) existing.remove();
             const dx = snapshot.rect.left - newRect.left;
@@ -5942,6 +6086,8 @@
     }
     window.addEventListener('resize', scheduleResponsiveFitPass, { passive: true });
     window.addEventListener('orientationchange', scheduleResponsiveFitPass, { passive: true });
+    window.addEventListener('pointerdown', () => SCRATCHBONES_AUDIO.startPlaylist(), { once: true, passive: true });
+    window.addEventListener('keydown', () => SCRATCHBONES_AUDIO.startPlaylist(), { once: true, passive: true });
     startGame();
   </script>
 </body>

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -636,6 +636,30 @@ window.SCRATCHBONES_CONFIG = {
           "fallbackSrc": "2DScratchbones{rank}.png"
         }
       },
+      "audio": {
+        "enabled": true,
+        "sfxVolume": 0.92,
+        "bgmVolume": 0.48,
+        "musicFadeMs": 280,
+        "movement": {
+          "handToTable": { "url": "./docs/assets/audio/scratchbones/sfx/hand-to-table.mp3", "pitch": 1.0, "tempo": 1.0, "volume": 0.95 },
+          "tableToClaim": { "url": "./docs/assets/audio/scratchbones/sfx/table-to-claim.mp3", "pitch": 1.08, "tempo": 1.0, "volume": 0.9 },
+          "claimToHand": { "url": "./docs/assets/audio/scratchbones/sfx/claim-to-hand.mp3", "pitch": 0.92, "tempo": 0.98, "volume": 0.94 },
+          "opponentToTable": { "url": "./docs/assets/audio/scratchbones/sfx/opponent-to-table.mp3", "pitch": 0.88, "tempo": 0.94, "volume": 0.9 },
+          "fadeIn": { "url": "./docs/assets/audio/scratchbones/sfx/card-fade.mp3", "pitch": 1.0, "tempo": 1.02, "volume": 0.78 }
+        },
+        "challenge": {
+          "start": { "url": "./docs/assets/audio/scratchbones/sfx/challenge-start.mp3", "pitch": 1.0, "tempo": 1.0, "volume": 1.0 },
+          "end": { "url": "./docs/assets/audio/scratchbones/sfx/challenge-end.mp3", "pitch": 1.0, "tempo": 1.0, "volume": 1.0 }
+        },
+        "bgm": {
+          "playlist": [
+            "./docs/assets/audio/scratchbones/bgm/table-loop-01.mp3",
+            "./docs/assets/audio/scratchbones/bgm/table-loop-02.mp3"
+          ],
+          "challenge": "./docs/assets/audio/scratchbones/bgm/challenge-loop.mp3"
+        }
+      },
       "portrait": {
         "assetBase": "./docs/assets/",
         "configBase": "./docs/config/"


### PR DESCRIPTION
### Motivation
- Make card visuals consistent by using the same sizing basis for cards on the board/claim bar as cards in the hand so their perceived size matches across UI zones.
- Add configurable, resilient audio (movement SFX, challenge SFX, playlist BGM and challenge BGM) driven from `scratchbones-config` and ensure smooth fades and safe failure handling so missing/blocked audio does not break gameplay.

### Description
- Unify card sizing by changing `.tableViewCard` and `.claimHandBar .tableViewCard` CSS to derive from the hand sizing CSS variables (`--layout-hand-card-*` clamps) so table/claim cards match hand card sizes.
- Extend config normalization to include `assets.audio` in `ScratchbonesBluffGame.html` and add default audio values in `docs/config/scratchbones-config.js` (SFX URLs + pitch/tempo/volume, `bgm.playlist` array and a `bgm.challenge` URL, `musicFadeMs`, and global volume flags).
- Add a resilient runtime audio manager (`SCRATCHBONES_AUDIO`) that safely builds `Audio` elements, plays movement SFX with pitch/tempo/volume, cycles a BGM playlist, starts/stops a looping challenge BGM, and cross-fades tracks via a `fadeTo` routine while gracefully ignoring missing URLs or playback rejections.
- Wire audio hooks into runtime flows: call `SCRATCHBONES_AUDIO.startPlaylist()` on game start (and on first user interaction fallback), call `SCRATCHBONES_AUDIO.playMovement(...)` from card animation branches (distinct movement types: `handToTable`, `tableToClaim`, `claimToHand`, `opponentToTable`, `fadeIn`), and call `playChallengeStart`/`startChallengeMusic` at challenge start and `playChallengeEnd`/`stopChallengeMusic` on challenge resolution.

### Testing
- Ran `npm test -- --runInBand` which executes lint + unit tests; overall test run executed the repository test suite and reported `# tests 339, # pass 310, # fail 29` (failures are pre-existing unrelated assertions across other modules and not caused by the Scratchbones changes in this PR).
- Verified that `ScratchbonesBluffGame.html` still initializes and that audio calls are guarded to no-op when URLs are absent or preload/play is blocked (playlist startup also attached to first `pointerdown`/`keydown` to accommodate autoplay restrictions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63025e248832697a0690a1f49c161)