### PR TITLE
Add species-driven color randomization rules and tune species palettes

### DIFF
--- a/docs/config/species/kenkari.json
+++ b/docs/config/species/kenkari.json
@@ -200,6 +200,48 @@
         "scaleY": 2.55,
         "rotDeg": 0
       }
+    },
+    "randomizationRules": {
+      "brightnessContrastAB": {
+        "medium": {
+          "min": -0.05,
+          "max": 0.2
+        },
+        "bright": {
+          "min": 0.22,
+          "max": 0.45
+        }
+      },
+      "clothingColors": {
+        "syncAcrossPieces": false,
+        "range": {
+          "minH": -40,
+          "maxH": 65,
+          "stops": [
+            {
+              "h": -40,
+              "sMin": -0.85,
+              "sMax": -0.35,
+              "vMin": -0.7,
+              "vMax": -0.1
+            },
+            {
+              "h": 10,
+              "sMin": -0.8,
+              "sMax": -0.25,
+              "vMin": -0.75,
+              "vMax": -0.15
+            },
+            {
+              "h": 65,
+              "sMin": -0.7,
+              "sMax": -0.2,
+              "vMin": -0.65,
+              "vMax": -0.05
+            }
+          ]
+        }
+      }
     }
   },
   "female": {
@@ -265,83 +307,83 @@
     },
     "bodyColorRanges": {
       "A": {
-        "minH": -180,
-        "maxH": 180,
+        "minH": -110,
+        "maxH": -15,
         "stops": [
           {
-            "h": -180,
-            "sMin": 0.35,
-            "sMax": 1.5,
-            "vMin": -0.15,
-            "vMax": 0.35
+            "h": -110,
+            "sMin": -0.95,
+            "sMax": -0.5,
+            "vMin": -0.35,
+            "vMax": 0.15
           },
           {
-            "h": 0,
-            "sMin": 0.35,
-            "sMax": 1.5,
-            "vMin": -0.15,
-            "vMax": 0.35
+            "h": -60,
+            "sMin": -0.98,
+            "sMax": -0.58,
+            "vMin": -0.4,
+            "vMax": 0.1
           },
           {
-            "h": 180,
-            "sMin": 0.35,
-            "sMax": 1.5,
-            "vMin": -0.15,
-            "vMax": 0.35
+            "h": -15,
+            "sMin": -0.9,
+            "sMax": -0.45,
+            "vMin": -0.3,
+            "vMax": 0.2
           }
         ]
       },
       "B": {
-        "minH": -180,
-        "maxH": 180,
+        "minH": -110,
+        "maxH": -15,
         "stops": [
           {
-            "h": -180,
-            "sMin": 0.45,
-            "sMax": 1.5,
-            "vMin": -0.25,
-            "vMax": 0.25
+            "h": -110,
+            "sMin": -0.98,
+            "sMax": -0.55,
+            "vMin": -0.55,
+            "vMax": -0.05
           },
           {
-            "h": 0,
-            "sMin": 0.45,
-            "sMax": 1.5,
-            "vMin": -0.25,
-            "vMax": 0.25
+            "h": -60,
+            "sMin": -1.0,
+            "sMax": -0.6,
+            "vMin": -0.6,
+            "vMax": -0.1
           },
           {
-            "h": 180,
-            "sMin": 0.45,
-            "sMax": 1.5,
-            "vMin": -0.25,
-            "vMax": 0.25
+            "h": -15,
+            "sMin": -0.95,
+            "sMax": -0.5,
+            "vMin": -0.5,
+            "vMax": 0.0
           }
         ]
       },
       "C": {
-        "minH": -180,
-        "maxH": 180,
+        "minH": -110,
+        "maxH": -15,
         "stops": [
           {
-            "h": -180,
-            "sMin": 0.3,
-            "sMax": 1.4,
-            "vMin": -0.1,
-            "vMax": 0.45
+            "h": -110,
+            "sMin": -1.0,
+            "sMax": -0.6,
+            "vMin": -0.2,
+            "vMax": 0.25
           },
           {
-            "h": 0,
-            "sMin": 0.3,
-            "sMax": 1.4,
-            "vMin": -0.1,
-            "vMax": 0.45
+            "h": -60,
+            "sMin": -1.0,
+            "sMax": -0.65,
+            "vMin": -0.15,
+            "vMax": 0.2
           },
           {
-            "h": 180,
-            "sMin": 0.3,
-            "sMax": 1.4,
+            "h": -15,
+            "sMin": -0.95,
+            "sMax": -0.55,
             "vMin": -0.1,
-            "vMax": 0.45
+            "vMax": 0.3
           }
         ]
       }
@@ -396,6 +438,38 @@
         "scaleX": 2.55,
         "scaleY": 2.55,
         "rotDeg": 0
+      }
+    },
+    "randomizationRules": {
+      "clothingColors": {
+        "syncAcrossPieces": false,
+        "range": {
+          "minH": -150,
+          "maxH": 115,
+          "stops": [
+            {
+              "h": -150,
+              "sMin": 0.15,
+              "sMax": 0.55,
+              "vMin": 0.05,
+              "vMax": 0.35
+            },
+            {
+              "h": -20,
+              "sMin": 0.2,
+              "sMax": 0.6,
+              "vMin": 0.1,
+              "vMax": 0.4
+            },
+            {
+              "h": 115,
+              "sMin": 0.18,
+              "sMax": 0.52,
+              "vMin": 0.08,
+              "vMax": 0.32
+            }
+          ]
+        }
       }
     }
   }

