### PR TITLE
Refine AI timing, suspicion scoring, and read-tracking

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -1910,10 +1910,18 @@
             turnMaxMs: rawGameConfig.timers?.aiDecisionDelays?.turnMaxMs ?? 1300,
             challengeMinMs: rawGameConfig.timers?.aiDecisionDelays?.challengeMinMs ?? 360,
             challengeMaxMs: rawGameConfig.timers?.aiDecisionDelays?.challengeMaxMs ?? 2200,
-            bettingMinMs: rawGameConfig.timers?.aiDecisionDelays?.bettingMinMs ?? 360,
-            bettingMaxMs: rawGameConfig.timers?.aiDecisionDelays?.bettingMaxMs ?? 1200,
+            bettingMinMs: rawGameConfig.timers?.aiDecisionDelays?.bettingMinMs ?? 200,
+            bettingMaxMs: rawGameConfig.timers?.aiDecisionDelays?.bettingMaxMs ?? 650,
             challengeStaggerMs: rawGameConfig.timers?.aiDecisionDelays?.challengeStaggerMs ?? 220,
           },
+        },
+        ai: {
+          challengeThreshold: rawGameConfig.ai?.challengeThreshold ?? 0.52,
+          challengeRandomNudgeMax: rawGameConfig.ai?.challengeRandomNudgeMax ?? 0.16,
+          backupJoinBaseScore: rawGameConfig.ai?.backupJoinBaseScore ?? 0.15,
+          backupJoinRandomMax: rawGameConfig.ai?.backupJoinRandomMax ?? 0.22,
+          backupJoinSuspicionWeight: rawGameConfig.ai?.backupJoinSuspicionWeight ?? 0.2,
+          bettingConfidenceSuspicionWeight: rawGameConfig.ai?.bettingConfidenceSuspicionWeight ?? 0.55,
         },
         layout: {
           mode: String(rawGameConfig.layout?.mode || 'responsive').toLowerCase(),
@@ -2513,6 +2521,7 @@
  // Used by: debug panel rendering and state dumps.
     const AI_THINK_MS = SCRATCHBONES_GAME.timers.aiThinkMs; // Used by: AI turn pacing so mobile play stays readable.
     const AI_DECISION_DELAYS = SCRATCHBONES_GAME.timers.aiDecisionDelays || {};
+    const AI_CONFIG = SCRATCHBONES_GAME.ai || {};
     const START_HAND_SIZE = SCRATCHBONES_GAME.deck.handSize; // Used by: dealing fresh hands at match start and after a clear.
     const WILD_COUNT = SCRATCHBONES_GAME.deck.wildCount; // Used by: deck construction and bluff validation.
     const RANK_COUNT = SCRATCHBONES_GAME.deck.rankCount;
@@ -2528,6 +2537,12 @@
       clearBonusBase: SCRATCHBONES_GAME.chips.clearBonusBase,
       clearBonusIncrement: SCRATCHBONES_GAME.chips.clearBonusIncrement,
       maxChallengeBet: SCRATCHBONES_GAME.chips.maxChallengeBet,
+      aiChallengeThreshold: Number(AI_CONFIG.challengeThreshold) || 0.52,
+      aiChallengeRandomNudgeMax: Number(AI_CONFIG.challengeRandomNudgeMax) || 0.16,
+      aiBackupJoinBaseScore: Number(AI_CONFIG.backupJoinBaseScore) || 0.15,
+      aiBackupJoinRandomMax: Number(AI_CONFIG.backupJoinRandomMax) || 0.22,
+      aiBackupJoinSuspicionWeight: Number(AI_CONFIG.backupJoinSuspicionWeight) || 0.2,
+      aiBettingConfidenceSuspicionWeight: Number(AI_CONFIG.bettingConfidenceSuspicionWeight) || 0.55,
     };
     const state = {
       players: [],
@@ -2811,7 +2826,7 @@
         actualSummary: cards.map(c => c.wild ? 'W' : String(c.rank)).join(', '),
       };
       state.pile.push(play);
