### PR TITLE
Align Scratchbones AI names with portrait species culture

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -1828,6 +1828,15 @@
         nameGeneration: {
           defaultCultureId: rawGameConfig.nameGeneration?.defaultCultureId ?? 'mao_ao',
           seedPrefix: rawGameConfig.nameGeneration?.seedPrefix ?? 'madiao-player',
+          aiCultureSelection: {
+            usePortraitSpeciesCulture: rawGameConfig.nameGeneration?.aiCultureSelection?.usePortraitSpeciesCulture ?? true,
+            fallbackCultureId: rawGameConfig.nameGeneration?.aiCultureSelection?.fallbackCultureId ?? (rawGameConfig.nameGeneration?.defaultCultureId ?? 'mao_ao'),
+            speciesToCultureId: rawGameConfig.nameGeneration?.aiCultureSelection?.speciesToCultureId ?? {
+              mao_ao: 'mao_ao',
+              'mao-ao': 'mao_ao',
+              kenkari: 'kenkari',
+            },
+          },
           cultures: rawGameConfig.nameGeneration?.cultures ?? {},
         },
         chips: {
@@ -2344,13 +2353,13 @@
     function hashStringToSeed(text) {
       return window.SCRATCHBONES_NAME_GENERATOR.hashStringToSeed(text);
     }
-    function generateMaoAoNameFromSeed(seedString, gender = 'male') {
-      return window.SCRATCHBONES_NAME_GENERATOR.generateIdentityFromSeed(seedString, gender);
+    function generateNameFromSeed(seedString, gender = 'male', cultureId) {
+      return window.SCRATCHBONES_NAME_GENERATOR.generateIdentityFromSeed(seedString, gender, cultureId);
     }
-    function generateAiIdentity(index) {
+    function generateAiIdentity(index, cultureId) {
       const identitySeed = `${NAME_SEED_PREFIX}-${state.seed}-${index}`;
       const gender = (hashStringToSeed(identitySeed) & 1) === 0 ? 'male' : 'female';
-      const name = generateMaoAoNameFromSeed(identitySeed, gender);
+      const name = generateNameFromSeed(identitySeed, gender, cultureId);
       return {
         name,
         seed: name,
@@ -2538,6 +2547,29 @@
         };
       });
     }
+    function inferPlayerCultureFromProfile(player) {
+      const cultureCfg = SCRATCHBONES_GAME.nameGeneration?.aiCultureSelection || {};
+      const speciesToCultureId = cultureCfg.speciesToCultureId || {};
+      const fallbackCultureId = cultureCfg.fallbackCultureId || SCRATCHBONES_GAME.nameGeneration?.defaultCultureId;
+      if (!cultureCfg.usePortraitSpeciesCulture) return fallbackCultureId;
+      const fighter = player?.profile?.fighter;
+      const speciesId = fighter?.speciesId || null;
+      if (speciesId && speciesToCultureId[speciesId]) return speciesToCultureId[speciesId];
+      const fighterId = String(fighter?.id || '').toLowerCase();
+      if ((fighterId === 'm' || fighterId === 'f') && speciesToCultureId.mao_ao) return speciesToCultureId.mao_ao;
+      return fallbackCultureId;
+    }
+    function applyAiNamesByPortraitCulture() {
+      for (const player of state.players) {
+        if (player.isHuman) continue;
+        const cultureId = inferPlayerCultureFromProfile(player);
+        const aiIdentity = generateAiIdentity(player.id, cultureId);
+        player.name = resolveSeatName(player.id, aiIdentity.name);
+        player.seed = aiIdentity.seed;
+        player.gender = aiIdentity.gender;
+        player.personality = aiIdentity.personality;
+      }
+    }
     function alivePlayers() {
       return state.players.filter(p => !p.eliminated);
     }
@@ -2615,6 +2647,8 @@
     function startGame() {
       SCRATCHBONES_AUDIO.startPlaylist();
       clearChallengeTimer();
+      state.seed = Math.floor(Math.random() * 1e9);
+      rand = mulberry32(state.seed);
       state.players = makePlayers();
       state.selectedCardIds.clear();
       state.pile = [];
@@ -2627,10 +2661,9 @@
       state.round = 1;
       state.roundConcessions.clear();
       state.stats = { successfulChallenges: 0, failedChallenges: 0, bluffsCaught: 0, safeTruths: 0, totalClears: 0, chipsMovedByChallenges: 0 };
-      state.seed = Math.floor(Math.random() * 1e9);
-      rand = mulberry32(state.seed);
       dealFreshHands();
       for (const p of state.players) p.profile = generatePlayerProfile(p);
+      applyAiNamesByPortraitCulture();
       for (const p of state.players) logPlayerPortraitXforms(p);
       state.leaderIndex = rngInt(0, state.players.length - 1);
       state.currentTurn = state.leaderIndex;
@@ -5002,6 +5035,7 @@
         _portraitCosmetics = cosmetics;
         if (state.players.length) {
           for (const p of state.players) p.profile = generatePlayerProfile(p);
+          applyAiNamesByPortraitCulture();
           renderSeatPortraits();
           renderCinematicPortraits();
         }

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -13,6 +13,15 @@ window.SCRATCHBONES_CONFIG = {
     "nameGeneration": {
       "defaultCultureId": "mao_ao",
       "seedPrefix": "madiao-player",
+      "aiCultureSelection": {
+        "usePortraitSpeciesCulture": true,
+        "fallbackCultureId": "mao_ao",
+        "speciesToCultureId": {
+          "mao_ao": "mao_ao",
+          "mao-ao": "mao_ao",
+          "kenkari": "kenkari"
+        }
+      },
       "cultures": {
         "mao_ao": {
           "id": "mao_ao",

--- a/docs/js/portrait-utils.js
+++ b/docs/js/portrait-utils.js
@@ -16,6 +16,7 @@ const _PORTRAIT_DEFAULTS = {
   fighters: [
     {
       id:      'M',
+      speciesId: 'mao_ao',
       label:   'Mao-ao (M)',
       headUrl: 'fightersprites/mao-ao-m/head_mint.png',
       bodyLayers: [
@@ -29,6 +30,7 @@ const _PORTRAIT_DEFAULTS = {
     },
     {
       id:      'F',
+      speciesId: 'mao_ao',
       label:   'Mao-ao (F)',
       headUrl: 'fightersprites/mao-ao-f/head.png',
       bodyLayers: [
@@ -576,6 +578,7 @@ async function loadPortraitCosmetics(configBase) {
           if (!fighter && genderData.headSprite && Array.isArray(genderData.portraitBodyLayers)) {
             fighter = normalizedFighterPortrait({
               id: `${sData.speciesId}_${genderKey}`,
+              speciesId: sData.speciesId,
               gender: genderKey,
               label: `${sData.label || entry.label} (${genderKey === 'male' ? 'M' : 'F'})`,
               headUrl: genderData.headSprite,


### PR DESCRIPTION
### Motivation
- AI players were always being named using the default culture which produced Mao-ao names even when their portrait fighter selection produced Kenkari visuals.
- The mismatch occurred because AI names were generated before portrait species were resolved and there was no way to select a name-generation culture based on portrait species.

### Description
- Added a configurable `nameGeneration.aiCultureSelection` block to `docs/config/scratchbones-config.js` to allow portrait-species-driven culture inference and mapping (including fallback behavior) via `usePortraitSpeciesCulture`, `fallbackCultureId`, and `speciesToCultureId`.
- Plumbed an optional `cultureId` through the name generation call path by adding `generateNameFromSeed(seedString, gender, cultureId)` which calls `generateIdentityFromSeed(...)` with an optional culture argument.
- Implemented `inferPlayerCultureFromProfile(player)` and `applyAiNamesByPortraitCulture()` in `ScratchbonesBluffGame.html` to infer each AI player’s culture from their resolved portrait fighter and re-generate AI identities accordingly, and called this after portrait cosmetics finish loading and during game startup.
- Ensured `speciesId` is persisted on portrait fighter records by adding `speciesId` to the built-in Mao-ao fighters and to dynamically loaded species fighters in `docs/js/portrait-utils.js`, and moved `state.seed` initialization earlier in `startGame` so identity seed generation uses the current game seed.

### Testing
- Ran a static grep to confirm usage of the new config and functions: `rg -n "generateMaoAoNameFromSeed|generateNameFromSeed|applyAiNamesByPortraitCulture|aiCultureSelection|speciesId" ScratchbonesBluffGame.html docs/config/scratchbones-config.js docs/js/portrait-utils.js`, which showed the expected references.
- Performed a JavaScript syntax check by evaluating the modified modules with Node using `node -e "const fs=require('fs'); new Function(fs.readFileSync('docs/js/portrait-utils.js','utf8')); new Function(fs.readFileSync('docs/js/scratchbones-name-generator.js','utf8')); console.log('js syntax ok')"`, which completed successfully.
- Confirmed the new behavior is applied after portrait cosmetics load and at game start by static inspection of the updated `startGame` and portrait-loading code paths, and the checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92eb431e08326aa72319afc02b43a)