--- a/docs/config/species/mao-ao.json
+++ b/docs/config/species/mao-ao.json
@@ -51,22 +51,15 @@
     },
     "bodyColorRanges": {
       "A": {
-        "minH": -100,
-        "maxH": 90,
+        "minH": -85,
+        "maxH": 70,
         "stops": [
           {
-            "h": -115,
-            "sMin": -0.5,
-            "sMax": 0.95,
-            "vMin": -0.35,
-            "vMax": 0.55
-          },
-          {
-            "h": -88,
-            "sMin": -0.3,
-            "sMax": 0.55,
-            "vMin": -0.72,
-            "vMax": 0.15
+            "h": -85,
+            "sMin": -0.95,
+            "sMax": -0.6,
+            "vMin": -0.92,
+            "vMax": 0.65
           },
           {
             "h": -60,
@@ -83,31 +76,24 @@
             "vMax": 0.85
           },
           {
-            "h": 90,
+            "h": 70,
             "sMin": -1,
-            "sMax": -0.25,
-            "vMin": -0.45,
-            "vMax": 0.12
+            "sMax": -0.45,
+            "vMin": -0.95,
+            "vMax": 0.85
           }
         ]
       },
       "B": {
-        "minH": -100,
-        "maxH": 90,
+        "minH": -85,
+        "maxH": 70,
         "stops": [
           {
-            "h": -115,
-            "sMin": -0.1,
-            "sMax": 1,
-            "vMin": -0.7,
-            "vMax": 0.1
-          },
-          {
-            "h": -88,
-            "sMin": -0.25,
-            "sMax": 0.55,
-            "vMin": -0.9,
-            "vMax": -0.2
+            "h": -85,
+            "sMin": -0.95,
+            "sMax": -0.4,
+            "vMin": -0.97,
+            "vMax": 0.3
           },
           {
             "h": -60,
@@ -124,24 +110,24 @@
             "vMax": 0.5
           },
           {
-            "h": 90,
+            "h": 70,
             "sMin": -1,
-            "sMax": -0.25,
-            "vMin": -0.65,
-            "vMax": -0.05
+            "sMax": -0.45,
+            "vMin": -0.97,
+            "vMax": 0.5
           }
         ]
       },
       "C": {
-        "minH": -100,
-        "maxH": 90,
+        "minH": -85,
+        "maxH": 70,
         "stops": [
           {
-            "h": -115,
-            "sMin": -0.6,
-            "sMax": 0.7,
-            "vMin": -0.2,
-            "vMax": 0.6
+            "h": -85,
+            "sMin": -0.9,
+            "sMax": -0.1,
+            "vMin": 0,
+            "vMax": 0.75
           },
           {
             "h": -70,
@@ -158,11 +144,11 @@
             "vMax": 0.9
           },
           {
-            "h": 90,
+            "h": 70,
             "sMin": -1,
-            "sMax": -0.4,
-            "vMin": -0.05,
-            "vMax": 0.35
+            "sMax": -0.5,
+            "vMin": 0.1,
+            "vMax": 0.9
           }
         ]
       }
@@ -217,6 +203,38 @@
         "scaleX": 2.55,
         "scaleY": 2.55,
         "rotDeg": 0
+      }
+    },
+    "randomizationRules": {
+      "clothingColors": {
+        "syncAcrossPieces": false,
+        "range": {
+          "minH": -180,
+          "maxH": 180,
+          "stops": [
+            {
+              "h": -180,
+              "sMin": -0.15,
+              "sMax": 0.9,
+              "vMin": -0.2,
+              "vMax": 0.45
+            },
+            {
+              "h": 0,
+              "sMin": -0.2,
+              "sMax": 0.95,
+              "vMin": -0.25,
+              "vMax": 0.5
+            },
+            {
+              "h": 180,
+              "sMin": -0.15,
+              "sMax": 0.9,
+              "vMin": -0.2,
+              "vMax": 0.45
+            }
+          ]
+        }
       }
     }
   },
