### PR TITLE
Improve portrait image load error diagnostics and add cosmetics asset path test

### DIFF
--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -144,14 +144,20 @@ function loadImg(relPath) {
   });
 
   const promise = (async () => {
+    const attemptedUrls = [];
     for (const url of uniqueCandidates) {
+      attemptedUrls.push(url);
       try {
         return await tryLoadUrl(url);
       } catch (_) {
         // Try next candidate URL.
       }
     }
-    throw new Error(`Failed to load portrait asset "${relPath}" from candidates: ${uniqueCandidates.join(', ')}`);
+    const error = new Error(`Failed to load portrait asset "${relPath}"`);
+    error.name = 'PortraitImageLoadError';
+    error.relPath = relPath;
+    error.attemptedUrls = attemptedUrls;
+    throw error;
   })();
 
   IMG_CACHE.set(relPath, promise);
@@ -309,7 +315,12 @@ async function renderProfile(canvas, profile) {
     );
     imgMap = new Map(entries);
   } catch (err) {
-    console.warn('[portrait] image load error', err);
+    console.warn('[portrait] image load error', {
+      message: err?.message || String(err),
+      name: err?.name || 'Error',
+      relPath: err?.relPath || null,
+      attemptedUrls: Array.isArray(err?.attemptedUrls) ? err.attemptedUrls : [],
+    });
     ctx.fillStyle = '#220000'; ctx.fillRect(0, 0, PORTRAIT_CW, PORTRAIT_CH);
     ctx.fillStyle = '#ff4444'; ctx.font = '11px sans-serif';
     ctx.textAlign = 'center';

--- a/tests/cosmetics-asset-paths.test.js
+++ b/tests/cosmetics-asset-paths.test.js
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import { deepStrictEqual } from 'assert';
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+
+const COSMETICS_INDEX_PATH = 'docs/config/cosmetics/index.json';
+const COSMETICS_CONFIG_ROOT = 'docs/config/cosmetics/';
+const ASSETS_ROOT = 'docs/assets/';
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function toAssetPath(url) {
+  if (typeof url !== 'string' || !url) return null;
+  if (url.startsWith('./assets/')) return `docs/${url.slice(2)}`;
+  if (url.startsWith('assets/')) return `docs/${url}`;
+  if (/^(https?:)?\/\//.test(url) || url.startsWith('data:')) return null;
+  return `${ASSETS_ROOT}${url}`;
+}
+
+function collectImageUrls(value, out = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectImageUrls(item, out);
+    return out;
+  }
+  if (!value || typeof value !== 'object') return out;
+  if (value.image && typeof value.image.url === 'string') out.push(value.image.url);
+  for (const child of Object.values(value)) collectImageUrls(child, out);
+  return out;
+}
+
+describe('cosmetics config asset paths', () => {
+  it('index entries resolve and every cosmetic image url exists', () => {
+    const index = readJson(COSMETICS_INDEX_PATH);
+    const missing = [];
+
+    for (const entry of index.entries || []) {
+      const configPath = path.resolve(COSMETICS_CONFIG_ROOT, entry.path);
+      if (!existsSync(configPath)) {
+        missing.push(`missing cosmetic config: id=${entry.id} path=${entry.path}`);
+        continue;
+      }
+
+      const cosmeticJson = readJson(configPath);
+      const imageUrls = collectImageUrls(cosmeticJson);
+      for (const url of imageUrls) {
+        const assetPath = toAssetPath(url);
+        if (!assetPath) continue;
+        if (!existsSync(assetPath)) {
+          missing.push(
+            `missing cosmetic asset: id=${entry.id} config=${entry.path} url=${url} resolved=${assetPath}`
+          );
+        }
+      }
+    }
+
+    deepStrictEqual(missing, []);
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve diagnostics when portrait image loading fails so callers can inspect which URLs were tried and why the load failed.
- Add an automated check to ensure cosmetics configs reference existing image assets in `docs/assets/` to catch missing files early.

### Description
- In `docs/js/portrait-utils.js` capture attempted candidate URLs and throw an enriched `Error` (with `name = 'PortraitImageLoadError'`, `relPath`, and `attemptedUrls`) when `loadImg` cannot load any candidate.
- Update the error logging in `renderProfile` to emit a structured object containing `message`, `name`, `relPath`, and `attemptedUrls` for clearer console diagnostics.
- Add `tests/cosmetics-asset-paths.test.js`, a Node test that reads `docs/config/cosmetics/index.json`, resolves each cosmetic config, collects referenced image URLs, and asserts that each local asset exists under `docs/assets/`.

### Testing
- Ran the new unit test `tests/cosmetics-asset-paths.test.js` with Node's test runner using `node --test tests/cosmetics-asset-paths.test.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b75312e08326973ad71e7435c263)