### PR TITLE
Fix Scratchbones AI default pacing and preserve avatar cluster snapshots

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -1832,7 +1832,7 @@
         },
         timers: {
           challengeTimerSecs: rawGameConfig.timers?.challengeSeconds ?? 6,
-          aiThinkMs: rawGameConfig.timers?.aiThinkMs ?? 6000,
+          aiThinkMs: rawGameConfig.timers?.aiThinkMs ?? 650,
         },
         layout: {
           mode: String(rawGameConfig.layout?.mode || 'responsive').toLowerCase(),
@@ -4819,9 +4819,9 @@
     }
 
     function render() {
-      document.querySelectorAll('[data-cluster-avatar-overlay]').forEach(el => el.remove());
       seatAvatarAnim.capturePreRender();
       cardAnimator.capturePreRender();
+      document.querySelectorAll('[data-cluster-avatar-overlay]').forEach(el => el.remove());
       const app = document.getElementById('app');
       const layoutPolicy = applyLayoutContract(app);
       const player = state.players[0] || { hand: [], chips: 0, clears: 0 };


### PR DESCRIPTION
### Motivation
- Restore the intended AI pacing when no timer override is provided because the fallback `aiThinkMs` had been set to `6000`, causing a large slowdown versus the prior default.
- Ensure avatar cluster canvas snapshots are captured reliably before overlay elements are removed so opponent-origin card fly-in animations can consistently compute `actorRect`.

### Description
- Change the `timers.aiThinkMs` fallback in `normalizeScratchbonesGameConfig()` from `6000` back to `650` so `AI_THINK_MS` uses a sensible default.
- Reorder `render()` so `seatAvatarAnim.capturePreRender()` and `cardAnimator.capturePreRender()` run before removing `[data-cluster-avatar-overlay]` nodes to preserve pre-render cluster snapshots.
- Modified file: `ScratchbonesBluffGame.html`.

### Testing
- Ran `npm run lint` (ESLint) and it passed.
- Ran `npm run test:unit` and the suite failed, but failures are from pre-existing, unrelated tests in this branch (e.g., angle conversion, attack timeline, and several cosmetics tests) and were not introduced by these changes.
- Manual browser verification was not performed in this environment (no headless browser/screenshot capture available), but the fixes are targeted and limited to timing/defaults and render ordering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7876cd64c8326a8ad3a551627c2b5)