@@ -295,22 +313,15 @@
     ],
     "bodyColorRanges": {
       "A": {
-        "minH": -100,
-        "maxH": 90,
+        "minH": -85,
+        "maxH": 70,
         "stops": [
           {
-            "h": -115,
-            "sMin": -0.5,
-            "sMax": 0.95,
-            "vMin": -0.35,
-            "vMax": 0.55
-          },
-          {
-            "h": -88,
-            "sMin": -0.3,
-            "sMax": 0.55,
-            "vMin": -0.72,
-            "vMax": 0.15
+            "h": -85,
+            "sMin": -0.95,
+            "sMax": -0.6,
+            "vMin": -0.92,
+            "vMax": 0.65
           },
           {
             "h": -60,
@@ -327,31 +338,24 @@
             "vMax": 0.85
           },
           {
-            "h": 90,
+            "h": 70,
             "sMin": -1,
-            "sMax": -0.25,
-            "vMin": -0.45,
-            "vMax": 0.12
+            "sMax": -0.45,
+            "vMin": -0.95,
+            "vMax": 0.85
           }
         ]
       },
       "B": {
-        "minH": -100,
-        "maxH": 90,
+        "minH": -85,
+        "maxH": 70,
         "stops": [
           {
-            "h": -115,
-            "sMin": -0.1,
-            "sMax": 1,
-            "vMin": -0.7,
-            "vMax": 0.1
-          },
-          {
-            "h": -88,
-            "sMin": -0.25,
-            "sMax": 0.55,
-            "vMin": -0.9,
-            "vMax": -0.2
+            "h": -85,
+            "sMin": -0.95,
+            "sMax": -0.4,
+            "vMin": -0.97,
+            "vMax": 0.3
           },
           {
             "h": -60,
@@ -368,24 +372,24 @@
             "vMax": 0.5
           },
           {
-            "h": 90,
+            "h": 70,
             "sMin": -1,
-            "sMax": -0.25,
-            "vMin": -0.65,
-            "vMax": -0.05
+            "sMax": -0.45,
+            "vMin": -0.97,
+            "vMax": 0.5
           }
         ]
       },
       "C": {
-        "minH": -100,
-        "maxH": 90,
+        "minH": -85,
+        "maxH": 70,
         "stops": [
           {
-            "h": -115,
-            "sMin": -0.6,
-            "sMax": 0.7,
-            "vMin": -0.2,
-            "vMax": 0.6
+            "h": -85,
+            "sMin": -0.9,
+            "sMax": -0.1,
+            "vMin": 0,
+            "vMax": 0.75
           },
           {
             "h": -70,
@@ -402,11 +406,11 @@
             "vMax": 0.9
           },
           {
-            "h": 90,
+            "h": 70,
             "sMin": -1,
-            "sMax": -0.4,
-            "vMin": -0.05,
-            "vMax": 0.35
+            "sMax": -0.5,
+            "vMin": 0.1,
+            "vMax": 0.9
           }
         ]
       }
@@ -461,6 +465,38 @@
         "scaleX": 2.55,
         "scaleY": 2.55,
         "rotDeg": 0
+      }
+    },
+    "randomizationRules": {
+      "clothingColors": {
+        "syncAcrossPieces": false,
+        "range": {
+          "minH": -150,
+          "maxH": 115,
+          "stops": [
+            {
+              "h": -150,
+              "sMin": 0.15,
+              "sMax": 0.55,
+              "vMin": 0.05,
+              "vMax": 0.35
+            },
+            {
+              "h": -20,
+              "sMin": 0.2,
+              "sMax": 0.6,
+              "vMin": 0.1,
+              "vMax": 0.4
+            },
+            {
+              "h": 115,
+              "sMin": 0.18,
+              "sMax": 0.52,
+              "vMin": 0.08,
+              "vMax": 0.32
+            }
+          ]
+        }
       }
     }
   }

