### PR TITLE
Fix challenge betting auto-reveal turn handoff

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -3285,15 +3285,20 @@
       return checkGameOverBySurvivors();
     }
     function maybeAutoRevealAfterMatchedBet() {
-      if (!state.betting) return;
+      if (!state.betting) return false;
       const a = state.betting.challengerId;
       const b = state.betting.challengedId;
       if (getContribution(a) === state.betting.stake && getContribution(b) === state.betting.stake) {
+        if (state.betting.pendingAutoReveal) return true;
+        state.betting.pendingAutoReveal = true;
         revealChallenge();
+        return true;
       }
+      return false;
     }
     function resolveBetAction(playerId, action) {
       if (!state.betting || state.gameOver) return;
+      if (state.betting.pendingAutoReveal) return;
       if (state.betting.currentActorId !== playerId) return;
       const command = typeof action === 'string' ? action : action?.type;
       const player = state.players[playerId];
@@ -3318,7 +3323,7 @@
           finalizeChallengeByFold(opponentId, playerId, 'could not cover the call');
           return;
         }
-        maybeAutoRevealAfterMatchedBet();
+        if (maybeAutoRevealAfterMatchedBet()) return;
         if (!state.betting) return;
         state.betting.currentActorId = opponentId;
         render();
@@ -3374,7 +3379,7 @@
               finalizeChallengeByFold(state.betting.challengedId, backupId, 'could not cover the backup call');
               return;
             }
-            maybeAutoRevealAfterMatchedBet();
+            if (maybeAutoRevealAfterMatchedBet()) return;
             if (!state.betting) return;
             state.betting.currentActorId = state.betting.challengedId;
             render();


### PR DESCRIPTION
### Motivation
- Traced the scratchbones challenge betting path from `startChallenge()` → `resolveBetAction()` → `revealChallenge()` and found the handoff after both sides matched stake could still schedule further betting actions leading to duplicate/late actions during the reveal window. (Fix is targeted at preventing actions submitted while auto-reveal is outstanding.)

### Description
- Changed `maybeAutoRevealAfterMatchedBet()` to return a boolean and mark `state.betting.pendingAutoReveal` when an auto-reveal is triggered to avoid duplicate triggers. 
- Added a guard in `resolveBetAction()` to ignore betting input while `pendingAutoReveal` is true. 
- Updated both the check/call path and the challenger-fold-with-backup path to short-circuit turn handoff when `maybeAutoRevealAfterMatchedBet()` indicates the reveal has been started. 
- Modified only `ScratchbonesBluffGame.html` to implement the above flow-control changes.

### Testing
- Ran lint: `npm run lint` — succeeded. 
- Ran unit tests: `npm run test:unit` — failed, but failures are from unrelated pre-existing tests in this branch (multiple suites), not due to the betting flow changes. The betting flow change was exercised in local inspection and static validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacddea2c083269210dd1bbf90a46b)