### PR TITLE
Fix portrait asset fallback resolution for Scratchbones paths

### DIFF
--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -114,27 +114,47 @@ function setPortraitAssetBase(base) {
 }
 
 function loadImg(relPath) {
-  const url = _puAssetBase + relPath;
-  if (IMG_CACHE.has(url)) return IMG_CACHE.get(url);
-  const promise = new Promise((resolve, reject) => {
+  if (IMG_CACHE.has(relPath)) return IMG_CACHE.get(relPath);
+
+  const ensureTrailingSlash = (base) => String(base || './assets/').replace(/\/?$/, '/');
+  const localBase = ensureTrailingSlash(_puAssetBase);
+  const fallbackBase = localBase.includes('/docs/assets/')
+    ? localBase.replace('/docs/assets/', '/assets/')
+    : localBase.replace('/assets/', '/docs/assets/');
+
+  const candidateUrls = [
+    localBase + relPath,
+    fallbackBase + relPath,
+    'https://raw.githubusercontent.com/Oolnokk/SoKEmpirePrologue/main/docs/assets/' + relPath,
+  ];
+
+  const seen = new Set();
+  const uniqueCandidates = candidateUrls.filter((url) => {
+    if (!url || seen.has(url)) return false;
+    seen.add(url);
+    return true;
+  });
+
+  const tryLoadUrl = (url) => new Promise((resolve, reject) => {
     const img = new Image();
     img.crossOrigin = 'anonymous';
-    img.onload  = () => resolve(img);
-    img.onerror = () => {
-      if (!url.startsWith('https://raw.githubusercontent.com')) {
-        const rawUrl = 'https://raw.githubusercontent.com/Oolnokk/SoKEmpirePrologue/main/docs/assets/' + relPath;
-        const img2 = new Image();
-        img2.crossOrigin = 'anonymous';
-        img2.onload  = () => resolve(img2);
-        img2.onerror = () => reject(new Error('Failed: ' + relPath));
-        img2.src = rawUrl;
-      } else {
-        reject(new Error('Failed: ' + relPath));
-      }
-    };
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(url);
     img.src = url;
   });
-  IMG_CACHE.set(url, promise);
+
+  const promise = (async () => {
+    for (const url of uniqueCandidates) {
+      try {
+        return await tryLoadUrl(url);
+      } catch (_) {
+        // Try next candidate URL.
+      }
+    }
+    throw new Error(`Failed to load portrait asset "${relPath}" from candidates: ${uniqueCandidates.join(', ')}`);
+  })();
+
+  IMG_CACHE.set(relPath, promise);
   return promise;
 }
 


### PR DESCRIPTION
### Motivation
- Portrait rendering sometimes failed with an opaque `[portrait] image load error {}` when pages were served from a different root than the portrait module expected (notably Kenkari cosmetics on Scratchbones-style pages). 
- The intent is to make `loadImg()` resilient to different hosting roots by trying sensible alternate asset bases before giving up.

### Description
- Changed `loadImg(relPath)` to use the relative path as the cache key and try multiple candidate URLs rather than a single base URL. 
- Added automatic fallback logic between `./assets/` and `./docs/assets/` layouts and a final GitHub raw URL candidate. 
- Implemented `ensureTrailingSlash()` and de-duplicated candidate URLs before attempting loads. 
- Improved error reporting to include the failed relative path and the list of attempted candidate URLs.

### Testing
- Ran `node --check docs/js/portrait-utils.js` which succeeded. 
- Executed a config asset scanner script that verifies referenced config URLs resolve to files on disk, which reported zero missing assets. 
- No automated browser rendering tests were available in this environment, so runtime verification in a browser was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78edbb6f48326b6940b135690cdb3)