### PR TITLE
Fix Kenkari NPCs falling back to Mao-ao names

### DIFF
--- a/docs/NPC_GROUP_SPAWNER.md
+++ b/docs/NPC_GROUP_SPAWNER.md
@@ -5,7 +5,7 @@ A comprehensive system for spawning groups of NPCs with procedurally generated n
 ## Features
 
 - ✅ **Group-based NPC spawning** from spawn points with group metadata
-- ✅ **Procedural name generation** using the Mao-ao culture naming system
+- ✅ **Procedural name generation** using culture-specific naming systems (Mao-ao + Kenkari)
 - ✅ **Deterministic generation** - same spawner always produces same names
 - ✅ **Family relationships** - support for inherited surnames and marriage rules
 - ✅ **Debug controls** - toggle logging for names, patterns, and generation steps
@@ -22,7 +22,7 @@ A comprehensive system for spawning groups of NPCs with procedurally generated n
   - `generateNpcName(options)` - Generate a single name
 
 - **`docs/js/namegen.js`** - Name generation engine
-  - Mao-ao culture implementation with syllable patterns
+  - Mao-ao and Kenkari culture implementations
   - Birth rules (surname inheritance, initial matching)
   - Marriage rules (surname adoption, initial prefixing)
 
@@ -142,8 +142,8 @@ const spawners = [
 
 Names are automatically generated based on the fighter's culture and gender, which are encoded in the fighter name using suffixes:
 
-- **`_m`** = Male (e.g., `Mao-ao_m`)
-- **`_f`** = Female (e.g., `Mao-ao_f`)
+- **`_m` / `_male`** = Male (e.g., `Mao-ao_m`, `Kenkari_male`)
+- **`_f` / `_female`** = Female (e.g., `Mao-ao_f`, `Kenkari_female`)
 
 The prefix determines the culture (e.g., `Mao-ao` → `mao_ao` culture).
 
@@ -208,6 +208,10 @@ window.CONFIG.characterTemplates = {
 
 **Female:**
 - A'eynga Kayao (married to a K-named husband)
+
+### Kenkari Culture Rules
+
+Kenkari names use dedicated phonology and patronymic surname rules implemented in `namegen.js` (for example, `Kenkari_m` / `Kenkari_f` resolve to the `kenkari` culture).
 - Oshinga Oshim
 - E'ira Hoshey
 

--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -1552,6 +1552,16 @@ window.CONFIG = {
       minProgress: 4,
       minDistance: 18
     },
+    nameGeneration: {
+      defaultCultureId: 'mao_ao',
+      cultureAliases: {
+        mao_ao: 'mao_ao',
+        'mao-ao': 'mao_ao',
+        kenkari: 'kenkari',
+        'kenkari_m': 'kenkari',
+        'kenkari_f': 'kenkari'
+      }
+    },
     schedule: {
       // POI names to use when NPCs are off-duty (only used if their main schedule has no matches).
       // Example: ['idle', 'barracks']

--- a/docs/js/npc-group-spawner.js
+++ b/docs/js/npc-group-spawner.js
@@ -109,8 +109,8 @@ function parseFighterName(fighterName) {
     return { culture: null, gender: null };
   }
 
-  // Check for _m (male) or _f (female) suffix
-  const genderMatch = fighterName.match(/^(.+?)_([mf])$/i);
+  // Check for _m/_male (male) or _f/_female (female) suffix
+  const genderMatch = fighterName.match(/^(.+?)_(m|f|male|female)$/i);
   if (!genderMatch) {
     return { culture: null, gender: null };
   }
@@ -120,9 +120,17 @@ function parseFighterName(fighterName) {
 
   // Normalize culture name (e.g., "Mao-ao" → "mao_ao")
   const cultureName = culturePart.toLowerCase().replace(/-/g, '_');
-  const gender = genderPart === 'm' ? 'male' : 'female';
+  const gender = genderPart === 'm' || genderPart === 'male' ? 'male' : 'female';
 
   return { culture: cultureName, gender };
+}
+
+function resolveDefaultCultureId() {
+  return ROOT.CONFIG?.npc?.nameGeneration?.defaultCultureId || 'mao_ao';
+}
+
+function resolveCultureAliasMap() {
+  return ROOT.CONFIG?.npc?.nameGeneration?.cultureAliases || {};
 }
 
 /**
@@ -132,16 +140,20 @@ function parseFighterName(fighterName) {
 function resolveCulture(fighterName, groupMeta, member) {
   // Try to parse from fighter name first (e.g., "Mao-ao_m" → "mao_ao")
   const parsed = parseFighterName(fighterName);
-  const cultureName = parsed.culture
+  const aliasMap = resolveCultureAliasMap();
+  const configuredDefaultCultureId = resolveDefaultCultureId();
+  const rawCultureName = parsed.culture
     || member?.culture
     || groupMeta?.culture
     || groupMeta?.meta?.culture
-    || 'mao_ao';
+    || configuredDefaultCultureId;
+  const cultureName = aliasMap[rawCultureName] || rawCultureName;
 
   const culture = CULTURES[cultureName];
   if (!culture) {
-    debugLog(`Culture "${cultureName}" not found, falling back to mao_ao`);
-    return CULTURES.mao_ao;
+    const fallbackCulture = CULTURES[configuredDefaultCultureId] || CULTURES.mao_ao;
+    debugLog(`Culture "${cultureName}" not found, falling back to ${fallbackCulture?.id || 'mao_ao'}`);
+    return fallbackCulture;
   }
   return culture;
 }
@@ -188,7 +200,8 @@ function resolveGender(fighterName, member, templateResult, rng) {
  * @returns {object} Generated name result with {name, parts, seed, debug?}
  */
 export function generateNpcName(options = {}) {
-  const culture = CULTURES[options.culture] || CULTURES.mao_ao;
+  const configuredDefaultCultureId = resolveDefaultCultureId();
+  const culture = CULTURES[options.culture] || CULTURES[configuredDefaultCultureId] || CULTURES.mao_ao;
 
   const nameResult = generateName(culture, {
     gender: options.gender || 'male',


### PR DESCRIPTION
### Motivation
- Kenkari NPCs were ending up with Mao-ao names when culture parsing failed or when culture identifiers used alternate forms, due to hardcoded fallback and limited suffix parsing.
- Make culture resolution configurable and robust so additional cultures (like `kenkari`) resolve deterministically instead of falling back to `mao_ao`.

### Description
- Extended `parseFighterName` in `docs/js/npc-group-spawner.js` to accept `_m`/`_f` and `_male`/`_female` suffixes and normalize culture tokens (e.g., `Mao-ao` → `mao_ao`).
- Added `resolveDefaultCultureId` and `resolveCultureAliasMap` helpers and updated `resolveCulture` to consult `CONFIG.npc.nameGeneration.cultureAliases` and a configurable default before falling back to a culture implementation.
- Updated `generateNpcName` to prefer the configured default culture id when `options.culture` is not provided.
- Added `CONFIG.npc.nameGeneration` (defaultCultureId + cultureAliases) to `docs/config/config.js` and refreshed `docs/NPC_GROUP_SPAWNER.md` to document Mao-ao + Kenkari support and the expanded suffix parsing.

### Testing
- Ran `npm run lint` and it completed successfully (no lint errors).
- Ran `npm run test:unit` which exercised the test suite; the suite fails due to pre-existing unrelated test failures in the repository and not caused by these changes (unit tests report multiple unrelated failures).
- Manual/spot checks: spawned names via the NPC spawner flow to confirm that `kenkari` identifiers now resolve to the `kenkari` culture and that `_male`/`_female` suffixes parse as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e905387e14832684c8f0122a495dea)