### PR TITLE
Fix iframe-local billboard center mapping for tabletop holster projection

### DIFF
--- a/docs/tabletop-holster.html
+++ b/docs/tabletop-holster.html
@@ -453,9 +453,8 @@
             if (rect.width <= 0 || rect.height <= 0) {
               return;
             }
-            const frameRect = frameElement.getBoundingClientRect();
-            const sourceCenterX = rect.left - frameRect.left + rect.width * 0.5;
-            const sourceCenterY = rect.top - frameRect.top + rect.height * 0.5;
+            const sourceCenterX = rect.left + rect.width * 0.5;
+            const sourceCenterY = rect.top + rect.height * 0.5;
             const projectedCenter = applyHomographyToPoint(latestHomography, sourceCenterX, sourceCenterY);
             if (!projectedCenter) {
               return;


### PR DESCRIPTION
### Motivation
- Correct billboard overlay placement by ensuring iframe element centers from `getBoundingClientRect()` are treated as iframe-local coordinates before applying the source→target homography, which previously caused double-applied iframe offset and visible misplacement when the projection was not top-left anchored.

### Description
- Updated `docs/tabletop-holster.html` to remove the subtraction of the host iframe rect and pass the iframe-local center (`rect.left + rect.width * 0.5`, `rect.top + rect.height * 0.5`) directly into `applyHomographyToPoint` so projected billboards align with their source elements.

### Testing
- Ran repository checks and commits (`git diff -- docs/tabletop-holster.html`, `git status --short`, and `git show`), and committed the change as `Fix billboard coordinate mapping inside iframe`; no unit or CI tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e938bca26c83268910070c6e963d8b)