### PR TITLE
Fix claim cluster count ReferenceError and wire SCRATCHBONES_GAME.assets into CONFIG

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2543,6 +2543,7 @@
       aiBackupJoinRandomMax: Number(AI_CONFIG.backupJoinRandomMax) || 0.22,
       aiBackupJoinSuspicionWeight: Number(AI_CONFIG.backupJoinSuspicionWeight) || 0.2,
       aiBettingConfidenceSuspicionWeight: Number(AI_CONFIG.bettingConfidenceSuspicionWeight) || 0.55,
+      assets: SCRATCHBONES_GAME.assets,
     };
     const state = {
       players: [],
@@ -4929,7 +4930,6 @@
       const focusReactor = claimFocus.reactorId !== null ? state.players[claimFocus.reactorId] : null;
       const claimRankText = claimFocus.declaredRank === null || claimFocus.declaredRank === undefined ? '—' : String(claimFocus.declaredRank);
       const claimCount = claimFocus.cards?.length || 0;
-      const claimCountText = String(claimCount);
       const claimRankNumeric = Number(claimFocus.declaredRank);
       const claimRankGlyphSrc = Number.isFinite(claimRankNumeric)
         ? String(CONFIG.assets.claimRankGlyphTemplateSrc || '')
@@ -5069,9 +5069,9 @@
             <div class="claimRankBox ${claimClusterShellClass}" data-proj-id="claim-rank-box" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimRankBox)}">${claimRankGlyphHtml}</div>
             <div class="claimHandBar ${claimClusterShellClass}" data-proj-id="claim-hand-bar" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimHandBar)}">${claimHandCardsHtml}</div>
             <div class="claimTimesBoxLeft ${claimClusterShellClass}" data-proj-id="claim-times-left" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimTimesBoxLeft)}">×</div>
-            <div class="claimCountBoxLeft ${claimClusterShellClass}" data-proj-id="claim-count-left" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimCountBoxLeft)}">${claimCountGlyphHtml}</div>
+            <div class="claimCountBoxLeft ${claimClusterShellClass}" data-proj-id="claim-count-left" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimCountBoxLeft)}">${claimCount}</div>
             <div class="claimTimesBoxRight ${claimClusterShellClass}" data-proj-id="claim-times-right" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimTimesBoxRight)}">×</div>
-            <div class="claimCountBoxRight ${claimClusterShellClass}" data-proj-id="claim-count-right" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimCountBoxRight)}">${claimCountGlyphHtml}</div>
+            <div class="claimCountBoxRight ${claimClusterShellClass}" data-proj-id="claim-count-right" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimCountBoxRight)}">${claimCount}</div>
             <div class="actorAvatarFloat ${claimClusterShellClass}" data-proj-id="claim-avatar-actor" style="${claimClusterElementStyle(claimClusterPolicy.elements.actorAvatarFloat)}" title="${seatLabel(focusActor || claimFocus.actorId)}">
               <div class="claimAvatarShell">
                 <canvas class="seatPortrait" data-seat-id="${claimFocus.actorId}" width="220" height="220"></canvas>


### PR DESCRIPTION
### Motivation
- Resolve runtime render errors in the claim cluster: a `TypeError` from dereferencing `CONFIG.assets` (missing at runtime) and a `ReferenceError` from an undefined `claimCountGlyphHtml` used in the claim cluster template. 
- Remove an unused variable and ensure asset template paths are provided via runtime `CONFIG` so UI rendering paths are robust.

### Description
- Add `assets: SCRATCHBONES_GAME.assets` to the `CONFIG` object in `ScratchbonesBluffGame.html` so code reading `CONFIG.assets.*` no longer dereferences `undefined`.
- Replace both occurrences of the undefined `claimCountGlyphHtml` with the already-computed numeric `claimCount`, and remove the now-unused `claimCountText` declaration in `ScratchbonesBluffGame.html`.
- All changes are localized to `ScratchbonesBluffGame.html` and avoid introducing hardcoded constants outside the existing game config.

### Testing
- Ran `npm run test:unit`; the test suite executed fully and reports `# pass 318` and `# fail 29`, where the failures are pre-existing and not introduced by these edits.
- Ran an automated code search to confirm removal of `claimCountGlyphHtml`/`claimCountText` and to confirm `assets` was added to `CONFIG` (no remaining occurrences of the undefined symbol).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a613d1e48326aa20fa1cc1438ce9)