### PR TITLE
Include attempted URLs and structured error for portrait image load failures

### DIFF
--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -144,14 +144,20 @@ function loadImg(relPath) {
   });
 
   const promise = (async () => {
+    const attemptedUrls = [];
     for (const url of uniqueCandidates) {
+      attemptedUrls.push(url);
       try {
         return await tryLoadUrl(url);
       } catch (_) {
         // Try next candidate URL.
       }
     }
-    throw new Error(`Failed to load portrait asset "${relPath}" from candidates: ${uniqueCandidates.join(', ')}`);
+    const error = new Error(`Failed to load portrait asset "${relPath}"`);
+    error.name = 'PortraitImageLoadError';
+    error.relPath = relPath;
+    error.attemptedUrls = attemptedUrls;
+    throw error;
   })();
 
   IMG_CACHE.set(relPath, promise);
@@ -309,7 +315,12 @@ async function renderProfile(canvas, profile) {
     );
     imgMap = new Map(entries);
   } catch (err) {
-    console.warn('[portrait] image load error', err);
+    console.warn('[portrait] image load error', {
+      message: err?.message || String(err),
+      name: err?.name || 'Error',
+      relPath: err?.relPath || null,
+      attemptedUrls: Array.isArray(err?.attemptedUrls) ? err.attemptedUrls : [],
+    });
     ctx.fillStyle = '#220000'; ctx.fillRect(0, 0, PORTRAIT_CW, PORTRAIT_CH);
     ctx.fillStyle = '#ff4444'; ctx.font = '11px sans-serif';
     ctx.textAlign = 'center';


### PR DESCRIPTION
### Motivation
- Improve diagnostics for portrait image loading failures by recording which candidate URLs were tried and exposing structured error metadata for better logging and debugging.

### Description
- Collect attempted candidate URLs in `loadImg`, throw an error with `name = 'PortraitImageLoadError'` and attach `relPath` and `attemptedUrls` to the error object, and update the `renderProfile` catch to log a structured warning containing `message`, `name`, `relPath`, and `attemptedUrls` instead of dumping the raw error.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b75312e08326973ad71e7435c263)