### PR TITLE
Wire SCRATCHBONES_GAME.assets into runtime CONFIG to fix claim glyph crash

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2543,6 +2543,7 @@
       aiBackupJoinRandomMax: Number(AI_CONFIG.backupJoinRandomMax) || 0.22,
       aiBackupJoinSuspicionWeight: Number(AI_CONFIG.backupJoinSuspicionWeight) || 0.2,
       aiBettingConfidenceSuspicionWeight: Number(AI_CONFIG.bettingConfidenceSuspicionWeight) || 0.55,
+      assets: SCRATCHBONES_GAME.assets,
     };
     const state = {
       players: [],


### PR DESCRIPTION
### Motivation
- Fix the uncaught `TypeError` when rendering claim glyphs caused by `CONFIG.assets` being undefined even though `normalizeScratchbonesGameConfig()` builds `SCRATCHBONES_GAME.assets`.

### Description
- Add `assets: SCRATCHBONES_GAME.assets` to the `CONFIG` object in `ScratchbonesBluffGame.html` so code reading `CONFIG.assets.claimRankGlyphTemplateSrc` and `CONFIG.assets.cinematicTokenIconSrc` has the expected data.

### Testing
- Ran `npm run test:unit`; the test suite executed but the repository contains multiple pre-existing failing tests (29 failing tests reported) and the run completed without introducing regressions attributable to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a613d1e48326aa20fa1cc1438ce9)