### PR TITLE
Make claim cluster cards match hand panel card sizing

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -347,8 +347,8 @@
       padding: 2px;
     }
     .claimHandBar .tableViewCard {
-      width: var(--layout-claim-card-width, calc(clamp(var(--layout-hand-card-min-width), 14vw, var(--layout-hand-card-max-width)) * var(--layout-challenge-image-scale) * var(--layout-fit-image-scale) * var(--layout-table-card-container-scale) * var(--layout-table-card-auto-scale)));
-      height: var(--layout-claim-card-height, calc(clamp(var(--layout-hand-card-min-height), 20vh, var(--layout-hand-card-max-height)) * var(--layout-challenge-image-scale) * var(--layout-fit-image-scale) * var(--layout-table-card-container-scale) * var(--layout-table-card-auto-scale)));
+      width: var(--layout-claim-card-width, clamp(var(--layout-hand-card-min-width), 14vw, var(--layout-hand-card-max-width)));
+      height: var(--layout-claim-card-height, clamp(var(--layout-hand-card-min-height), 20vh, var(--layout-hand-card-max-height)));
       margin-left: -8px;
     }
     .claimHandBar .tableViewCard:first-child {


### PR DESCRIPTION
### Motivation
- Align claim cluster card dimensions with the hand panel cards so cards look consistent across the table and claim cluster, removing the extra table/fit/challenge scaling that caused size divergence.

### Description
- Change CSS in `ScratchbonesBluffGame.html` so `.claimHandBar .tableViewCard` uses `width: var(--layout-claim-card-width, clamp(var(--layout-hand-card-min-width), 14vw, var(--layout-hand-card-max-width)))` and `height: var(--layout-claim-card-height, clamp(var(--layout-hand-card-min-height), 20vh, var(--layout-hand-card-max-height)))`, replacing the previous `calc(... * var(--layout-...)-scale)` expressions.

### Testing
- Ran `npm run lint` which completes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93db45cac8326be98de28ae329c86)