### PR TITLE
[PR #1019 Follow-up] Remove transparent shell class from cinematic text anchor

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -5113,7 +5113,7 @@
               </div>
               <div class="claimAvatarLocalOverlay" aria-hidden="true"></div>
             </div>
-            <div class="claimClusterTextAnchor ${claimClusterShellClass}" data-proj-id="claim-cinematic-text" style="${claimClusterElementStyle(claimClusterPolicy.elements.cinematicPane)}"></div>
+            <div class="claimClusterTextAnchor" data-proj-id="claim-cinematic-text" style="${claimClusterElementStyle(claimClusterPolicy.elements.cinematicPane)}"></div>
           </div>
         ` : ''}
         ${showLegacyActionFocus ? `


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where applying `${claimClusterShellClass}` to `.claimClusterTextAnchor` caused it to become `floatingTransparentShell` under `transparentShells`, which washed out cinematic pane and control surfaces during betting/reveal phases.

### Description
- Removed `${claimClusterShellClass}` from the `.claimClusterTextAnchor` element in `ScratchbonesBluffGame.html` so the text anchor no longer inherits the transparent shell styling.

### Testing
- Ran `git diff --check` (passed), verified the template now emits the `.claimClusterTextAnchor` without `${claimClusterShellClass}` using `rg -n "claimClusterTextAnchor" ScratchbonesBluffGame.html`, and confirmed the change was recorded with `git status --short`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac6837b688326abbc0b61a48bf6ca)