--- a/docs/config/species/tletingan.json
+++ b/docs/config/species/tletingan.json
@@ -47,33 +47,105 @@
     },
     "bodyColorRanges": {
       "A": {
-        "minH": -130,
-        "maxH": 20,
+        "minH": -95,
+        "maxH": 10,
         "stops": [
-          { "h": -130, "sMin": -0.6, "sMax": 0.1,  "vMin": -0.3,  "vMax": 0.25 },
-          { "h":  -60, "sMin": -0.5, "sMax": 0.15, "vMin": -0.4,  "vMax": 0.2  },
-          { "h":    0, "sMin": -0.7, "sMax": 0.05, "vMin": -0.35, "vMax": 0.15 },
-          { "h":   20, "sMin": -0.7, "sMax": 0.1,  "vMin": -0.3,  "vMax": 0.2  }
+          {
+            "h": -95,
+            "sMin": -0.5,
+            "sMax": 0.15,
+            "vMin": -0.4,
+            "vMax": 0.2
+          },
+          {
+            "h": -60,
+            "sMin": -0.5,
+            "sMax": 0.15,
+            "vMin": -0.4,
+            "vMax": 0.2
+          },
+          {
+            "h": 0,
+            "sMin": -0.7,
+            "sMax": 0.05,
+            "vMin": -0.35,
+            "vMax": 0.15
+          },
+          {
+            "h": 10,
+            "sMin": -0.7,
+            "sMax": 0.05,
+            "vMin": -0.35,
+            "vMax": 0.15
+          }
         ]
       },
       "B": {
-        "minH": -130,
-        "maxH": 20,
+        "minH": -95,
+        "maxH": 10,
         "stops": [
-          { "h": -130, "sMin": -0.7, "sMax": 0.05, "vMin": -0.5,  "vMax": 0.1  },
-          { "h":  -60, "sMin": -0.65,"sMax": 0.05, "vMin": -0.55, "vMax": 0.05 },
-          { "h":    0, "sMin": -0.75,"sMax": -0.1, "vMin": -0.5,  "vMax": 0.15 },
-          { "h":   20, "sMin": -0.75,"sMax": 0.0,  "vMin": -0.45, "vMax": 0.1  }
+          {
+            "h": -95,
+            "sMin": -0.65,
+            "sMax": 0.05,
+            "vMin": -0.55,
+            "vMax": 0.05
+          },
+          {
+            "h": -60,
+            "sMin": -0.65,
+            "sMax": 0.05,
+            "vMin": -0.55,
+            "vMax": 0.05
+          },
+          {
+            "h": 0,
+            "sMin": -0.75,
+            "sMax": -0.1,
+            "vMin": -0.5,
+            "vMax": 0.15
+          },
+          {
+            "h": 10,
+            "sMin": -0.75,
+            "sMax": -0.1,
+            "vMin": -0.5,
+            "vMax": 0.15
+          }
         ]
       },
       "C": {
-        "minH": -130,
-        "maxH": 20,
+        "minH": -95,
+        "maxH": 10,
         "stops": [
-          { "h": -130, "sMin": -0.8, "sMax": -0.1,  "vMin": 0.0, "vMax": 0.5  },
-          { "h":  -60, "sMin": -0.75,"sMax": -0.05, "vMin": 0.05,"vMax": 0.55 },
-          { "h":    0, "sMin": -0.85,"sMax": -0.2,  "vMin": 0.1, "vMax": 0.6  },
-          { "h":   20, "sMin": -0.8, "sMax": -0.1,  "vMin": 0.05,"vMax": 0.5  }
+          {
+            "h": -95,
+            "sMin": -0.75,
+            "sMax": -0.05,
+            "vMin": 0.05,
+            "vMax": 0.55
+          },
+          {
+            "h": -60,
+            "sMin": -0.75,
+            "sMax": -0.05,
+            "vMin": 0.05,
+            "vMax": 0.55
+          },
+          {
+            "h": 0,
+            "sMin": -0.85,
+            "sMax": -0.2,
+            "vMin": 0.1,
+            "vMax": 0.6
+          },
+          {
+            "h": 10,
+            "sMin": -0.85,
+            "sMax": -0.2,
+            "vMin": 0.1,
+            "vMax": 0.6
+          }
         ]
       }
     },
