### PR TITLE
Follow-up: rebind cinematic FX adapter when overlay layer is recreated

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -5274,8 +5274,15 @@
       renderSeatPortraits();
       const fxLayer = document.getElementById('cinematicFxLayer');
       if (app && fxLayer) {
-        if (!clusterCinematicFxRuntime.adapter) {
+        const shouldRebindAdapter = !clusterCinematicFxRuntime.adapter
+          || clusterCinematicFxRuntime.layerEl !== fxLayer
+          || clusterCinematicFxRuntime.appEl !== app;
+        if (shouldRebindAdapter) {
+          clusterCinematicFxRuntime.adapter?.clear?.();
           clusterCinematicFxRuntime.adapter = createClusterAnimationAdapter({ appEl: app, layerEl: fxLayer, stateRef: state });
+          clusterCinematicFxRuntime.layerEl = fxLayer;
+          clusterCinematicFxRuntime.appEl = app;
+          clusterCinematicFxRuntime.phaseKey = null;
         }
         const adapter = clusterCinematicFxRuntime.adapter;
         if (adapter) {
@@ -5667,6 +5674,8 @@
     const clusterCinematicFxRuntime = {
       adapter: null,
       phaseKey: null,
+      appEl: null,
+      layerEl: null,
     };
     function claimClusterAvatarAnchorForPlayer(playerId, root = document.getElementById('app')) {
       if (!root) return null;


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where cinematic FX shells were appended to a detached `#cinematicFxLayer` after `render()` replaced that DOM node, causing effects to disappear during normal gameplay rerenders. 

### Description
- Detect stale adapter bindings in `render()` by computing `shouldRebindAdapter` when `clusterCinematicFxRuntime.adapter` is missing or when the stored `appEl`/`layerEl` no longer match the current `#app`/`#cinematicFxLayer`. 
- Clear any prior adapter before recreating it and then create a fresh adapter via `createClusterAnimationAdapter({ appEl, layerEl, stateRef })`. 
- Store live `appEl` and `layerEl` references on `clusterCinematicFxRuntime` and reset `phaseKey` when rebinding so cinematic effects can respawn on the new layer. 
- Added `appEl` and `layerEl` fields to `clusterCinematicFxRuntime` to enable stale-reference detection. 

### Testing
- Ran `git diff --check` to verify no whitespace/patch issues and it succeeded. 
- Ran `git status --short` to confirm the modified file was staged/updated and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9f09d24c8326aa758d5f1491c024)