### PR TITLE
Add configurable per-hat hide rules for portrait hair and facial hair

### DIFF
--- a/docs/config/species/kenkari.json
+++ b/docs/config/species/kenkari.json
@@ -212,6 +212,29 @@
           "max": 0.33
         }
       },
+      "hatHideRules": {
+        "basic_headband": {
+          "hideSlots": []
+        },
+        "riverlandskasa_low": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_tight": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_wide": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        }
+      },
       "clothingColors": {
         "syncAcrossPieces": false,
         "range": {
@@ -440,6 +463,29 @@
       }
     },
     "randomizationRules": {
+      "hatHideRules": {
+        "basic_headband": {
+          "hideSlots": []
+        },
+        "riverlandskasa_low": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_tight": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_wide": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        }
+      },
       "clothingColors": {
         "syncAcrossPieces": false,
         "range": {

--- a/docs/config/species/mao-ao.json
+++ b/docs/config/species/mao-ao.json
@@ -206,6 +206,29 @@
       }
     },
     "randomizationRules": {
+      "hatHideRules": {
+        "basic_headband": {
+          "hideSlots": []
+        },
+        "riverlandskasa_low": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_tight": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_wide": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        }
+      },
       "clothingColors": {
         "syncAcrossPieces": false,
         "range": {
@@ -468,6 +491,29 @@
       }
     },
     "randomizationRules": {
+      "hatHideRules": {
+        "basic_headband": {
+          "hideSlots": []
+        },
+        "riverlandskasa_low": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_tight": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_wide": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        }
+      },
       "clothingColors": {
         "syncAcrossPieces": false,
         "range": {

--- a/docs/config/species/tletingan.json
+++ b/docs/config/species/tletingan.json
@@ -202,6 +202,29 @@
       }
     },
     "randomizationRules": {
+      "hatHideRules": {
+        "basic_headband": {
+          "hideSlots": []
+        },
+        "riverlandskasa_low": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_tight": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        },
+        "riverlandskasa_wide": {
+          "hideSlots": [
+            "hairFront",
+            "hairBack"
+          ]
+        }
+      },
       "clothingColors": {
         "syncAcrossPieces": true,
         "range": {

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -732,6 +732,11 @@ function applyBodyColorRulesSeeded(bodyColors, rules, rng) {
  *     "hairBack":  { "none": 50, "long_ponytail": 25, "splayedknot_medium": 25 },
  *     "hairSide":  { "none": 90, "shoulder_length_drape": 10 }
  *   }
+ * Optional per-hat occlusion can be configured under "randomizationRules.hatHideRules":
+ *   "hatHideRules": {
+ *     "riverlandskasa_low": { "hideSlots": ["hairFront", "hairBack"] },
+ *     "basic_headband": { "hideSlots": [] }
+ *   }
  * Unspecified categories use uniform random. Cosmetics missing from a weight map default to weight 1.
  * Weight 0 excludes an item from selection entirely.
  */
@@ -767,6 +772,30 @@ function resolvePortraitFighter(fighter) {
     ? FIGHTERS.find((candidate) => candidate?.headUrl === fighter.headUrl)
     : null;
   return byHead || fighter;
+}
+
+function noneOptionForSlot(options, fallbackLabel) {
+  return options.find((option) => option?.id === 'none')
+    ?? options[0]
+    ?? { id: 'none', label: fallbackLabel, tintSlot: null, layers: [] };
+}
+
+function toHiddenSlotSet(rule) {
+  if (!rule) return null;
+  if (Array.isArray(rule.hideSlots)) {
+    return new Set(rule.hideSlots.filter((slot) => typeof slot === 'string'));
+  }
+  if (Array.isArray(rule)) {
+    return new Set(rule.filter((slot) => typeof slot === 'string'));
+  }
+  return null;
+}
+
+function hatHideRuleFor(hatId, randomizationRules) {
+  if (!hatId || hatId === 'none') return null;
+  const map = randomizationRules?.hatHideRules;
+  if (!map || typeof map !== 'object') return null;
+  return map[hatId] || null;
 }
 
 /**
@@ -902,6 +931,22 @@ function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, h
 
   const ruleMap = randomizationRulesByFighter || LAST_RANDOMIZATION_RULES_BY_FIGHTER || null;
   const randomizationRules = ruleMap?.[fighter.id] ?? ruleMap?.[fighterInput?.id] ?? null;
+  const hatHideSlots = toHiddenSlotSet(hatHideRuleFor(hat?.id, randomizationRules));
+  if (hatHideSlots?.size) {
+    if (hatHideSlots.has('hairFront')) {
+      hairFront = noneOptionForSlot(filteredHairFront, 'No Front Hair');
+    }
+    if (hatHideSlots.has('hairBack')) {
+      hairBack = noneOptionForSlot(filteredHairBack, 'No Back Hair');
+    }
+    if (hatHideSlots.has('hairSide')) {
+      hairSide = noneOptionForSlot(filteredHairSide, 'No Side Hair');
+    }
+    if (hatHideSlots.has('facialHair')) {
+      facialHair = noneOptionForSlot(filteredFacialHair, 'No Facial Hair');
+    }
+  }
+
   let bodyColors = randomBodyColorsSeeded(rng, bodyColorRangesByGender?.[fighter.id] ?? bodyColorRangesByGender?.[fighterInput?.id]);
   bodyColors = applyBodyColorRulesSeeded(bodyColors, randomizationRules, rng);
 

--- a/tests/hat-hide-rules.test.js
+++ b/tests/hat-hide-rules.test.js
@@ -1,0 +1,44 @@
+import { strictEqual, ok } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+describe('hat hide slot rules', () => {
+  it('portrait randomization applies hatHideRules to front/back/side/facial hair slots', () => {
+    const content = readFileSync('docs/js/portrait-utils.js', 'utf8');
+
+    ok(/randomizationRules\?\.hatHideRules/.test(content), 'randomization should read hatHideRules from species randomizationRules');
+    ok(/hatHideSlots\.has\('hairFront'\)/.test(content), 'hairFront should support hat-based hiding');
+    ok(/hatHideSlots\.has\('hairBack'\)/.test(content), 'hairBack should support hat-based hiding');
+    ok(/hatHideSlots\.has\('hairSide'\)/.test(content), 'hairSide should support hat-based hiding');
+    ok(/hatHideSlots\.has\('facialHair'\)/.test(content), 'facialHair should support hat-based hiding');
+  });
+
+  it('species rules define kasa hats hiding front/back hair while headband hides nothing', () => {
+    const speciesFiles = [
+      'docs/config/species/mao-ao.json',
+      'docs/config/species/kenkari.json',
+      'docs/config/species/tletingan.json'
+    ];
+
+    for (const speciesPath of speciesFiles) {
+      const data = JSON.parse(readFileSync(speciesPath, 'utf8'));
+      for (const genderKey of ['male', 'female']) {
+        const randomizationRules = data?.[genderKey]?.randomizationRules;
+        if (!randomizationRules) continue;
+        const hatHideRules = randomizationRules.hatHideRules;
+        ok(hatHideRules, `${speciesPath} ${genderKey} should include randomizationRules.hatHideRules`);
+
+        strictEqual(Array.isArray(hatHideRules.basic_headband?.hideSlots), true, `${speciesPath} ${genderKey} basic_headband should define hideSlots`);
+        strictEqual(hatHideRules.basic_headband.hideSlots.length, 0, `${speciesPath} ${genderKey} basic_headband should hide nothing`);
+
+        for (const hatId of ['riverlandskasa_low', 'riverlandskasa_tight', 'riverlandskasa_wide']) {
+          const hideSlots = hatHideRules[hatId]?.hideSlots || [];
+          ok(hideSlots.includes('hairFront'), `${speciesPath} ${genderKey} ${hatId} should hide hairFront`);
+          ok(hideSlots.includes('hairBack'), `${speciesPath} ${genderKey} ${hatId} should hide hairBack`);
+          strictEqual(hideSlots.includes('hairSide'), false, `${speciesPath} ${genderKey} ${hatId} should not hide hairSide`);
+          strictEqual(hideSlots.includes('facialHair'), false, `${speciesPath} ${genderKey} ${hatId} should not hide facialHair by default`);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Allow hats to control occlusion of portrait hair and facial hair independently so different hat types (e.g., kasas vs headbands) can hide front/back/side hair or facial hair as required. 
- Keep hair-hiding behavior data-driven so new hats that should hide facial hair can be supported without code changes.

### Description
- Added small helper functions in `docs/js/portrait-utils.js`: `noneOptionForSlot`, `toHiddenSlotSet`, and `hatHideRuleFor`, and documented the `randomizationRules.hatHideRules` config option in the header comment. 
- Integrated per-hat hide logic into `randomProfileSeeded(...)` so the chosen hat can force `hairFront`, `hairBack`, `hairSide`, and/or `facialHair` to the `none` option when configured. 
- Added `randomizationRules.hatHideRules` entries to `docs/config/species/mao-ao.json`, `docs/config/species/kenkari.json`, and `docs/config/species/tletingan.json` so the various `riverlandskasa_*` kasas hide `hairFront` and `hairBack` while `basic_headband` hides nothing. 
- Added `tests/hat-hide-rules.test.js` to verify both runtime support for the four hideable slots and that the species configs implement the kasa/headband rules.

### Testing
- Ran the new unit check with `node --test tests/hat-hide-rules.test.js` and it passed. 
- Ran lint with `npm run lint` and it passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e900c909e88326b9aabf9c16123507)