@@ -127,6 +199,38 @@
         "scaleX": 2.55,
         "scaleY": 2.55,
         "rotDeg": 0
+      }
+    },
+    "randomizationRules": {
+      "clothingColors": {
+        "syncAcrossPieces": true,
+        "range": {
+          "minH": -180,
+          "maxH": 180,
+          "stops": [
+            {
+              "h": -180,
+              "sMin": 0.35,
+              "sMax": 0.95,
+              "vMin": 0.1,
+              "vMax": 0.55
+            },
+            {
+              "h": 0,
+              "sMin": 0.35,
+              "sMax": 0.95,
+              "vMin": 0.1,
+              "vMax": 0.55
+            },
+            {
+              "h": 180,
+              "sMin": 0.35,
+              "sMax": 0.95,
+              "vMin": 0.1,
+              "vMax": 0.55
+            }
+          ]
+        }
       }
     }
   }

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -633,14 +633,6 @@ function applyBodyColorRulesSeeded(bodyColors, rules, rng) {
   return result;
 }
 
-function resolveClothingColorRangeSeeded(hat, torsoCosmetic, armCosmetic, clothingRule) {
-  return clothingRule?.range
-    || torsoCosmetic?.colorRange
-    || armCosmetic?.colorRange
-    || hat?.colorRange
-    || null;
-}
-
 /**
  * Weighted random pick from an array, driven by rng().
  * weights: object mapping item.id to a numeric weight (items absent from the map default to 1).
@@ -799,22 +791,19 @@ function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, h
   bodyColors = applyBodyColorRulesSeeded(bodyColors, randomizationRules, rng);
 
   const clothingRule = randomizationRules?.clothingColors;
-  const clothingRange = resolveClothingColorRangeSeeded(hat, torsoCosmetic, armCosmetic, clothingRule);
   const hasClothPiece = Boolean(torsoCosmetic?.colorRange || armCosmetic?.colorRange);
   const syncAcrossPieces = clothingRule?.syncAcrossPieces === true;
+  const ruleRange = clothingRule?.range || null;
+  const clothSourceRange = ruleRange || torsoCosmetic?.colorRange || armCosmetic?.colorRange || null;
+  const hatSourceRange = ruleRange || hat?.colorRange || null;
 
-  if (clothingRange && (hasClothPiece || hat?.colorRange)) {
-    const clothColor = randomColorFromRangeSeeded(clothingRange, rng);
-    if (hasClothPiece) bodyColors.CLOTH = clothColor;
-    if (hat?.colorRange) {
-      bodyColors.HAT = syncAcrossPieces ? clothColor : randomColorFromRangeSeeded(clothingRange, rng);
-    }
-  } else {
-    if (hat?.colorRange) bodyColors.HAT = randomColorFromRangeSeeded(hat.colorRange, rng);
-    if (torsoCosmetic?.colorRange || armCosmetic?.colorRange) {
-      const sourceRange = torsoCosmetic?.colorRange || armCosmetic?.colorRange;
-      bodyColors.CLOTH = randomColorFromRangeSeeded(sourceRange, rng);
-    }
+  if (hasClothPiece && clothSourceRange) {
+    bodyColors.CLOTH = randomColorFromRangeSeeded(clothSourceRange, rng);
+  }
+  if (hat?.colorRange && hatSourceRange) {
+    bodyColors.HAT = (syncAcrossPieces && bodyColors.CLOTH)
+      ? bodyColors.CLOTH
+      : randomColorFromRangeSeeded(hatSourceRange, rng);
   }
   return { fighter, hairFront, hairBack, hairSide, eyes, facialHair, hat, torsoCosmetic, armCosmetic, bodyColors };
 }

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -100,6 +100,7 @@ let PORTRAIT_L  = _portraitConfig.canvas?.layerSize ?? 80;
 let HEAD_XFORM = _portraitConfig.headXform || _PORTRAIT_DEFAULTS.headXform;
 let FIGHTERS = (_portraitConfig.fighters || _PORTRAIT_DEFAULTS.fighters).map(normalizedFighterPortrait);
 let BODYCOLOR_LIMITS = _portraitConfig.bodyColorLimits || _PORTRAIT_DEFAULTS.bodyColorLimits;
+let LAST_RANDOMIZATION_RULES_BY_FIGHTER = {};
 
 // ── Image loading ──────────────────────────────────────────
 
@@ -480,6 +481,7 @@ async function loadPortraitCosmetics(configBase) {
   const fighterPortraitOverrides = {};
   const forcedCosmeticsByFighter = {};
   const conditionalCosmeticsByFighter = {};
+  const randomizationRulesByFighter = {};
   try {
     const speciesIdxUrl = new URL(configBase + 'species/index.json', window.location.href).toString();
     const speciesIdxResp = await fetch(speciesIdxUrl);
@@ -538,6 +540,9 @@ async function loadPortraitCosmetics(configBase) {
             if (Array.isArray(genderData.conditionalCosmetics)) {
               conditionalCosmeticsByFighter[fighter.id] = genderData.conditionalCosmetics;
             }
+            if (genderData.randomizationRules && typeof genderData.randomizationRules === 'object') {
+              randomizationRulesByFighter[fighter.id] = genderData.randomizationRules;
+            }
           }
         }
       }));
@@ -559,7 +564,9 @@ async function loadPortraitCosmetics(configBase) {
     });
   }
 
-  return { hairFrontOptions, hairBackOptions, hairSideOptions, eyesOptions, facialHairOptions, hatOptions, torsoPortraitOptions, armPortraitOptions, indexEntries, optionCache, bodyColorRangesByGender, allowedCosmeticsByFighter, cosmeticWeightsByFighter, forcedCosmeticsByFighter, conditionalCosmeticsByFighter };
+  LAST_RANDOMIZATION_RULES_BY_FIGHTER = randomizationRulesByFighter;
+
+  return { hairFrontOptions, hairBackOptions, hairSideOptions, eyesOptions, facialHairOptions, hatOptions, torsoPortraitOptions, armPortraitOptions, indexEntries, optionCache, bodyColorRangesByGender, allowedCosmeticsByFighter, cosmeticWeightsByFighter, forcedCosmeticsByFighter, conditionalCosmeticsByFighter, randomizationRulesByFighter };
 }
 
 // ── Seeded randomisation ───────────────────────────────────
@@ -599,6 +606,39 @@ function randomBodyColorsSeeded(rng, bodyColorRanges) {
     B: bodyColorRanges && bodyColorRanges.B ? randomColorFromRangeSeeded(bodyColorRanges.B, rng) : fallback('B'),
     C: bodyColorRanges && bodyColorRanges.C ? randomColorFromRangeSeeded(bodyColorRanges.C, rng) : fallback('C'),
   };
+}
+
+function randomInRange(rng, lo, hi) {
+  return lo + rng() * (hi - lo);
+}
+
+function applyBodyColorRulesSeeded(bodyColors, rules, rng) {
+  if (!bodyColors || !rules || typeof rules !== 'object') return bodyColors;
+  const result = {
+    ...bodyColors,
+    A: bodyColors.A ? { ...bodyColors.A } : bodyColors.A,
+    B: bodyColors.B ? { ...bodyColors.B } : bodyColors.B,
+    C: bodyColors.C ? { ...bodyColors.C } : bodyColors.C
+  };
+  const brightnessRule = rules.brightnessContrastAB;
+  if (!brightnessRule || !result.A || !result.B) return result;
+  const medium = brightnessRule.medium;
+  const bright = brightnessRule.bright;
+  if (!medium || !bright) return result;
+  const flip = rng() < 0.5;
+  const slotA = flip ? 'A' : 'B';
+  const slotB = flip ? 'B' : 'A';
+  result[slotA].v = randomInRange(rng, medium.min, medium.max);
+  result[slotB].v = randomInRange(rng, bright.min, bright.max);
+  return result;
+}
+
+function resolveClothingColorRangeSeeded(hat, torsoCosmetic, armCosmetic, clothingRule) {
+  return clothingRule?.range
+    || torsoCosmetic?.colorRange
+    || armCosmetic?.colorRange
+    || hat?.colorRange
+    || null;
 }
 
 /**
@@ -648,7 +688,7 @@ function resolvePortraitFighter(fighter) {
  *   per-category weights map (see weightedPickRng docs above). When omitted the selection
  *   falls back to the original uniform-random behaviour.
  */
