### PR TITLE
Normalize portrait head transforms to fix missing kenkari female heads

### DIFF
--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -73,6 +73,7 @@ function normalizedFighterPortrait(fighter) {
   if (!fighter || typeof fighter !== 'object') return fighter;
   return {
     ...fighter,
+    headXform: normalizePortraitLayerXform(fighter.headXform),
     bodyLayers: Array.isArray(fighter.bodyLayers)
       ? fighter.bodyLayers.map(normalizePortraitLayerXform)
       : fighter.bodyLayers,
@@ -590,7 +591,7 @@ async function loadPortraitCosmetics(configBase) {
             bodyColorRangesByGender[fighter.id] = genderData.bodyColorRanges;
             fighterPortraitOverrides[fighter.id] = {
               ...(fighterPortraitOverrides[fighter.id] || {}),
-              ...(genderData.headXform ? { headXform: genderData.headXform } : {}),
+              ...(genderData.headXform ? { headXform: normalizePortraitLayerXform(genderData.headXform) } : {}),
               ...(Array.isArray(genderData.portraitBodyLayers) ? {
                 bodyLayers: genderData.portraitBodyLayers.map(normalizePortraitLayerXform)
               } : {}),


### PR DESCRIPTION
### Motivation
- Species JSON sometimes provides head transform fields using `scaleX/scaleY` (or `xform` variants) while the portrait renderer expects canonical `ax/ay/sx/sy`, which caused some species (notably kenkari female) to render head layers with incorrect sizing or not appear.
- The pipeline created fighter objects but later applied raw species `headXform` overrides without normalization, allowing regressions after initial normalization.

### Description
- Ensure every fighter's `headXform` is normalized by calling `normalizePortraitLayerXform` inside `normalizedFighterPortrait` so `headXform` always has `ax`, `ay`, `sx`, and `sy`.
- Normalize species-provided `headXform` when building `fighterPortraitOverrides` by applying `normalizePortraitLayerXform` before merging overrides.
- Change made in `docs/js/portrait-utils.js` to close the normalization gap in the portrait pipeline.

### Testing
- Ran `node --test tests/kenkari-portrait-asset-paths.test.js` and the test suite for the kenkari portrait asset references passed (all tests green).
- Ran `npx eslint --no-ignore docs/js/portrait-utils.js` for lint verification and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e4131c508326999e49e326752532)