### PR TITLE
Hide claim cluster avatar shell chrome by default

### DIFF
--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -199,8 +199,8 @@ window.SCRATCHBONES_CONFIG = {
           "claimAvatarSizePx": 180,
           "claimAvatarZoomScale": 1.2,
           "claimAvatarBorderRadiusPx": 12,
-          "claimAvatarBorderColor": "rgba(242,208,143,0.28)",
-          "claimAvatarBackground": "rgba(22,16,14,0.72)",
+          "claimAvatarBorderColor": "transparent",
+          "claimAvatarBackground": "transparent",
           "avatarAdditiveZoomScale": 1.2,
           "claimAvatarOverlayZIndex": 9990
         },


### PR DESCRIPTION
### Motivation
- The claim-cluster avatars displayed a visible shell (border and background) that should be removable for a cleaner visual presentation. 
- Prefer a config-driven change so the legacy rendering code remains untouched while enabling the new default appearance.

### Description
- Updated `docs/config/scratchbones-config.js` to set `claimAvatarBorderColor` and `claimAvatarBackground` to `transparent` in the `tableView.visualFit` block. 
- Confirmed the runtime reads these config values in `ScratchbonesBluffGame.html` and maps them to CSS variables `--layout-claim-avatar-border-color` and `--layout-claim-avatar-background`. 
- Verified the same values are applied directly to the floating overlay path that sets `.claimAvatarShell` styles, so no JS runtime changes were required.

### Testing
- Used `rg` to locate the `claimAvatar*` keys and references and confirmed the relevant code paths were found successfully. 
- Inspected the config change with `git diff -- docs/config/scratchbones-config.js` and printed relevant slices of `ScratchbonesBluffGame.html` with `nl` to confirm the values are read and applied, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93df923588326945ad04f37e05dfb)