### PR TITLE
Fix challenge intro re-entry race in LIAR cinematic flow

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -3376,7 +3376,7 @@
       return AI_THINK_MS;
     }
     function scheduleAiChallengeWindowDecisions(playerIndex) {
-      if (!state.challengeWindow || state.betting || state.gameOver) return;
+      if (!state.challengeWindow || state.betting || state.challengeIntro || state.gameOver) return;
       const lastPlay = state.challengeWindow.lastPlay;
       if (!lastPlay || lastPlay.playerIndex !== playerIndex) return;
       const possibleChallengers = state.challengeWindow.challengerOptions.filter(idx => idx !== 0 && !state.players[idx].eliminated);
@@ -3388,7 +3388,7 @@
         cumulativeDelay += thinkMs + staggerMs;
         setTimeout(() => {
           if (state.challengeDecisionSession !== challengeSessionId) return;
-          if (!state.challengeWindow || state.betting || state.gameOver) return;
+          if (!state.challengeWindow || state.betting || state.challengeIntro || state.gameOver) return;
           if (state.challengeWindow.lastPlay?.playerIndex !== playerIndex) return;
           if (aiShouldChallenge(idx, lastPlay)) {
             startChallenge(idx, playerIndex);
@@ -3398,21 +3398,21 @@
       if (playerIndex === 0) {
         setTimeout(() => {
           if (state.challengeDecisionSession !== challengeSessionId) return;
-          if (state.challengeWindow && !state.betting && !state.gameOver && state.challengeWindow.lastPlay?.playerIndex === playerIndex) {
+          if (state.challengeWindow && !state.betting && !state.challengeIntro && !state.gameOver && state.challengeWindow.lastPlay?.playerIndex === playerIndex) {
             advanceAfterNoChallenge(playerIndex);
           }
         }, cumulativeDelay + 30);
       }
     }
     function humanChallenge() {
-      if (!state.challengeWindow || state.gameOver || state.betting) return;
+      if (!state.challengeWindow || state.gameOver || state.betting || state.challengeIntro) return;
       const target = state.challengeWindow.lastPlay.playerIndex;
       if (target === 0) return;
       clearChallengeTimer();
       startChallenge(0, target);
     }
     function humanAcceptNoChallenge() {
-      if (!state.challengeWindow || state.gameOver || state.betting) return;
+      if (!state.challengeWindow || state.gameOver || state.betting || state.challengeIntro) return;
       clearChallengeTimer();
       const target = state.challengeWindow.lastPlay.playerIndex;
       advanceAfterNoChallenge(target);
@@ -3459,7 +3459,7 @@
       scheduleBettingAiIfNeeded();
     }
     function startChallenge(challengerIndex, challengedIndex) {
-      if (!state.challengeWindow || state.gameOver || state.betting) return;
+      if (!state.challengeWindow || state.gameOver || state.betting || state.challengeIntro) return;
       clearChallengeTimer();
       clearChallengeIntro();
       state.challengeIntro = {


### PR DESCRIPTION
### Motivation
- Prevent queued AI or additional human actions from re-entering and overwriting a pending challenge while the cinematic "LIAR" intro delay (`state.challengeIntro`) is active.

### Description
- Treat `state.challengeIntro` as an active-in-progress signal and add it to guards in `scheduleAiChallengeWindowDecisions` to stop delayed AI callbacks from starting a new challenge during the intro.
- Add `state.challengeIntro` checks to the delayed no-challenge auto-advance path so the intro cannot be bypassed while pending.
- Harden `humanChallenge` and `humanAcceptNoChallenge` to ignore input when an intro is active to avoid re-entry races from player actions.
- Harden `startChallenge` guard to reject new starts when `state.challengeIntro` is already set, ensuring a single challenger/challenged pair survives the intro timeout.

### Testing
- Ran `git diff --check` to validate the patch formatting and it passed.
- Ran `git status --short` to confirm only the intended file (`ScratchbonesBluffGame.html`) changed; no automated unit tests were executed for this UI/logic fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2b3799d08326895714f010962059)