### PR TITLE
Follow-up: wire claim-avatar overlay visualFit fields through layout policy

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -4020,6 +4020,11 @@
       const claimAvatarContainerScale = clampNumber(Number(tableVisualFit.claimAvatarContainerScale) || 1.25, 0.75, 2.25);
       const claimAvatarContentScale = clampNumber(Number(tableVisualFit.claimAvatarContentScale) || 0.8, 0.45, 1);
       const avatarAdditiveZoomScale = clampNumber(Number(tableVisualFit.avatarAdditiveZoomScale) || 1.2, 0.8, 1.6);
+      const claimAvatarOverlayMatchSpotlightSize = tableVisualFit.claimAvatarOverlayMatchSpotlightSize !== false;
+      const claimAvatarOverlayZIndex = Math.max(1, Math.round(Number(tableVisualFit.claimAvatarOverlayZIndex) || 9990));
+      const claimAvatarOverlayBorderRadiusPx = clampNumber(Number(tableVisualFit.claimAvatarOverlayBorderRadiusPx) || 12, 0, 48);
+      const claimAvatarOverlayBorderColor = String(tableVisualFit.claimAvatarOverlayBorderColor || 'rgba(242,208,143,0.28)');
+      const claimAvatarOverlayBackground = String(tableVisualFit.claimAvatarOverlayBackground || 'rgba(22,16,14,0.72)');
       const tabletopImageSrcRaw = String(backgroundLayout.tabletopImageSrc || '').trim();
       const tabletopImageSrc = tabletopImageSrcRaw.replace(/["\\]/g, '');
       const flameXPct = clampNumber(numberOrDefault(flameLighting.xPct, 0.5), 0, 1);
@@ -4149,6 +4154,11 @@
             claimAvatarContainerScale,
             claimAvatarContentScale,
             avatarAdditiveZoomScale,
+            claimAvatarOverlayMatchSpotlightSize,
+            claimAvatarOverlayZIndex,
+            claimAvatarOverlayBorderRadiusPx,
+            claimAvatarOverlayBorderColor,
+            claimAvatarOverlayBackground,
           },
           cinematicEnabled,
         },


### PR DESCRIPTION
### Motivation

- Ensure runtime overlay styling and sizing honors configured layout values for claim-cluster avatars instead of always using hardcoded defaults.
- Fix a high-priority mismatch where `moveAvatarFloatsToOverlay` reads overlay options from `layoutPolicy.tableView.visualFit` but `applyLayoutContract` did not return those fields.

### Description

- Added normalization/defaulting for new visual-fit overlay fields in `applyLayoutContract` inside `ScratchbonesBluffGame.html`, including `claimAvatarOverlayMatchSpotlightSize`, `claimAvatarOverlayZIndex`, `claimAvatarOverlayBorderRadiusPx`, `claimAvatarOverlayBorderColor`, and `claimAvatarOverlayBackground`.
- Included those fields in the returned `layoutPolicy.tableView.visualFit` object so callers receive the full visual-fit policy.
- This allows `moveAvatarFloatsToOverlay` to honor configured flags and styling (matching spotlight size, z-index, border radius/color, and background) at runtime.

### Testing

- Ran `npm run lint` and it completed successfully.
- Attempted `npm run build` and it failed because this repository contains no `build` npm script (no project build step to run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92033a7088326aa9c5948ba0e1626)