### PR TITLE
Kenkari: explicitly force female `eyes` to `none` after eyedisks removal

### DIFF
--- a/docs/config/species/kenkari.json
+++ b/docs/config/species/kenkari.json
@@ -272,6 +272,7 @@
       "tankanwrap_kenk_f"
     ],
     "forcedCosmetics": {
+      "eyes": "none"
     },
     "conditionalCosmetics": [
       {


### PR DESCRIPTION
### Motivation
- Removing the male-only `kenk_eyedisks` cosmetic left the female Kenkari portrait pipeline in an ambiguous state where the randomiser/forced-selection could still attempt to resolve a removed eye cosmetic, so the intent needs to be made explicit in the species config.

### Description
- Add `"eyes": "none"` to the `female.forcedCosmetics` block in `docs/config/species/kenkari.json` so the female Kenkari explicitly forces the `eyes` slot to `none` while keeping `headUrLayers` unchanged.

### Testing
- Validated the change by parsing the modified JSON with `node -e "const fs=require('fs');const d=JSON.parse(fs.readFileSync('docs/config/species/kenkari.json','utf8')); console.log(d.female.forcedCosmetics.eyes);"` which printed `none`, and confirmed UR head overlay and the eyedisks asset paths exist with `test -f docs/assets/fightersprites/kenkari-f/untinted_regions/ur-head.png` and `test -f docs/config/cosmetics/appearance/kenkari/kenk_m_eyedisks.png`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c1b27ea083268609a3a218f7a0ee)