### PR TITLE
Fix Scratchbones challenge sequencing and avatar role presentation

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -3392,6 +3392,7 @@
         setTimeout(() => {
           if (state.challengeDecisionSession !== challengeSessionId) return;
           if (!state.challengeWindow || state.betting || state.gameOver) return;
+          if (state.challengeIntro) return;
           if (state.challengeWindow.lastPlay?.playerIndex !== playerIndex) return;
           if (aiShouldChallenge(idx, lastPlay)) {
             startChallenge(idx, playerIndex);
@@ -3401,7 +3402,7 @@
       if (playerIndex === 0) {
         setTimeout(() => {
           if (state.challengeDecisionSession !== challengeSessionId) return;
-          if (state.challengeWindow && !state.betting && !state.gameOver && state.challengeWindow.lastPlay?.playerIndex === playerIndex) {
+          if (state.challengeWindow && !state.challengeIntro && !state.betting && !state.gameOver && state.challengeWindow.lastPlay?.playerIndex === playerIndex) {
             advanceAfterNoChallenge(playerIndex);
           }
         }, cumulativeDelay + 30);
@@ -3462,7 +3463,7 @@
       scheduleBettingAiIfNeeded();
     }
     function startChallenge(challengerIndex, challengedIndex) {
-      if (!state.challengeWindow || state.gameOver || state.betting) return;
+      if (!state.challengeWindow || state.gameOver || state.betting || state.challengeIntro) return;
       clearChallengeTimer();
       clearChallengeIntro();
       state.challengeIntro = {
@@ -5578,17 +5579,17 @@
             <div class="claimTimesBoxRight ${claimClusterShellClass}" data-proj-id="claim-times-right" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimTimesBoxRight)}">×</div>
             <div class="claimCountBoxRight ${claimClusterShellClass}" data-proj-id="claim-count-right" style="${claimClusterElementStyle(claimClusterPolicy.elements.claimCountBoxRight)}">${claimCount}</div>
             <div class="actorAvatarFloat ${claimClusterShellClass}" data-proj-id="claim-avatar-actor" style="${claimClusterElementStyle(claimClusterPolicy.elements.actorAvatarFloat)}" title="${seatLabel(focusActor || claimFocus.actorId)}">
-              <div class="claimAvatarShell">
+              <div class="claimAvatarShell ${(challengeIntro && focusActor) ? 'alert-pulse' : ''}">
                 <canvas class="seatPortrait" data-seat-id="${claimFocus.actorId}" width="220" height="220"></canvas>
               </div>
-              ${(!challengeVisualsActive && focusActor) ? `<div class="claimAvatarNameTag">${escapeHtml(seatFirstName(focusActor))}</div>` : ''}
+              ${focusActor ? `<div class="claimAvatarNameTag">${escapeHtml(seatFirstName(focusActor))}</div>` : ''}
               <div class="claimAvatarLocalOverlay" aria-hidden="true"></div>
             </div>
             <div class="reactorAvatarFloat ${claimClusterShellClass}" data-proj-id="claim-avatar-reactor" style="${claimClusterElementStyle(claimClusterPolicy.elements.reactorAvatarFloat)}" title="${focusReactor ? seatLabel(focusReactor) : 'No reactor'}">
-              <div class="claimAvatarShell ${(challengeIntro && focusReactor) ? 'alert-pulse' : ''}">
+              <div class="claimAvatarShell">
                 ${focusReactor ? `<canvas class="seatPortrait" data-seat-id="${focusReactor.id}" width="220" height="220"></canvas>` : ''}
               </div>
-              ${(!challengeVisualsActive && focusReactor) ? `<div class="claimAvatarNameTag">${escapeHtml(seatFirstName(focusReactor))}</div>` : ''}
+              ${focusReactor ? `<div class="claimAvatarNameTag">${escapeHtml(seatFirstName(focusReactor))}</div>` : ''}
               ${(challengeIntro && focusReactor) ? `<div class="fx-burst-shell"><div class="cin-action-burst burst-liar">${escapeHtml(challengeIntro.burstText || 'LIAR!!!')}</div></div>` : ''}
               <div class="claimAvatarLocalOverlay" aria-hidden="true"></div>
             </div>
@@ -5855,8 +5856,10 @@
       const bettingModeActive = !!(state.betting && !state.gameOver && isTableCinematicEnabled());
       if (bettingModeActive && !state.cinematicMode) {
         setCinematicMode('betting', {
-          actorId: state.betting.challengerId,
-          reactorId: state.betting.challengedId,
+          actorId: state.betting.challengedId,
+          reactorId: state.betting.challengerId,
+          actorRole: 'Challenged',
+          reactorRole: 'Challenger',
           headline: '⚔ Challenge betting',
         });
       }
@@ -5965,12 +5968,12 @@
     function mountActorAvatarCinematic(app, cinematicMode) {
       const anchor = app?.querySelector('.actorAvatarFloat');
       if (!anchor) return;
-      mountAvatarCinematic(anchor, cinematicMode?.actorId, 'Challenger');
+      mountAvatarCinematic(anchor, cinematicMode?.actorId, cinematicMode?.actorRole || 'Challenger');
     }
     function mountReactorAvatarCinematic(app, cinematicMode) {
       const anchor = app?.querySelector('.reactorAvatarFloat');
       if (!anchor) return;
-      mountAvatarCinematic(anchor, cinematicMode?.reactorId, 'Challenged');
+      mountAvatarCinematic(anchor, cinematicMode?.reactorId, cinematicMode?.reactorRole || 'Challenged');
     }
     function mountClaimHandCinematic(app, { cinematicPhase, cinematicMode, cinematicRevealPlay }) {
       const claimHandAnchor = app?.querySelector('.claimHandBar');
@@ -6156,8 +6159,10 @@
       setCinematicMode('reveal', {
         challengerId: challengerIndex,
         challengedId: challengedIndex,
-        actorId: challengerIndex,
-        reactorId: challengedIndex,
+        actorId: challengedIndex,
+        reactorId: challengerIndex,
+        actorRole: 'Challenged',
+        reactorRole: 'Challenger',
         winnerId,
         loserId,
         play,
@@ -6180,8 +6185,10 @@
         loserId,
         challengerId: state.betting?.challengerId ?? winnerId,
         challengedId: state.betting?.challengedId ?? loserId,
-        actorId: state.betting?.challengerId ?? winnerId,
-        reactorId: state.betting?.challengedId ?? loserId,
+        actorId: state.betting?.challengedId ?? loserId,
+        reactorId: state.betting?.challengerId ?? winnerId,
+        actorRole: 'Challenged',
+        reactorRole: 'Challenger',
         headline: '🏳 Fold',
       }, {
         onClose,


### PR DESCRIPTION
### Motivation
- Prevent NPCs from stacking multiple delayed challenge triggers and blocking the betting flow during the challenge window. 
- Ensure the cinematic/claim-cluster visuals match the intended left/right semantics (challenged on left, challenger on right) and make avatar labels visible and accurate during challenge visuals.

### Description
- Added guard in `scheduleAiChallengeWindowDecisions` to short-circuit delayed AI callbacks when a `state.challengeIntro` is active to stop overlapping AI challenge triggers. 
- Added a guard to `startChallenge` so a challenge intro cannot be started while another intro is active. 
- Prevented the auto "no challenge" advancement from executing when a challenge intro is active by checking `state.challengeIntro` before calling `advanceAfterNoChallenge`. 
- Restored avatar name tags during challenge visuals by rendering name tags whenever the actor/reactor exists. 
- Moved the intro alert pulse to the challenged avatar and kept the `LIAR!!!` burst emitted from the challenger. 
- Swapped cinematic role mapping and made role labels payload-driven so the challenged is presented on the left and the challenger on the right across betting/reveal/fold phases. 
- Changes are limited to `ScratchbonesBluffGame.html`.

### Testing
- Ran unit tests via `npm run test:unit`; the command completed but the repository baseline contains unrelated failing tests (report shows multiple pre-existing failures), so the test run reported failures not caused by this change. 
- Manual code review and local render hooks added (`render()` call points) to validate the visual role/label mapping and the challenge sequencing logic. 
- No visual screenshots were produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2d8eb61083268c16a3ab4866afd3)