### PR TITLE
Portrait: apply clothing color rules only to cloth headwear and tag basic_headband

### DIFF
--- a/docs/config/config.js
+++ b/docs/config/config.js
@@ -225,6 +225,11 @@ const MATERIALS = {
 };
 window.CONFIG = window.CONFIG || {};
 window.CONFIG.materials = MATERIALS;
+window.CONFIG.portraitRandomization = window.CONFIG.portraitRandomization || {};
+window.CONFIG.portraitRandomization.materialTags = {
+  cloth: 'cloth',
+  ...(window.CONFIG.portraitRandomization.materialTags || {})
+};
 window.CONFIG.cosmeticMaterialPalettes = {
   reed: {
     minH: 26,

--- a/docs/config/cosmetics/basic_headband.json
+++ b/docs/config/cosmetics/basic_headband.json
@@ -1,5 +1,6 @@
 {
   "slot": "hat",
+  "tags": ["material:cloth"],
   "colorRange": {
     "minH": -180,
     "maxH": 180,

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -698,6 +698,11 @@ function materialColorRangeFor(option) {
   return materialPalettes[materialTag] || null;
 }
 
+function isMaterialTag(option, expectedTag) {
+  if (!expectedTag || typeof expectedTag !== 'string') return false;
+  return String(option?.materialTag || '').trim().toLowerCase() === expectedTag.trim().toLowerCase();
+}
+
 function applyBodyColorRulesSeeded(bodyColors, rules, rng) {
   if (!bodyColors || !rules || typeof rules !== 'object') return bodyColors;
   const result = {
@@ -955,14 +960,17 @@ function randomProfileSeeded(rng, fighters, hairFrontOptions, hairBackOptions, h
   const syncAcrossPieces = clothingRule?.syncAcrossPieces === true;
   const ruleRange = clothingRule?.range || null;
   const clothSourceRange = ruleRange || torsoCosmetic?.colorRange || armCosmetic?.colorRange || null;
+  const clothMaterialTag = window.CONFIG?.portraitRandomization?.materialTags?.cloth || 'cloth';
+  const hatUsesClothMaterial = isMaterialTag(hat, clothMaterialTag);
   const hatMaterialRange = materialColorRangeFor(hat);
-  const hatSourceRange = hatMaterialRange || hat?.colorRange || null;
+  const hatSourceRange = hatMaterialRange
+    || (hatUsesClothMaterial ? (ruleRange || hat?.colorRange || null) : (hat?.colorRange || null));
 
   if (hasClothPiece && clothSourceRange) {
     bodyColors.CLOTH = randomColorFromRangeSeeded(clothSourceRange, rng);
   }
   if (hatSourceRange) {
-    bodyColors.HAT = (syncAcrossPieces && bodyColors.CLOTH && !hatMaterialRange)
+    bodyColors.HAT = (syncAcrossPieces && hatUsesClothMaterial && bodyColors.CLOTH)
       ? bodyColors.CLOTH
       : randomColorFromRangeSeeded(hatSourceRange, rng);
   }

--- a/tests/portrait-clothing-color-rules.test.js
+++ b/tests/portrait-clothing-color-rules.test.js
@@ -1,0 +1,47 @@
+import { deepStrictEqual, ok } from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+test('basic headband is explicitly tagged as cloth material', () => {
+  const headband = JSON.parse(readFileSync('docs/config/cosmetics/basic_headband.json', 'utf8'));
+  ok(Array.isArray(headband.tags), 'basic_headband should define tags');
+  ok(headband.tags.includes('material:cloth'), 'basic_headband should carry material:cloth tag');
+});
+
+test('portrait randomization applies clothing hue rules to cloth hats and syncs only cloth hats', () => {
+  const source = readFileSync('docs/js/portrait-utils.js', 'utf8');
+  ok(source.includes('const clothMaterialTag = window.CONFIG?.portraitRandomization?.materialTags?.cloth || \'cloth\';'),
+    'portrait-utils should resolve cloth material tag from config fallback');
+  ok(source.includes('const hatUsesClothMaterial = isMaterialTag(hat, clothMaterialTag);'),
+    'portrait-utils should detect cloth hats via material tags');
+  ok(source.includes('|| (hatUsesClothMaterial ? (ruleRange || hat?.colorRange || null) : (hat?.colorRange || null));'),
+    'portrait-utils should apply clothing color range to cloth hats');
+  ok(source.includes('syncAcrossPieces && hatUsesClothMaterial && bodyColors.CLOTH'),
+    'portrait-utils should only sync HAT to CLOTH when hat material is cloth');
+});
+
+test('portrait randomization material tags are centralized in config', () => {
+  const configSource = readFileSync('docs/config/config.js', 'utf8');
+  ok(configSource.includes('window.CONFIG.portraitRandomization = window.CONFIG.portraitRandomization || {};'),
+    'config should define portraitRandomization namespace');
+  ok(configSource.includes('window.CONFIG.portraitRandomization.materialTags = {'),
+    'config should centralize portrait randomization material tags');
+  ok(configSource.includes("cloth: 'cloth'"),
+    'config should define cloth material tag value');
+});
+
+test('kenkari clothing color ranges remain earthy for male and bright for female profiles', () => {
+  const species = JSON.parse(readFileSync('docs/config/species/kenkari.json', 'utf8'));
+  const maleRange = species?.male?.randomizationRules?.clothingColors?.range;
+  const femaleRange = species?.female?.randomizationRules?.clothingColors?.range;
+  deepStrictEqual(
+    { minH: maleRange?.minH, maxH: maleRange?.maxH },
+    { minH: -40, maxH: 65 },
+    'male kenkari clothing range should stay earthy'
+  );
+  deepStrictEqual(
+    { minH: femaleRange?.minH, maxH: femaleRange?.maxH },
+    { minH: -150, maxH: 115 },
+    'female kenkari clothing range should stay bright/flowery'
+  );
+});


### PR DESCRIPTION
### Motivation
- Prevent non-cloth headwear (e.g. reed kasa) from inheriting clothing color rules and material palettes intended for cloth. 
- Ensure species-level clothing color preferences (male earthy / female bright for Kenkari) also affect cloth headwear like the basic headband. 
- Centralize the material-tag mapping so material-type behavior is configurable rather than hardcoded.

### Description
- Updated portrait randomization in `docs/js/portrait-utils.js` to detect a cosmetic's material tag and only apply hat↔cloth syncing (`syncAcrossPieces`) when the selected hat is explicitly a cloth material. 
- Added `isMaterialTag` helper and refined `hatSourceRange` selection so species `clothingColors.range` is applied to cloth-tagged hats while material palettes (e.g. `reed`, `wood`) still constrain non-cloth items via `materialColorRangeFor`. 
- Centralized the portrait material tag name under `window.CONFIG.portraitRandomization.materialTags` in `docs/config/config.js` so tags like `cloth` can be overridden from config. 
- Tagged `basic_headband` as `material:cloth` in `docs/config/cosmetics/basic_headband.json` so it becomes subject to cloth color rules. 
- Added `tests/portrait-clothing-color-rules.test.js` to assert the cloth tag, config centralization, cloth-only sync logic, and that Kenkari male/female clothing ranges remain unchanged.

### Testing
- Ran `node --test tests/portrait-clothing-color-rules.test.js` and it passed (4/4). 
- Ran `node --test tests/hat-hide-rules.test.js` and it passed (2/2).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e922d35f208326ba7c247151b6cb12)