-      observePlayForReads(play);
+      observeClaimForReads(play);
       player.lastAction = truthful ? `Played ${cards.length}` : `Bluffed ${cards.length}`;
       if (truthful) state.stats.safeTruths += 1;
       state.selectedCardIds.clear();
@@ -2863,17 +2878,33 @@
           currentTruthStreak: 0,
           currentBluffStreak: 0,
           lastDeclaredRank: null,
-          lastTruthful: null,
         };
       }
       return observer.reads[targetIndex];
     }
-    function observePlayForReads(play) {
+    function observeClaimForReads(play) {
       for (const observer of state.players) {
         if (observer.eliminated || observer.id === play.playerIndex) continue;
         const read = ensureReadProfile(observer.id, play.playerIndex);
         if (!read) continue;
-        if (play.truthful) {
+        if (read.lastDeclaredRank === play.declaredRank) {
+          read.repeatRankCount += 1;
+          read.repeatedCount += 1;
+          read.quickJudgmentBias += 0.06;
+        } else {
+          read.repeatRankCount = 0;
+        }
+        read.quickJudgmentBias += Math.max(0, play.cards.length - 2) * 0.015;
+        read.lastDeclaredRank = play.declaredRank;
+        read.quickJudgmentBias = clamp01((read.quickJudgmentBias + 1) / 2) * 2 - 1;
+      }
+    }
+    function observeRevealedTruthForReads(play, wasTruthful) {
+      for (const observer of state.players) {
+        if (observer.eliminated || observer.id === play.playerIndex) continue;
+        const read = ensureReadProfile(observer.id, play.playerIndex);
+        if (!read) continue;
+        if (wasTruthful) {
           read.truthfulCount += 1;
           read.currentTruthStreak += 1;
           read.currentBluffStreak = 0;
@@ -2886,16 +2917,7 @@
           if (read.quickJudgmentBias > 0) read.quickJudgmentBias *= 0.55;
           read.quickJudgmentBias += 0.14;
         }
-        if (read.lastDeclaredRank === play.declaredRank) {
-          read.repeatRankCount += 1;
-          read.repeatedCount += 1;
-          read.quickJudgmentBias += 0.06;
-        } else {
-          read.repeatRankCount = 0;
-        }
-        read.lastDeclaredRank = play.declaredRank;
-        read.lastTruthful = play.truthful;
-        read.quickJudgmentBias = clamp01((read.quickJudgmentBias + 1) / 2) * 2 - 1;
+        read.quickJudgmentBias = Math.max(-1, Math.min(1, read.quickJudgmentBias));
       }
     }
     function noteChallengeReadResult(challengerIndex, targetIndex, challengeSucceeded) {
@@ -2926,7 +2948,7 @@
         read.quickJudgmentBias * snapWeight
       );
     }
-    function aiShouldChallenge(challengerIndex, play) {
+    function challengeSuspicionScore(challengerIndex, play, { includeRandom = true } = {}) {
       const challenger = state.players[challengerIndex];
       const pers = challenger.personality;
       const knownRankCount = countKnownRank(play.declaredRank);
@@ -2934,7 +2956,6 @@
       const impossibleOverage = Math.max(0, knownRankCount + play.cards.length - 4 - visibleWilds);
       const read = ensureReadProfile(challengerIndex, play.playerIndex);
       let suspicion = 0;
-      if (!play.truthful) suspicion += 0.24;
       suspicion += impossibleOverage * 0.27;
       suspicion += play.cards.length >= 3 ? 0.1 : 0;
       suspicion += play.cards.length >= 5 ? 0.08 : 0;
@@ -2942,13 +2963,16 @@
       suspicion += challenger.chips >= 8 ? 0.05 : 0;
       suspicion += play.playerIndex === 0 ? 0.1 : 0;
       suspicion += suspicionFromReadProfile(read, pers);
-      suspicion += rand() * 0.16;
+      if (includeRandom) suspicion += rand() * CONFIG.aiChallengeRandomNudgeMax;
       if (pers) {
         suspicion += (pers.suspicion  - 0.5) * 0.34;
         suspicion += (pers.aggression - 0.5) * 0.08;
         if (pers.overSuspects) suspicion += 0.1;
       }
-      return suspicion >= 0.52;
+      return suspicion;
+    }
+    function aiShouldChallenge(challengerIndex, play) {
+      return challengeSuspicionScore(challengerIndex, play, { includeRandom: true }) >= CONFIG.aiChallengeThreshold;
     }
     function clampMs(value, minMs, maxMs) {
       return Math.max(minMs, Math.min(maxMs, Math.round(value)));
@@ -2991,9 +3015,14 @@
         const stakePressure = state.betting ? Math.min(0.25, Math.max(0, state.betting.stake - CONFIG.challengeBaseTransfer) * 0.03) : 0;
         const styleTempo = 1 - ((pers.courage ?? 0.5) * 0.5 + (pers.aggression ?? 0.5) * 0.3 + (pers.greed ?? 0.5) * 0.2);
         const uncertainty = clamp01(0.42 - confidenceGap * 0.6 + Math.min(0.2, toCall * 0.05) + stakePressure + rand() * 0.08);
+        const canRaise = getRaiseOptionsForPlayer(actorId).length > 0;
+        const decisiveSpot = (toCall === 0 && !canRaise) || confidenceGap >= 0.42;
         const pace = clamp01(uncertainty * 0.66 + styleTempo * 0.34);
-        const minMs = Number(AI_DECISION_DELAYS.bettingMinMs) || 360;
-        const maxMs = Number(AI_DECISION_DELAYS.bettingMaxMs) || 1200;
+        const minMs = Number(AI_DECISION_DELAYS.bettingMinMs) || 200;
+        const maxMs = Number(AI_DECISION_DELAYS.bettingMaxMs) || 650;
+        if (decisiveSpot) {
+          return clampMs(minMs + Math.max(20, (maxMs - minMs) * 0.12), minMs, maxMs);
+        }
         return clampMs(minMs + (maxMs - minMs) * pace, minMs, maxMs);
       }
       return AI_THINK_MS;
@@ -3079,8 +3108,9 @@
     }
     function aiShouldJoinBackup(playerIndex, play) {
       const p = state.players[playerIndex];
-      let score = 0.15 + rand() * 0.22;
-      if (!play.truthful) score += 0.22;
+      const suspicion = challengeSuspicionScore(playerIndex, play, { includeRandom: false });
+      let score = CONFIG.aiBackupJoinBaseScore + rand() * CONFIG.aiBackupJoinRandomMax;
+      score += suspicion * CONFIG.aiBackupJoinSuspicionWeight;
       if (p.chips <= 2) score -= 0.18;
       if (play.playerIndex === 0) score += 0.05;
       if (p.personality) score += (p.personality.solidarity - 0.5) * 0.3;
@@ -3164,7 +3194,6 @@
       const command = typeof action === 'string' ? action : action?.type;
       const player = state.players[playerId];
       const opponentId = getOpponentId(playerId);
-      const opponent = state.players[opponentId];
       const toCall = amountToCall(playerId);
       if (command === 'joinBackup') {
         if (state.betting.backupQueue.includes(playerId) || playerId === state.betting.challengerId || playerId === state.betting.challengedId || player.eliminated) return;
@@ -3311,6 +3340,7 @@
       showClaimGlow('red', 2500, () => {
         winner.chips += pot;
         state.stats.chipsMovedByChallenges += pot;
+        observeRevealedTruthForReads(play, play.truthful);
         if (success) {
           state.stats.successfulChallenges += 1;
           state.stats.bluffsCaught += 1;
@@ -3465,6 +3495,7 @@
       if (!state.betting || state.gameOver) return;
       const actorId = state.betting.currentActorId;
       if (actorId === 0) return;
+      const intent = aiBetIntent(actorId);
       const thinkMs = aiDecisionDelayMs('betting', actorId);
       window.setTimeout(() => {
         if (state.betting && !state.gameOver && state.betting.currentActorId === actorId) {
@@ -3666,7 +3697,6 @@
       return { type: 'concede' };
     }
     function estimateFoldPressureAgainst(actorId, opponentId) {
-      const actor = state.players[actorId];
       const opponent = state.players[opponentId];
       const actorRead = ensureReadProfile(actorId, opponentId);
       const opponentPers = opponent?.personality;
@@ -3697,9 +3727,11 @@
       const bankrollBoost = Math.min(0.18, player.chips / 40);
       const couragePush = pers ? (pers.courage - 0.5) * 0.22 : 0;
       const randomNudge = rand() * 0.12 - 0.06;
+      const challengerSuspicion = challengeSuspicionScore(b.challengerId, play, { includeRandom: false });
+      const suspicionWeight = CONFIG.aiBettingConfidenceSuspicionWeight;
       let confidence = actorId === b.challengerId
-        ? (play.truthful ? 0.3 : 0.74)
-        : (play.truthful ? 0.74 : 0.24);
+        ? (0.5 + challengerSuspicion * suspicionWeight)
+        : (0.5 - challengerSuspicion * suspicionWeight);
       confidence += bankrollBoost + couragePush + randomNudge;
       let raiseDrive = confidence;
       let foldFloor = pers ? 0.32 - (pers.courage - 0.5) * 0.18 : 0.32;
@@ -3707,8 +3739,8 @@
         confidence += suspicionFromReadProfile(playerRead, pers) * 0.18;
         raiseDrive += foldPressure * 0.45;
         raiseDrive += opponentRead && opponentRead.currentBluffStreak > 0 ? Math.min(0.12, opponentRead.currentBluffStreak * 0.05) : 0;
-        raiseDrive -= play.truthful ? 0.14 : 0;
-      } else if (play.truthful) {
+        raiseDrive -= challengerSuspicion < 0 ? Math.min(0.14, Math.abs(challengerSuspicion) * 0.2) : 0;
+      } else if (challengerSuspicion < 0) {
         raiseDrive += (1 - foldPressure) * 0.34;
         raiseDrive += opponentPers ? opponentPers.aggression * 0.12 : 0;
         raiseDrive += Math.min(0.12, Math.max(0, b.stake - CONFIG.challengeBaseTransfer) * 0.04);

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -119,10 +119,18 @@ window.SCRATCHBONES_CONFIG = {
         "turnMaxMs": 1300,
         "challengeMinMs": 360,
         "challengeMaxMs": 2200,
-        "bettingMinMs": 360,
-        "bettingMaxMs": 1200,
+        "bettingMinMs": 200,
+        "bettingMaxMs": 650,
         "challengeStaggerMs": 220
       }
+    },
+    "ai": {
+      "challengeThreshold": 0.52,
+      "challengeRandomNudgeMax": 0.16,
+      "backupJoinBaseScore": 0.15,
+      "backupJoinRandomMax": 0.22,
+      "backupJoinSuspicionWeight": 0.2,
+      "bettingConfidenceSuspicionWeight": 0.55
     },
     "layout": {
       "mode": "authored",


### PR DESCRIPTION
### Motivation
- Improve AI responsiveness and make AI behavior tunable via configuration while producing more nuanced suspicion/read signals for challenge and betting decisions.

### Description
- Add a new `ai` config block to the game config and expose parameters into `CONFIG` such as `aiChallengeThreshold`, `aiChallengeRandomNudgeMax`, `aiBackupJoinBaseScore`, `aiBackupJoinRandomMax`, `aiBackupJoinSuspicionWeight`, and `aiBettingConfidenceSuspicionWeight`.
- Shorten default betting decision delays by changing `bettingMinMs`/`bettingMaxMs` from `360`/`1200` to `200`/`650` in both `ScratchbonesBluffGame.html` and `docs/config/scratchbones-config.js`.
- Introduce `challengeSuspicionScore` that returns a numeric suspicion value and refactor `aiShouldChallenge`, `aiShouldJoinBackup`, and betting confidence calculations to use this score and the new configurable weights, and precompute betting intent in `scheduleBettingAiIfNeeded`.
- Replace `observePlayForReads` with `observeClaimForReads`, add `observeRevealedTruthForReads`, adjust read-profile fields and `quickJudgmentBias` updates, and wire revealed-truth observation into `revealChallenge`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99d1ab0b083268aaa4e167d014554)