-function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, hairSideOptions, eyesOptions, facialHairOptions, bodyColorRangesByGender, allowedCosmeticsByFighter, hatOptions, cosmeticWeightsByFighter, torsoPortraitOptions, armPortraitOptions, forcedCosmeticsByFighter, conditionalCosmeticsByFighter) {
+function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, hairSideOptions, eyesOptions, facialHairOptions, bodyColorRangesByGender, allowedCosmeticsByFighter, hatOptions, cosmeticWeightsByFighter, torsoPortraitOptions, armPortraitOptions, forcedCosmeticsByFighter, conditionalCosmeticsByFighter, randomizationRulesByFighter) {
   const pickRng   = (arr) => arr[Math.floor(rng() * arr.length)];
   const fighterInput = pickRng(fighters);
   const fighter = resolvePortraitFighter(fighterInput);
@@ -753,9 +793,29 @@ function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, h
     }
   }
 
-  const bodyColors = randomBodyColorsSeeded(rng, bodyColorRangesByGender?.[fighter.id] ?? bodyColorRangesByGender?.[fighterInput?.id]);
-  if (hat && hat.colorRange) bodyColors.HAT = randomColorFromRangeSeeded(hat.colorRange, rng);
-  if (torsoCosmetic?.colorRange) bodyColors.CLOTH = randomColorFromRangeSeeded(torsoCosmetic.colorRange, rng);
+  const ruleMap = randomizationRulesByFighter || LAST_RANDOMIZATION_RULES_BY_FIGHTER || null;
+  const randomizationRules = ruleMap?.[fighter.id] ?? ruleMap?.[fighterInput?.id] ?? null;
+  let bodyColors = randomBodyColorsSeeded(rng, bodyColorRangesByGender?.[fighter.id] ?? bodyColorRangesByGender?.[fighterInput?.id]);
+  bodyColors = applyBodyColorRulesSeeded(bodyColors, randomizationRules, rng);
+
+  const clothingRule = randomizationRules?.clothingColors;
+  const clothingRange = resolveClothingColorRangeSeeded(hat, torsoCosmetic, armCosmetic, clothingRule);
+  const hasClothPiece = Boolean(torsoCosmetic?.colorRange || armCosmetic?.colorRange);
+  const syncAcrossPieces = clothingRule?.syncAcrossPieces === true;
+
+  if (clothingRange && (hasClothPiece || hat?.colorRange)) {
+    const clothColor = randomColorFromRangeSeeded(clothingRange, rng);
+    if (hasClothPiece) bodyColors.CLOTH = clothColor;
+    if (hat?.colorRange) {
+      bodyColors.HAT = syncAcrossPieces ? clothColor : randomColorFromRangeSeeded(clothingRange, rng);
+    }
+  } else {
+    if (hat?.colorRange) bodyColors.HAT = randomColorFromRangeSeeded(hat.colorRange, rng);
+    if (torsoCosmetic?.colorRange || armCosmetic?.colorRange) {
+      const sourceRange = torsoCosmetic?.colorRange || armCosmetic?.colorRange;
+      bodyColors.CLOTH = randomColorFromRangeSeeded(sourceRange, rng);
+    }
+  }
   return { fighter, hairFront, hairBack, hairSide, eyes, facialHair, hat, torsoCosmetic, armCosmetic, bodyColors };
 }
 


