### PR TITLE
Add 'LIAR' challenge intro cinematic, configurable timers, and UI refinements

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -163,6 +163,9 @@
       --layout-cinematic-player-info-font: 1.05rem;
       --layout-cinematic-burst-font: 2rem;
       --layout-cinematic-burst-duration: 2.1s;
+      --layout-liar-burst-font: 3.2rem;
+      --layout-liar-burst-duration: 3.2s;
+      --layout-liar-burst-end-y: -180%;
       --layout-flame-x: 50%;
       --layout-flame-y: 14%;
       --layout-flame-core-alpha: 0.4;
@@ -471,6 +474,20 @@
       font-size: calc(var(--layout-cinematic-player-info-font) * 0.72);
       color: var(--accent);
     }
+    .claimAvatarNameTag {
+      position: absolute;
+      top: calc(100% + 10px);
+      left: 50%;
+      transform: translateX(-50%);
+      min-width: max-content;
+      pointer-events: none;
+      color: var(--accent-2);
+      font-weight: 800;
+      font-size: 1rem;
+      letter-spacing: 0.06em;
+      text-shadow: 0 2px 8px rgba(0,0,0,0.72);
+      z-index: 5;
+    }
     .claimClusterTextAnchor {
       pointer-events: none;
       overflow: visible;
@@ -589,16 +606,15 @@
       transform: scale(var(--layout-claim-avatar-zoom));
       transform-origin: center center;
     }
