### PR TITLE
Constrain portrait hat colors by material palette and keep species rules cloth-only

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -225,6 +225,26 @@ const MATERIALS = {
 };
 window.CONFIG = window.CONFIG || {};
 window.CONFIG.materials = MATERIALS;
+window.CONFIG.cosmeticMaterialPalettes = {
+  reed: {
+    minH: 26,
+    maxH: 58,
+    stops: [
+      { h: 26, sMin: 0.12, sMax: 0.42, vMin: -0.42, vMax: 0.06 },
+      { h: 42, sMin: 0.10, sMax: 0.38, vMin: -0.38, vMax: 0.10 },
+      { h: 58, sMin: 0.08, sMax: 0.34, vMin: -0.32, vMax: 0.16 }
+    ]
+  },
+  wood: {
+    minH: 12,
+    maxH: 42,
+    stops: [
+      { h: 12, sMin: 0.20, sMax: 0.48, vMin: -0.52, vMax: 0.02 },
+      { h: 26, sMin: 0.16, sMax: 0.42, vMin: -0.46, vMax: 0.08 },
+      { h: 42, sMin: 0.10, sMax: 0.34, vMin: -0.40, vMax: 0.14 }
+    ]
+  }
+};
 
 const abilityKnockback = window.abilityKnockback || ((base, { clamp } = {}) => {
   return (context, opponent) => {

--- a/docs/config/cosmetics/riverlandskasa_low.json
+++ b/docs/config/cosmetics/riverlandskasa_low.json
@@ -1,5 +1,6 @@
 {
   "slot": "hat",
+  "tags": ["material:reed"],
   "colorRange": {
     "minH": -100,
     "maxH":  -45,

--- a/docs/config/cosmetics/riverlandskasa_tight.json
+++ b/docs/config/cosmetics/riverlandskasa_tight.json
@@ -1,5 +1,6 @@
 {
   "slot": "hat",
+  "tags": ["material:reed"],
   "colorRange": {
     "minH": -100,
     "maxH":  -45,

--- a/docs/config/cosmetics/riverlandskasa_wide.json
+++ b/docs/config/cosmetics/riverlandskasa_wide.json
@@ -1,5 +1,6 @@
 {
   "slot": "hat",
+  "tags": ["material:reed"],
   "colorRange": {
     "minH": -100,
     "maxH":  -45,

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -450,13 +450,20 @@ function portraitOptionFromJson(entry, json) {
   }
 
   const colorRange = json.colorRange || null;
+  const tags = Array.isArray(json.tags) ? json.tags : [];
+  const materialTag = (typeof json.material === 'string' && json.material.trim())
+    ? json.material.trim().toLowerCase()
+    : (tags.find(tag => typeof tag === 'string' && tag.toLowerCase().startsWith('material:')) || '')
+      .split(':')[1]
+      ?.trim()
+      ?.toLowerCase()
+      || null;
   const resolvedTintSlot = json.slot === 'hat' && colorRange ? 'HAT'
                          : !json.appearance && colorRange ? 'CLOTH'
                          : !json.appearance && json.tintSlot != null ? json.tintSlot
                          : tintSlot;
   const hairSlot = json.hairSlot || null; // 'front' | 'back' | 'side'
-  const tags = Array.isArray(json.tags) ? json.tags : [];
-  return { id: shortId, label, tintSlot: resolvedTintSlot, layers, slot: json.slot || null, colorRange, hairSlot, tags };
+  return { id: shortId, label, tintSlot: resolvedTintSlot, layers, slot: json.slot || null, colorRange, hairSlot, tags, materialTag };
 }
 
 /**
@@ -683,6 +690,14 @@ function randomInRange(rng, lo, hi) {
   return lo + rng() * (hi - lo);
 }
 
+function materialColorRangeFor(option) {
+  const materialTag = option?.materialTag;
+  if (!materialTag) return null;
+  const materialPalettes = window.CONFIG?.cosmeticMaterialPalettes;
+  if (!materialPalettes || typeof materialPalettes !== 'object') return null;
+  return materialPalettes[materialTag] || null;
+}
+
 function applyBodyColorRulesSeeded(bodyColors, rules, rng) {
   if (!bodyColors || !rules || typeof rules !== 'object') return bodyColors;
   const result = {
@@ -891,16 +906,16 @@ function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, h
   bodyColors = applyBodyColorRulesSeeded(bodyColors, randomizationRules, rng);
 
   const clothingRule = randomizationRules?.clothingColors;
-  const hasClothPiece = Boolean(torsoCosmetic?.colorRange || armCosmetic?.colorRange);
+  const hasClothPiece = Boolean(torsoCosmetic?.layers?.length || armCosmetic?.layers?.length);
   const syncAcrossPieces = clothingRule?.syncAcrossPieces === true;
   const ruleRange = clothingRule?.range || null;
   const clothSourceRange = ruleRange || torsoCosmetic?.colorRange || armCosmetic?.colorRange || null;
-  const hatSourceRange = ruleRange || hat?.colorRange || null;
+  const hatSourceRange = materialColorRangeFor(hat) || hat?.colorRange || null;
 
   if (hasClothPiece && clothSourceRange) {
     bodyColors.CLOTH = randomColorFromRangeSeeded(clothSourceRange, rng);
   }
-  if (hat?.colorRange && hatSourceRange) {
+  if (hatSourceRange) {
     bodyColors.HAT = (syncAcrossPieces && bodyColors.CLOTH)
       ? bodyColors.CLOTH
       : randomColorFromRangeSeeded(hatSourceRange, rng);

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -910,13 +910,14 @@ function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, h
   const syncAcrossPieces = clothingRule?.syncAcrossPieces === true;
   const ruleRange = clothingRule?.range || null;
   const clothSourceRange = ruleRange || torsoCosmetic?.colorRange || armCosmetic?.colorRange || null;
-  const hatSourceRange = materialColorRangeFor(hat) || hat?.colorRange || null;
+  const hatMaterialRange = materialColorRangeFor(hat);
+  const hatSourceRange = hatMaterialRange || hat?.colorRange || null;
 
   if (hasClothPiece && clothSourceRange) {
     bodyColors.CLOTH = randomColorFromRangeSeeded(clothSourceRange, rng);
   }
   if (hatSourceRange) {
-    bodyColors.HAT = (syncAcrossPieces && bodyColors.CLOTH)
+    bodyColors.HAT = (syncAcrossPieces && bodyColors.CLOTH && !hatMaterialRange)
       ? bodyColors.CLOTH
       : randomColorFromRangeSeeded(hatSourceRange, rng);
   }


### PR DESCRIPTION
### Motivation
- Portrait generation was allowing species-level `clothingColors` rules to influence hat hues, producing out-of-family colors (e.g. hot-pink kasa); hats should respect material palettes while species clothing rules should target cloth only.
- Make material palettes configurable and move hardcoded material limits into `config.js` so material color constraints are data-driven and editable.

### Description
- Added `window.CONFIG.cosmeticMaterialPalettes` to `docs/config/config.js` with initial `reed` and `wood` HSV stop ranges so material palettes are config-driven and not hardcoded in portrait logic.
- Extended `portraitOptionFromJson` in `docs/js/portrait-utils.js` to extract a `materialTag` from `json.material` or `json.tags` (e.g. `"material:reed"`).
- Added `materialColorRangeFor(option)` and changed hat color resolution so hat tint ranges are derived from material palettes first, then fall back to the cosmetic `colorRange` if present.
- Scoped species `randomizationRules.clothingColors.range` to produce `bodyColors.CLOTH` only, and adjusted the cloth-presence detection to check for clothing layers rather than just `colorRange`.
- Tagged the riverlands kasa cosmetics (`riverlandskasa_low|tight|wide.json`) with `"material:reed"` so they resolve through the reed palette and avoid cloth-based random hues.

### Testing
- Ran linting with `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7bec01c708326830fe9bfda0b03af)