### PR DESCRIPTION
### Motivation
- Prevent unnatural pink body tints and introduce species+gender preferences for body/clothing palettes so generated portraits match lore expectations. 
- Ensure Kenkari male body slots A/B always differ in brightness while Kenkari females are more desaturated and stay out of the orange/red hue band. 
- Allow cloth pieces to obey species+gender clothing preferences and optionally be synchronized across multiple cloth pieces (Tletingan requirement).

### Description
- Added reading of a new `randomizationRules` block in `loadPortraitCosmetics()` and return it as `randomizationRulesByFighter`, with a global fallback `LAST_RANDOMIZATION_RULES_BY_FIGHTER` for backward compatibility. 
- Extended `randomProfileSeeded()` to accept `randomizationRulesByFighter` (or use the fallback) and apply rules during color generation using new helpers `applyBodyColorRulesSeeded()`, `randomInRange()`, and `resolveClothingColorRangeSeeded()`. 
- Implemented `brightnessContrastAB` handling so Kenkari males get A/B brightness contrast (randomized which slot is bright vs medium). 
- Implemented `clothingColors` handling to prefer species/gender clothing palettes and support `syncAcrossPieces` to reuse the same tint across multiple cloth pieces (used for Tletingan). 
- Tuned species config files under `docs/config/species/` to: tighten Mao-ao and Tletingan body hue spans to avoid pink outcomes; set Kenkari male brightness/clothing ranges to earthy/darker palettes; set Kenkari female body ranges to be more desaturated and exclude left orange/red hues; add clothing palette preferences for Mao-ao to match requested ranges.

### Testing
- Parsed updated species JSON files with `python -m json.tool` (all succeeded). 
- Syntax-checked `docs/js/portrait-utils.js` with `node --check` (succeeded). 
- Ran local code inspection and exercised portrait generation paths in the portrait utilities (manual smoke checks with the seeded generator to confirm rules are being applied).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e785d6afdc83268503b822611551c4)