+    .claimAvatarShell.alert-pulse {
+      animation: claimGlowRed 0.8s ease-in-out infinite;
+    }
     .actorAvatarFloat canvas,
     .reactorAvatarFloat canvas {
       width: 100%;
       height: auto;
       aspect-ratio: 1;
       display: block;
-    }
-    .reactorAvatarFloat canvas {
-      transform: scaleX(-1);
-      transform-origin: center center;
     }
     .tableViewHeader {
       display: flex;
@@ -844,7 +860,21 @@
     .claimHandBar.glow-green .tableViewCard { animation: claimGlowGreen 1.5s ease-in-out 1 both; }
     .claimHandBar.glow-red .tableViewCard   { animation: claimGlowRed   0.8s ease-in-out 3 both; }
     .eliminated { opacity: 0.55; filter: grayscale(0.4); }
-    .seatPortrait { display: block; width: 100%; aspect-ratio: 1; height: auto; border-radius: 8px; }
+    .seatPortrait {
+      display: block;
+      width: 100%;
+      aspect-ratio: 1;
+      height: auto;
+      border-radius: 8px;
+      transform: scaleX(-1);
+      transform-origin: center center;
+    }
+    .actorAvatarFloat .seatPortrait {
+      transform: none;
+    }
+    .reactorAvatarFloat .seatPortrait {
+      transform: scaleX(-1);
+    }
     .controls {
       padding: calc(var(--layout-controls-padding-y) * var(--layout-challenge-gap-scale) * var(--layout-fit-gap-scale))
                calc(var(--layout-controls-padding-x) * var(--layout-challenge-gap-scale) * var(--layout-fit-gap-scale));
@@ -1556,6 +1586,12 @@
     .cin-action-burst.burst-call  { color: #88ccff; text-shadow: 0 0 14px rgba(100,180,255,0.9), 0 0 32px rgba(60,140,255,0.5); }
     .cin-action-burst.burst-raise { color: #f2d08f; text-shadow: 0 0 14px rgba(242,160,40,0.95), 0 0 32px rgba(200,110,10,0.6); }
     .cin-action-burst.burst-fold  { color: #ff9090; text-shadow: 0 0 14px rgba(255,70,70,0.95),  0 0 32px rgba(200,30,30,0.6); }
+    .cin-action-burst.burst-liar  {
+      color: #ff6f6f;
+      text-shadow: 0 0 16px rgba(255,70,70,0.98), 0 0 34px rgba(220,10,10,0.7);
+      font-size: var(--layout-liar-burst-font);
+      animation: cinBurstLiar var(--layout-liar-burst-duration) both;
+    }
     @keyframes cinBurst {
       0%   { transform: translate(-50%, -50%) scale(0.3);  opacity: 1;
              animation-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1); }
@@ -1564,6 +1600,15 @@
       67%  { transform: translate(-50%, -50%) scale(1.5);  opacity: 1;
              animation-timing-function: ease-in; }
       100% { transform: translate(-50%, -105%) scale(2.28); opacity: 0; }
+    }
+    @keyframes cinBurstLiar {
+      0%   { transform: translate(-50%, -50%) scale(0.3); opacity: 1;
+             animation-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1); }
+      20%  { transform: translate(-50%, -50%) scale(2.2); opacity: 1;
+             animation-timing-function: linear; }
+      82%  { transform: translate(-50%, -50%) scale(2.2); opacity: 1;
+             animation-timing-function: ease-in; }
+      100% { transform: translate(-50%, var(--layout-liar-burst-end-y)) scale(2.95); opacity: 0; }
     }
     .cin-reveal-label {
       position: absolute;
@@ -2177,6 +2222,7 @@
         },
         timers: {
           challengeTimerSecs: rawGameConfig.timers?.challengeSeconds ?? 6,
+          challengeIntroMs: rawGameConfig.timers?.challengeIntroMs ?? 2200,
           aiThinkMs: rawGameConfig.timers?.aiThinkMs ?? 650,
           aiDecisionDelays: {
             turnMinMs: rawGameConfig.timers?.aiDecisionDelays?.turnMinMs ?? 420,
@@ -2287,6 +2333,9 @@
               claimTitleScale: rawGameConfig.layout?.tableView?.cinematic?.claimTitleScale ?? 1.5,
               betActionBurstFontRem: rawGameConfig.layout?.tableView?.cinematic?.betActionBurstFontRem ?? 2,
               betActionBurstDurationSec: rawGameConfig.layout?.tableView?.cinematic?.betActionBurstDurationSec ?? 2.1,
+              liarBurstFontRem: rawGameConfig.layout?.tableView?.cinematic?.liarBurstFontRem ?? 3.2,
+              liarBurstDurationSec: rawGameConfig.layout?.tableView?.cinematic?.liarBurstDurationSec ?? 3.2,
+              liarBurstEndYPct: rawGameConfig.layout?.tableView?.cinematic?.liarBurstEndYPct ?? -180,
               betActionBurstClampInsetPx: rawGameConfig.layout?.tableView?.cinematic?.betActionBurstClampInsetPx ?? 24,
               revealDurationMs: rawGameConfig.layout?.tableView?.cinematic?.revealDurationMs ?? 4200,
               foldDurationMs: rawGameConfig.layout?.tableView?.cinematic?.foldDurationMs ?? 2600,
@@ -2307,6 +2356,9 @@
               enabled: rawGameConfig.layout?.regions?.contextBox?.enabled ?? true,
               sharedDeclareAndChallengeSlot: rawGameConfig.layout?.regions?.contextBox?.sharedDeclareAndChallengeSlot ?? true,
               mustStayVisible: rawGameConfig.layout?.regions?.contextBox?.mustStayVisible ?? true,
+            },
+            log: {
+              enabled: rawGameConfig.layout?.regions?.log?.enabled ?? false,
             },
           },
           claimCluster: {
@@ -2366,6 +2418,7 @@
           pickCardWarning: rawGameConfig.uiText?.pickCardWarning ?? 'Pick at least one card before playing.',
           challengeTimerLabel: rawGameConfig.uiText?.challengeTimerLabel ?? 'Auto: let it stand',
           challengePromptTemplate: rawGameConfig.uiText?.challengePromptTemplate ?? '{seat} declared {count} × {rank}. Challenge before the timer runs out, or let it stand.',
+          challengeBurstText: rawGameConfig.uiText?.challengeBurstText ?? 'LIAR!!!',
           letStandButton: rawGameConfig.uiText?.letStandButton ?? 'Let it stand',
         },
         assets: {
@@ -2862,6 +2915,8 @@
       challengeTimer: null,
       challengeTimeLeft: 0,
       challengeDecisionSession: 0,
+      challengeIntro: null,
+      challengeIntroTimeout: null,
       cinematicMode: null,
       cinematicTimeout: null,
       bettingUiDebugKey: null,
@@ -3042,6 +3097,7 @@
       state.pile = [];
       state.challengeWindow = null;
       state.betting = null;
+      clearChallengeIntro();
       state.declaredRank = null;
       state.gameOver = false;
       state.winnerIndex = null;
@@ -3363,12 +3419,22 @@
       const target = state.challengeWindow.lastPlay.playerIndex;
       advanceAfterNoChallenge(target);
     }
-    function startChallenge(challengerIndex, challengedIndex) {
-      if (!state.challengeWindow || state.gameOver || state.betting) return;
-      clearChallengeTimer();
+    function clearChallengeIntro() {
+      if (state.challengeIntroTimeout) {
+        clearTimeout(state.challengeIntroTimeout);
+        state.challengeIntroTimeout = null;
+      }
+      state.challengeIntro = null;
+    }
+    function startChallengeBetting(challengerIndex, challengedIndex) {
+      const play = state.challengeWindow?.lastPlay;
+      if (!play) {
+        clearChallengeIntro();
+        return;
+      }
+      clearChallengeIntro();
       SCRATCHBONES_AUDIO.playChallengeStart();
       SCRATCHBONES_AUDIO.startChallengeMusic();
-      const play = state.challengeWindow.lastPlay;
       addLog(`${seatLabel(challengerIndex)} challenges ${seatLabel(challengedIndex)}.`);
       state.betting = {
         play,
@@ -3393,6 +3459,24 @@
       setBanner(`${seatLabel(challengerIndex)} and ${seatLabel(challengedIndex)} are betting on the challenge.`);
       render();
       scheduleBettingAiIfNeeded();
+    }
+    function startChallenge(challengerIndex, challengedIndex) {
+      if (!state.challengeWindow || state.gameOver || state.betting) return;
+      clearChallengeTimer();
+      clearChallengeIntro();
+      state.challengeIntro = {
+        challengerId: challengerIndex,
+        challengedId: challengedIndex,
+        burstText: String(CONFIG.uiText?.challengeBurstText || 'LIAR!!!'),
+      };
+      setBanner(`${seatFirstName(challengerIndex)} calls liar! Challenge begins...`);
+      render();
+      const introMs = Math.max(0, Number(CONFIG.timers?.challengeIntroMs) || 2200);
+      state.challengeIntroTimeout = setTimeout(() => {
+        if (!state.challengeWindow || state.gameOver || state.betting) return;
+        if (!state.challengeIntro || state.challengeIntro.challengerId !== challengerIndex || state.challengeIntro.challengedId !== challengedIndex) return;
+        startChallengeBetting(challengerIndex, challengedIndex);
+      }, introMs);
     }
     function stakeTierValueById(tierId) {
       return STAKE_TIER_BY_ID[tierId]?.value ?? 0;
@@ -3796,6 +3880,7 @@
     function advanceAfterNoChallenge(lastPlayerIndex) {
       if (!state.challengeWindow || state.gameOver || state.betting) return;
       clearChallengeTimer();
+      clearChallengeIntro();
       state.challengeWindow = null;
       showClaimGlow('green', 1600, () => {
         if (state.gameOver) return;
@@ -3846,6 +3931,7 @@
       state.declaredRank = null;
       state.challengeWindow = null;
       state.betting = null;
+      clearChallengeIntro();
       state.round += 1;
       state.leaderIndex = playerIndex;
       state.currentTurn = playerIndex;
@@ -3864,6 +3950,7 @@
       state.declaredRank = null;
       state.challengeWindow = null;
       state.betting = null;
+      clearChallengeIntro();
       state.pile = [];
       state.roundConcessions.clear();
       state.round += 1;
@@ -4518,6 +4605,9 @@
           sharedDeclareAndChallengeSlot: layoutRegions.contextBox?.sharedDeclareAndChallengeSlot !== false,
           mustStayVisible: layoutRegions.contextBox?.mustStayVisible !== false,
         },
+        log: {
+          enabled: layoutRegions.log?.enabled === true,
+        },
       };
     }
     function getClaimClusterConfig() {
@@ -4592,6 +4682,7 @@
       const cinematicEnabled = tableViewLayout.cinematic?.enabled !== false;
       const actionColumnHeightScale = clampNumber(Number(layout.actionColumn?.heightScale) || 0.25, 0.1, 0.75);
       const controlsHeightScale = clampNumber(Number(layout.controls?.heightScale) || 0.5, 0.2, 0.9);
+      const logRegionEnabled = layoutRegions.log?.enabled === true;
       const root = document.documentElement;
       const cssTargets = [root, app];
       const setCssVar = (name, value) => {
@@ -4643,6 +4734,9 @@
       const claimTitleScale = clampNumber(Number(cinematicLayout.claimTitleScale) || 1.5, 0.6, 3.2);
       const cinematicBurstFontRem = clampNumber(Number(cinematicLayout.betActionBurstFontRem) || 2, 0.75, 5);
       const cinematicBurstDurationSec = clampNumber(Number(cinematicLayout.betActionBurstDurationSec) || 2.1, 0.4, 6);
+      const liarBurstFontRem = clampNumber(Number(cinematicLayout.liarBurstFontRem) || 3.2, 1, 7);
+      const liarBurstDurationSec = clampNumber(Number(cinematicLayout.liarBurstDurationSec) || 3.2, 0.6, 8);
+      const liarBurstEndYPct = clampNumber(Number(cinematicLayout.liarBurstEndYPct) || -180, -320, -110);
       const tabletopImageSrcRaw = String(backgroundLayout.tabletopImageSrc || '').trim();
       const tabletopImageSrc = tabletopImageSrcRaw.replace(/["\\]/g, '');
       const flameXPct = clampNumber(numberOrDefault(flameLighting.xPct, 0.5), 0, 1);
@@ -4709,6 +4803,9 @@
       setCssVar('--layout-claim-title-scale', claimTitleScale.toFixed(3));
       setCssVar('--layout-cinematic-burst-font', `${cinematicBurstFontRem.toFixed(3)}rem`);
       setCssVar('--layout-cinematic-burst-duration', `${cinematicBurstDurationSec.toFixed(3)}s`);
+      setCssVar('--layout-liar-burst-font', `${liarBurstFontRem.toFixed(3)}rem`);
+      setCssVar('--layout-liar-burst-duration', `${liarBurstDurationSec.toFixed(3)}s`);
+      setCssVar('--layout-liar-burst-end-y', `${liarBurstEndYPct.toFixed(2)}%`);
       setCssVar('--layout-ui-tabletop-url', tabletopImageSrc ? `url("${tabletopImageSrc}")` : 'none');
       setCssVar('--layout-flame-x', `${(flameXPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-y', `${(flameYPct * 100).toFixed(2)}%`);
@@ -4731,7 +4828,7 @@
       setCssVar('--layout-action-column-max-height', `${(actionColumnHeightScale * 100).toFixed(2)}%`);
       setCssVar('--layout-controls-max-height', `${(controlsHeightScale * 100).toFixed(2)}%`);
       setCssVar('--layout-hand-max-row-height', `${(handHeightScale * 100).toFixed(2)}%`);
-      setCssVar('--layout-log-max-row-height', `${(actionColumnHeightScale * 100).toFixed(2)}%`);
+      setCssVar('--layout-log-max-row-height', logRegionEnabled ? `${(actionColumnHeightScale * 100).toFixed(2)}%` : '0px');
       setCssVar('--hand-compact-card-min', `${Math.round(compactCardMinWidthPx)}px`);
       setCssVar('--hand-compact-card-gap', `${compactCardGapPx.toFixed(2)}px`);
       setCssVar('--hand-compact-card-min-height', `${Math.round(compactCardMinHeightPx)}px`);
@@ -5261,6 +5358,7 @@
       const turnSpotlightEmbedded = tableViewPolicy.turnSpotlight?.embedded !== false;
       const contextBoxEnabled = regionsPolicy.contextBox?.enabled;
       const sharedContextBox = regionsPolicy.contextBox?.sharedDeclareAndChallengeSlot;
+      const eventLogEnabled = regionsPolicy.log?.enabled === true;
       const showLegacyActionFocus = !claimClusterEnabled && !regionsPolicy.actionFocus?.replaceWithFloatingClaimCluster && regionsPolicy.actionFocus?.enabled;
       const tableCardVisualMode = tableViewPolicy.cardVisualMode || 'facedown';
       const tableCardFaceDown = tableCardVisualMode !== 'faceup';
@@ -5270,6 +5368,8 @@
       const cinematicFocusReactorId = Number.isInteger(cinematicMode?.reactorId) ? cinematicMode.reactorId : null;
       const cinematicRevealPlay = cinematicMode?.play || null;
       const cinematicRevealActive = cinematicPhase === 'reveal' && !!cinematicRevealPlay;
+      const challengeIntro = state.challengeIntro;
+      const challengeVisualsActive = !!(state.challengeWindow || state.betting || state.cinematicMode || challengeIntro);
       const claimFocus = (() => {
         if (!latestPlay) {
           return {
@@ -5281,10 +5381,10 @@
             subtext: 'Select cards and declare a number to begin the next claim.'
           };
         }
-        let actorId = (state.betting || state.challengeWindow) ? latestPlay.playerIndex : state.currentTurn;
+        let actorId = (state.betting || state.challengeWindow || challengeIntro) ? latestPlay.playerIndex : state.currentTurn;
         let reactorId = null;
         if (state.betting) reactorId = latestPlay.playerIndex === state.betting.challengerId ? state.betting.challengedId : state.betting.challengerId;
-        else if (state.challengeWindow) reactorId = latestPlay.playerIndex === 0 ? (state.challengeWindow.challengerOptions.find(id => id !== 0) ?? null) : 0;
+        else if (challengeIntro) reactorId = challengeIntro.challengerId;
         const declaredRank = latestPlay.declaredRank ?? state.declaredRank;
         const cardCount = latestPlay.cards?.length || 0;
         const cards = latestPlay.cards || [];
@@ -5324,7 +5424,7 @@
               return `<div class="tableViewCard" data-card-id="${card.id}"><img src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${tableCardFaceDown ? 'Face-down scratchbone card' : (card.wild ? 'Wild scratchbone card' : `Scratchbone ${card.rank} card`)}"></div>`;
             }).join(''))
         : '<div class="tiny">No cards on the table yet.</div>';
-      const recentLogs = state.logs.slice(0, 4);
+      const recentLogs = eventLogEnabled ? state.logs.slice(0, 4) : [];
       const turnPlayer = state.players[state.currentTurn];
       const turnSpotlightTitle = `${seatLabel(turnPlayer)}'s turn`;
       const renderDeclareControls = () => `
@@ -5480,12 +5580,15 @@
               <div class="claimAvatarShell">
                 <canvas class="seatPortrait" data-seat-id="${claimFocus.actorId}" width="220" height="220"></canvas>
               </div>
+              ${(!challengeVisualsActive && focusActor) ? `<div class="claimAvatarNameTag">${escapeHtml(seatFirstName(focusActor))}</div>` : ''}
               <div class="claimAvatarLocalOverlay" aria-hidden="true"></div>
             </div>
             <div class="reactorAvatarFloat ${claimClusterShellClass}" data-proj-id="claim-avatar-reactor" style="${claimClusterElementStyle(claimClusterPolicy.elements.reactorAvatarFloat)}" title="${focusReactor ? seatLabel(focusReactor) : 'No reactor'}">
-              <div class="claimAvatarShell">
+              <div class="claimAvatarShell ${(challengeIntro && focusReactor) ? 'alert-pulse' : ''}">
                 ${focusReactor ? `<canvas class="seatPortrait" data-seat-id="${focusReactor.id}" width="220" height="220"></canvas>` : ''}
               </div>
+              ${(!challengeVisualsActive && focusReactor) ? `<div class="claimAvatarNameTag">${escapeHtml(seatFirstName(focusReactor))}</div>` : ''}
+              ${(challengeIntro && focusReactor) ? `<div class="fx-burst-shell"><div class="cin-action-burst burst-liar">${escapeHtml(challengeIntro.burstText || 'LIAR!!!')}</div></div>` : ''}
               <div class="claimAvatarLocalOverlay" aria-hidden="true"></div>
             </div>
             <div class="claimClusterTextAnchor ${claimClusterShellClass}" data-proj-id="claim-cinematic-text" style="${claimClusterElementStyle(claimClusterPolicy.elements.cinematicPane)}"></div>
@@ -5537,10 +5640,12 @@
             </div>
           </div>
         </div>
-        <div class="eventLog fit-target fit-0" data-proj-id="log">
-          <div class="sectionTitle">Recent events</div>
-          ${recentLogs.map(item => `<div class="logItem">${escapeHtml(item.text)}</div>`).join('')}
-        </div>
+        ${eventLogEnabled ? `
+          <div class="eventLog fit-target fit-0" data-proj-id="log">
+            <div class="sectionTitle">Recent events</div>
+            ${recentLogs.map(item => `<div class="logItem">${escapeHtml(item.text)}</div>`).join('')}
+          </div>
+        ` : ''}
       `;
       if (state.declaredRank !== null) {
         const select = document.getElementById('declareRank');
@@ -5757,7 +5862,7 @@
       if ((!bettingModeActive) && state.cinematicMode?.mode === 'betting') {
         closeCinematic(false);
       }
-      const challengeVisualsActive = !!(state.challengeWindow || state.betting || state.cinematicMode);
+      const challengeVisualsActive = !!(state.challengeWindow || state.betting || state.cinematicMode || state.challengeIntro);
       const hadChallengeVisuals = app.classList.contains('challenge-visuals-active');
       app.classList.toggle('cinematic-mode-active', bettingModeActive || !!state.cinematicMode);
       app.classList.toggle('challenge-visuals-active', challengeVisualsActive);

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -121,6 +121,7 @@ window.SCRATCHBONES_CONFIG = {
     },
     "timers": {
       "challengeSeconds": 3,
+      "challengeIntroMs": 2200,
       "aiThinkMs": 650,
       "aiDecisionDelays": {
         "turnMinMs": 420,
@@ -239,6 +240,9 @@ window.SCRATCHBONES_CONFIG = {
           "claimTitleScale": 1.5,
           "betActionBurstFontRem": 2,
           "betActionBurstDurationSec": 2.1,
+          "liarBurstFontRem": 3.2,
+          "liarBurstDurationSec": 3.2,
+          "liarBurstEndYPct": -180,
           "betActionBurstClampInsetPx": 24,
           "revealDurationMs": 4200,
           "foldDurationMs": 2600
@@ -259,6 +263,9 @@ window.SCRATCHBONES_CONFIG = {
           "enabled": true,
           "sharedDeclareAndChallengeSlot": true,
           "mustStayVisible": true
+        },
+        "log": {
+          "enabled": false
         }
       },
       "claimCluster": {
@@ -793,6 +800,7 @@ window.SCRATCHBONES_CONFIG = {
       "pickCardWarning": "Pick at least one card before playing.",
       "challengeTimerLabel": "Auto: let it stand",
       "challengePromptTemplate": "{seat} declared {count} × {rank}. Challenge before the timer runs out, or let it stand.",
+      "challengeBurstText": "LIAR!!!",
       "letStandButton": "Let it stand"
     },
     "assets": {


### PR DESCRIPTION
### Motivation
- Introduce a short cinematic intro when a player issues a challenge so the challenge event feels more dramatic and configurable.
- Make the challenge intro visuals (burst text, timing, end position) and behavior configurable via the existing layout/timers/uiText config.
- Avoid visual noise by limiting a previously global red glow to only pulse during active challenge intro and provide better avatar mirroring and name-tag placement during non-challenge states.

### Description
- Added a challenge intro flow using new state fields `challengeIntro` and `challengeIntroTimeout`, plus helper `clearChallengeIntro`, and split `startChallenge` into an intro stage and `startChallengeBetting` to handle the delayed transition to betting.
- Added configurable timers and cinematic settings (`timers.challengeIntroMs`, `layout.cinematic.li arBurst*` options) and UI text `uiText.challengeBurstText` in `docs/config/scratchbones-config.js` and wired them into layout CSS variables (`--layout-liar-burst-*`).
- Implemented the liar/"LIAR!!!" burst visuals with new CSS variables, keyframes `cinBurstLiar`, and class `.cin-action-burst.burst-liar`, and render the burst over the reactor avatar during the intro; also added `.claimAvatarNameTag` and restricted `alert-pulse` to only apply during challenge intro.
- Updated avatar mirroring logic by moving `transform: scaleX(-1)` into `.seatPortrait` defaults and adding exceptions for `.actorAvatarFloat .seatPortrait` and `.reactorAvatarFloat .seatPortrait`, and added an optional `log` region toggle to control the event log rendering.

### Testing
- No automated tests were run for these UI and configuration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb250480dc8326a0feee50e75664a1)