### PR TITLE
Only apply relative conversion to portrait layers with explicit xform

### DIFF
--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -69,9 +69,25 @@ function normalizePortraitMaskLayer(maskLayer) {
   return normalizePortraitLayerXform(maskLayer);
 }
 
+function hasExplicitPortraitLayerXform(layer) {
+  if (!layer || typeof layer !== 'object') return false;
+  const xform = (layer.xform && typeof layer.xform === 'object') ? layer.xform : null;
+  return (
+    layer.ax != null || layer.ay != null || layer.sx != null || layer.sy != null ||
+    layer.x != null || layer.y != null ||
+    layer.scaleX != null || layer.scaleY != null ||
+    layer.scaleMulX != null || layer.scaleMulY != null ||
+    xform?.ax != null || xform?.ay != null || xform?.sx != null || xform?.sy != null ||
+    xform?.x != null || xform?.y != null ||
+    xform?.scaleX != null || xform?.scaleY != null ||
+    xform?.scaleMulX != null || xform?.scaleMulY != null
+  );
+}
+
 function toRelativePortraitLayerXform(layer, parentXform) {
   const normalizedLayer = normalizePortraitLayerXform(layer);
   if (!normalizedLayer || typeof normalizedLayer !== 'object') return normalizedLayer;
+  if (!hasExplicitPortraitLayerXform(layer)) return normalizedLayer;
   const base = normalizePortraitLayerXform(parentXform) || { ax: 0, ay: 0, sx: 1, sy: 1 };
   const baseSx = Number(base.sx) || 1;
   const baseSy = Number(base.sy) || 1;


### PR DESCRIPTION
### Motivation
- Species and override portrait layer data sometimes omit per-layer transform fields and intentionally rely on implicit identity; normalizing missing values then converting to parent space produced inverse head transforms that made layers collapse toward identity when composed with the head.
- The conversion in `toRelativePortraitLayerXform` should therefore only run when a layer actually declares absolute transform fields to avoid regressing species/override and default body layers.

### Description
- Add `hasExplicitPortraitLayerXform(layer)` to detect whether a layer contains any explicit transform fields or nested `xform` aliases (checks `ax/ay/sx/sy`, `x/y`, `scale*`, and nested `xform` variants).
- Update `toRelativePortraitLayerXform(layer, parentXform)` to return the normalized layer unchanged when no explicit transform fields are present, and only perform parent subtraction/division when explicit fields exist.
- Preserve existing normalization logic via `normalizePortraitLayerXform` and existing relative-conversion behavior for layers that do declare transforms.
- Change implemented in `docs/js/portrait-utils.js`.

### Testing
- Ran `node --check docs/js/portrait-utils.js` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e812a1a41883268012d54f5bfc42fc)