### PR TITLE
Fix billboard anchor coordinate space for tabletop holster projection

### DIFF
--- a/docs/tabletop-holster.html
+++ b/docs/tabletop-holster.html
@@ -395,9 +395,8 @@
             if (rect.width <= 0 || rect.height <= 0) {
               return;
             }
-            const frameRect = frameElement.getBoundingClientRect();
-            const sourceCenterX = rect.left - frameRect.left + rect.width * 0.5;
-            const sourceCenterY = rect.top - frameRect.top + rect.height * 0.5;
+            const sourceCenterX = rect.left + rect.width * 0.5;
+            const sourceCenterY = rect.top + rect.height * 0.5;
             const projectedCenter = applyHomographyToPoint(latestHomography, sourceCenterX, sourceCenterY);
             if (!projectedCenter) {
               return;


### PR DESCRIPTION
### Motivation
- The billboard overlay computed anchor points using a mixture of iframe-local and top-level viewport coordinates which caused projected labels to appear offset when the iframe is not at the host origin; this change ensures anchors are computed in the iframe's local coordinate space so homography projection is correct.

### Description
- In `docs/tabletop-holster.html` the billboard anchor calculation now uses the matched element's iframe-local center from `getBoundingClientRect()` (`rect.left + rect.width*0.5`, `rect.top + rect.height*0.5`) and removes the prior subtraction of the host `frameElement.getBoundingClientRect()` so projections use a consistent coordinate space.

### Testing
- Ran `git diff --check` to verify no patch formatting issues and ran `git status --short` to confirm only the intended file changed, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e939040a9c83269a818fa001651412)