### PR TITLE
Improve portrait image loading with fallback URLs and add kenkari asset-path test

### DIFF
--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -114,27 +114,47 @@ function setPortraitAssetBase(base) {
 }
 
 function loadImg(relPath) {
-  const url = _puAssetBase + relPath;
-  if (IMG_CACHE.has(url)) return IMG_CACHE.get(url);
-  const promise = new Promise((resolve, reject) => {
+  if (IMG_CACHE.has(relPath)) return IMG_CACHE.get(relPath);
+
+  const ensureTrailingSlash = (base) => String(base || './assets/').replace(/\/?$/, '/');
+  const localBase = ensureTrailingSlash(_puAssetBase);
+  const fallbackBase = localBase.includes('/docs/assets/')
+    ? localBase.replace('/docs/assets/', '/assets/')
+    : localBase.replace('/assets/', '/docs/assets/');
+
+  const candidateUrls = [
+    localBase + relPath,
+    fallbackBase + relPath,
+    'https://raw.githubusercontent.com/Oolnokk/SoKEmpirePrologue/main/docs/assets/' + relPath,
+  ];
+
+  const seen = new Set();
+  const uniqueCandidates = candidateUrls.filter((url) => {
+    if (!url || seen.has(url)) return false;
+    seen.add(url);
+    return true;
+  });
+
+  const tryLoadUrl = (url) => new Promise((resolve, reject) => {
     const img = new Image();
     img.crossOrigin = 'anonymous';
-    img.onload  = () => resolve(img);
-    img.onerror = () => {
-      if (!url.startsWith('https://raw.githubusercontent.com')) {
-        const rawUrl = 'https://raw.githubusercontent.com/Oolnokk/SoKEmpirePrologue/main/docs/assets/' + relPath;
-        const img2 = new Image();
-        img2.crossOrigin = 'anonymous';
-        img2.onload  = () => resolve(img2);
-        img2.onerror = () => reject(new Error('Failed: ' + relPath));
-        img2.src = rawUrl;
-      } else {
-        reject(new Error('Failed: ' + relPath));
-      }
-    };
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(url);
     img.src = url;
   });
-  IMG_CACHE.set(url, promise);
+
+  const promise = (async () => {
+    for (const url of uniqueCandidates) {
+      try {
+        return await tryLoadUrl(url);
+      } catch (_) {
+        // Try next candidate URL.
+      }
+    }
+    throw new Error(`Failed to load portrait asset "${relPath}" from candidates: ${uniqueCandidates.join(', ')}`);
+  })();
+
+  IMG_CACHE.set(relPath, promise);
   return promise;
 }
 

--- a/tests/kenkari-portrait-asset-paths.test.js
+++ b/tests/kenkari-portrait-asset-paths.test.js
@@ -50,11 +50,13 @@ function loadKenkariCosmeticUrls() {
     ok(entryPath, `Missing cosmetics index entry for "${cosmeticId}".`);
     const resolvedPath = path.resolve(COSMETICS_CONFIG_ROOT, entryPath);
     const cosmeticJson = readJson(resolvedPath);
-    const head = cosmeticJson?.parts?.head;
-    if (!head) continue;
-    if (head.image?.url) urls.push(head.image.url);
-    for (const layer of Object.values(head.layers || {})) {
-      if (layer?.image?.url) urls.push(layer.image.url);
+    const parts = cosmeticJson?.parts || {};
+    for (const part of Object.values(parts)) {
+      if (!part || typeof part !== 'object') continue;
+      if (part.image?.url) urls.push(part.image.url);
+      for (const layer of Object.values(part.layers || {})) {
+        if (layer?.image?.url) urls.push(layer.image.url);
+      }
     }
   }
   return urls;

--- a/tests/kenkari-portrait-asset-paths.test.js
+++ b/tests/kenkari-portrait-asset-paths.test.js
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test';
+import { deepStrictEqual, ok } from 'assert';
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+
+const SPECIES_PATH = 'docs/config/species/kenkari.json';
+const COSMETICS_INDEX_PATH = 'docs/config/cosmetics/index.json';
+const COSMETICS_CONFIG_ROOT = 'docs/config/cosmetics/';
+const ASSETS_ROOT = 'docs/assets/';
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function toAssetPath(url) {
+  if (typeof url !== 'string' || !url) return null;
+  if (url.startsWith('./assets/')) return `docs/${url.slice(2)}`;
+  if (url.startsWith('assets/')) return `docs/${url}`;
+  return `${ASSETS_ROOT}${url}`;
+}
+
+function collectPortraitUrlsForGender(genderData) {
+  const urls = [];
+  if (!genderData || typeof genderData !== 'object') return urls;
+  if (genderData.headSprite) urls.push(genderData.headSprite);
+  for (const layer of genderData.headUrLayers || []) {
+    if (layer?.url) urls.push(layer.url);
+  }
+  for (const layer of genderData.portraitBodyLayers || []) {
+    if (layer?.url) urls.push(layer.url);
+  }
+  return urls;
+}
+
+function loadKenkariCosmeticUrls() {
+  const species = readJson(SPECIES_PATH);
+  const index = readJson(COSMETICS_INDEX_PATH);
+  const entriesById = new Map((index.entries || []).map((entry) => [entry.id, entry.path]));
+
+  const cosmeticIds = new Set([
+    ...(species.male?.allowedCosmetics || []),
+    ...(species.female?.allowedCosmetics || []),
+    ...(species.male?.allowedPortraitClothing || []),
+    ...(species.female?.allowedPortraitClothing || []),
+  ]);
+
+  const urls = [];
+  for (const cosmeticId of cosmeticIds) {
+    const entryPath = entriesById.get(cosmeticId);
+    ok(entryPath, `Missing cosmetics index entry for "${cosmeticId}".`);
+    const resolvedPath = path.resolve(COSMETICS_CONFIG_ROOT, entryPath);
+    const cosmeticJson = readJson(resolvedPath);
+    const head = cosmeticJson?.parts?.head;
+    if (!head) continue;
+    if (head.image?.url) urls.push(head.image.url);
+    for (const layer of Object.values(head.layers || {})) {
+      if (layer?.image?.url) urls.push(layer.image.url);
+    }
+  }
+  return urls;
+}
+
+describe('kenkari portrait asset references', () => {
+  it('resolve to existing files used by portrait rendering flow', () => {
+    const species = readJson(SPECIES_PATH);
+    const portraitUrls = [
+      ...collectPortraitUrlsForGender(species.male),
+      ...collectPortraitUrlsForGender(species.female),
+      ...loadKenkariCosmeticUrls(),
+    ];
+
+    const uniqueAssetPaths = [...new Set(portraitUrls.map(toAssetPath).filter(Boolean))];
+    const missing = uniqueAssetPaths.filter((assetPath) => !existsSync(assetPath));
+
+    deepStrictEqual(
+      missing,
+      [],
+      `Kenkari portrait flow references missing assets: ${missing.join(', ')}`
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- Make portrait image loading in the docs more robust by trying alternate asset locations and a GitHub raw fallback when local paths fail.
- Avoid redundant cache entries and ensure consistent cache keys for image promises.
- Add an automated check to ensure kenkari portrait and cosmetic asset references resolve to existing files in `docs/assets`.

### Description

- Revamped `loadImg` in `docs/js/portrait-utils.js` to build a list of `candidateUrls` including the configured asset base, a swapped `/docs/assets/` ↔ `/assets/` fallback, and a GitHub raw CDN fallback, and to try them sequentially until one loads successfully.  
- Normalized the configured asset base with an `ensureTrailingSlash` helper and deduplicated candidate URLs before attempting loads.  
- Changed caching to key by the original `relPath` and introduced a `tryLoadUrl` helper that resolves on `img.onload` and rejects on `img.onerror`, with improved error messaging when all candidates fail.  
- Added a new test `tests/kenkari-portrait-asset-paths.test.js` that reads `docs/config/species/kenkari.json` and `docs/config/cosmetics/index.json`, resolves referenced portrait and cosmetic image URLs to `docs/assets/` paths, and asserts those files exist.

### Testing

- Ran the new asset-path test `tests/kenkari-portrait-asset-paths.test.js` using `node --test` and it passed.  
- The change to `loadImg` was exercised by loading portraits in the docs preview and the image lookup fallbacks behaved as expected in local checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78edbb6f48326b6940b135690cdb3)