### PR TITLE
Fix Scratchbones depth config zero-values and retune card camera defaults

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -172,22 +172,12 @@
       --layout-flame-mid-alpha: 0.27;
       --layout-flame-far-alpha: 0.14;
       --layout-flame-flicker-seconds: 2.9s;
-      --layout-card-perspective: 620px;
-      --layout-card-perspective-origin-x: 50%;
-      --layout-card-perspective-origin-y: 92%;
-      --layout-card-tilt-x: 8deg;
-      --layout-card-depth-z: 18px;
-      --layout-card-art-z: 6px;
-      --layout-card-shape-extrude: 4px;
-      --layout-card-shape-shadow-alpha: 0.32;
-      --layout-card-shape-layer-offset-x: 0.32px;
-      --layout-card-shape-layer-offset-y: 1.05px;
-      --layout-card-shape-layer-skew-x: -0.35deg;
-      --layout-card-shape-layer-alpha: 0.14;
-      --layout-card-bottom-layer-offset-x: 1.1px;
-      --layout-card-bottom-layer-offset-y: 4.2px;
-      --layout-card-bottom-layer-skew-x: -1.8deg;
-      --layout-card-bottom-layer-alpha: 0.34;
+      --layout-card-shadow-offset-x: 2px;
+      --layout-card-shadow-offset-y: 18px;
+      --layout-card-shadow-blur: 24px;
+      --layout-card-shadow-spread: -6px;
+      --layout-card-shadow-alpha: 0.44;
+      --layout-card-shadow-contact-alpha: 0.28;
     }
     * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
     html, body { margin: 0; background: transparent; color: var(--text); font-family: 'Khymeryyanroman4', Inter, system-ui, sans-serif; letter-spacing: 0.10em; height: 100%; }
@@ -229,9 +219,6 @@
       background-position: center center;
       background-repeat: no-repeat;
       background-size: 100% 100%;
-      perspective: var(--layout-card-perspective);
-      perspective-origin: var(--layout-card-perspective-origin-x) var(--layout-card-perspective-origin-y);
-      transform-style: preserve-3d;
       display: grid;
       container-type: size;
       grid-template-columns: minmax(0, 1fr) minmax(220px, 0.4fr) var(--layout-sidebar-width);
@@ -652,7 +639,9 @@
       border-radius: 0;
       border: 0;
       background: transparent;
-      box-shadow: none;
+      box-shadow:
+        var(--layout-card-shadow-offset-x) var(--layout-card-shadow-offset-y) var(--layout-card-shadow-blur) var(--layout-card-shadow-spread) rgba(0, 0, 0, var(--layout-card-shadow-alpha)),
+        calc(var(--layout-card-shadow-offset-x) * 0.4) calc(var(--layout-card-shadow-offset-y) * 0.34) calc(var(--layout-card-shadow-blur) * 0.56) calc(var(--layout-card-shadow-spread) * 0.72) rgba(0, 0, 0, var(--layout-card-shadow-contact-alpha));
       overflow: hidden;
       flex: 0 1 auto;
       max-width: 100%;
@@ -975,16 +964,16 @@
       color: var(--card-text);
       border: 3px solid transparent;
       border-radius: 0;
-      box-shadow: none;
+      box-shadow:
+        var(--layout-card-shadow-offset-x) var(--layout-card-shadow-offset-y) var(--layout-card-shadow-blur) var(--layout-card-shadow-spread) rgba(0, 0, 0, var(--layout-card-shadow-alpha)),
+        calc(var(--layout-card-shadow-offset-x) * 0.4) calc(var(--layout-card-shadow-offset-y) * 0.34) calc(var(--layout-card-shadow-blur) * 0.56) calc(var(--layout-card-shadow-spread) * 0.72) rgba(0, 0, 0, var(--layout-card-shadow-contact-alpha));
       display: flex;
       align-items: stretch;
       justify-content: stretch;
       position: relative;
       overflow: hidden;
       isolation: isolate;
-      transform: translateY(var(--card-lift-y)) translateZ(var(--layout-card-depth-z)) rotateX(var(--layout-card-tilt-x));
-      transform-origin: 50% 56%;
-      transform-style: preserve-3d;
+      transform: translateY(var(--card-lift-y));
       transition: transform 140ms ease-out, filter 140ms ease-out;
     }
     .card.selected { --card-lift-y: -4px; border-color: transparent; }
@@ -999,70 +988,9 @@
     }
     .card.selected .cardArt {
       filter:
-        drop-shadow(0 calc(var(--layout-card-shape-extrude) * 0.45) 0 rgba(0, 0, 0, var(--layout-card-shape-shadow-alpha)))
-        drop-shadow(0 calc(var(--layout-card-shape-extrude) * 0.9) calc(var(--layout-card-shape-extrude) * 0.95) rgba(0, 0, 0, calc(var(--layout-card-shape-shadow-alpha) * 0.76)))
         drop-shadow(0 0 1px rgba(98, 176, 255, 0.95))
         drop-shadow(0 0 4px rgba(98, 176, 255, 0.85))
         drop-shadow(0 0 9px rgba(98, 176, 255, 0.72));
-    }
-    .cardDepthStack {
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      transform: translateZ(calc(var(--layout-card-art-z) - 1px));
-      transform-origin: center;
-    }
-    .cardDepthBase {
-      position: absolute;
-      inset: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
-      object-position: center;
-      pointer-events: none;
-      opacity: var(--layout-card-bottom-layer-alpha);
-      filter: brightness(0.06) saturate(0.35);
-      transform:
-        translate(var(--layout-card-bottom-layer-offset-x), var(--layout-card-bottom-layer-offset-y))
-        skewX(var(--layout-card-bottom-layer-skew-x));
-      transform-origin: center;
-    }
-    .cardDepthLayer {
-      position: absolute;
-      inset: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
-      object-position: center;
-      pointer-events: none;
-      opacity: 0;
-      transform-origin: center;
-      filter: brightness(0.04) saturate(0.25);
-      transform:
-        translate(
-          calc(var(--layout-card-shape-layer-offset-x) * var(--depth-layer-index)),
-          calc(var(--layout-card-shape-layer-offset-y) * var(--depth-layer-index))
-        )
-        skewX(calc(var(--layout-card-shape-layer-skew-x) * var(--depth-layer-index)));
-    }
-    .cardDepthLayer[data-depth-layer="1"] { opacity: var(--layout-card-shape-layer-alpha); }
-    .cardDepthLayer[data-depth-layer="2"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.92); }
-    .cardDepthLayer[data-depth-layer="3"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.86); }
-    .cardDepthLayer[data-depth-layer="4"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.80); }
-    .cardDepthLayer[data-depth-layer="5"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.74); }
-    .cardDepthLayer[data-depth-layer="6"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.68); }
-    .cardDepthLayer[data-depth-layer="7"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.62); }
-    .cardDepthLayer[data-depth-layer="8"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.56); }
-    .card[data-depth-layers="0"] .cardDepthStack,
-    .card[data-depth-layers="1"] .cardDepthLayer:nth-child(n+2),
-    .card[data-depth-layers="2"] .cardDepthLayer:nth-child(n+3),
-    .card[data-depth-layers="3"] .cardDepthLayer:nth-child(n+4),
-    .card[data-depth-layers="4"] .cardDepthLayer:nth-child(n+5),
-    .card[data-depth-layers="5"] .cardDepthLayer:nth-child(n+6),
-    .card[data-depth-layers="6"] .cardDepthLayer:nth-child(n+7),
-    .card[data-depth-layers="7"] .cardDepthLayer:nth-child(n+8),
-    .card[data-depth-layers="8"] .cardDepthLayer:nth-child(n+9) {
-      display: none;
     }
     .cardArt {
       width: 100%;
@@ -1072,11 +1000,7 @@
       display: block;
       border-radius: 0;
       pointer-events: none;
-      transform: translateZ(var(--layout-card-art-z));
-      transform-origin: center;
-      filter:
-        drop-shadow(0 calc(var(--layout-card-shape-extrude) * 0.45) 0 rgba(0, 0, 0, var(--layout-card-shape-shadow-alpha)))
-        drop-shadow(0 calc(var(--layout-card-shape-extrude) * 0.9) calc(var(--layout-card-shape-extrude) * 0.95) rgba(0, 0, 0, calc(var(--layout-card-shape-shadow-alpha) * 0.76)));
+      filter: none;
     }
     .cardLabel {
       position: absolute;
@@ -1095,7 +1019,7 @@
       line-height: 1.1;
       letter-spacing: 0.04em;
       pointer-events: none;
-      transform: translateZ(calc(var(--layout-card-art-z) + 1px));
+      transform: none;
     }
     .cardGlyph {
       display: inline-flex;
@@ -2338,24 +2262,13 @@
           },
           cards: {
             baseScale: rawGameConfig.layout?.cards?.baseScale ?? 0.25,
-            depth: {
-              perspectivePx: rawGameConfig.layout?.cards?.depth?.perspectivePx ?? 620,
-              originXPct: rawGameConfig.layout?.cards?.depth?.originXPct ?? 0.5,
-              originYPct: rawGameConfig.layout?.cards?.depth?.originYPct ?? 0.92,
-              tiltXDeg: rawGameConfig.layout?.cards?.depth?.tiltXDeg ?? 8,
-              depthZPx: rawGameConfig.layout?.cards?.depth?.depthZPx ?? 18,
-              artLiftZPx: rawGameConfig.layout?.cards?.depth?.artLiftZPx ?? 6,
-              shapeExtrudePx: rawGameConfig.layout?.cards?.depth?.shapeExtrudePx ?? 4,
-              shapeShadowAlpha: rawGameConfig.layout?.cards?.depth?.shapeShadowAlpha ?? 0.32,
-              shapeLayerCount: rawGameConfig.layout?.cards?.depth?.shapeLayerCount ?? 4,
-              shapeLayerOffsetXPx: rawGameConfig.layout?.cards?.depth?.shapeLayerOffsetXPx ?? 0.32,
-              shapeLayerOffsetYPx: rawGameConfig.layout?.cards?.depth?.shapeLayerOffsetYPx ?? 1.05,
-              shapeLayerSkewXDeg: rawGameConfig.layout?.cards?.depth?.shapeLayerSkewXDeg ?? -0.35,
-              shapeLayerAlpha: rawGameConfig.layout?.cards?.depth?.shapeLayerAlpha ?? 0.14,
-              bottomLayerOffsetXPx: rawGameConfig.layout?.cards?.depth?.bottomLayerOffsetXPx ?? 1.1,
-              bottomLayerOffsetYPx: rawGameConfig.layout?.cards?.depth?.bottomLayerOffsetYPx ?? 4.2,
-              bottomLayerSkewXDeg: rawGameConfig.layout?.cards?.depth?.bottomLayerSkewXDeg ?? -1.8,
-              bottomLayerAlpha: rawGameConfig.layout?.cards?.depth?.bottomLayerAlpha ?? 0.34,
+            shadow: {
+              offsetXPx: rawGameConfig.layout?.cards?.shadow?.offsetXPx ?? 2,
+              offsetYPx: rawGameConfig.layout?.cards?.shadow?.offsetYPx ?? 18,
+              blurPx: rawGameConfig.layout?.cards?.shadow?.blurPx ?? 24,
+              spreadPx: rawGameConfig.layout?.cards?.shadow?.spreadPx ?? -6,
+              alpha: rawGameConfig.layout?.cards?.shadow?.alpha ?? 0.44,
+              contactAlpha: rawGameConfig.layout?.cards?.shadow?.contactAlpha ?? 0.28,
             },
           },
           animation: {
@@ -4390,19 +4303,6 @@
     function cardLabel(card) {
       return card.wild ? 'Wild' : String(card.rank);
     }
-    function renderCardDepthLayers(art, flippedArt, layerCount) {
-      const safeLayerCount = Math.max(0, Math.min(8, Number(layerCount) || 0));
-      const hasFlippedArt = Boolean(flippedArt?.src && flippedArt?.fallbackSrc);
-      if (safeLayerCount < 1 && !hasFlippedArt) return '';
-      const layers = [];
-      if (hasFlippedArt) {
-        layers.push(`<img class="cardDepthBase" src="${flippedArt.src}" data-fallback-src="${flippedArt.fallbackSrc}" alt="" aria-hidden="true">`);
-      }
-      for (let index = 1; index <= safeLayerCount; index += 1) {
-        layers.push(`<img class="cardDepthLayer" data-depth-layer="${index}" style="--depth-layer-index:${index};" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="" aria-hidden="true">`);
-      }
-      return `<span class="cardDepthStack" aria-hidden="true">${layers.join('')}</span>`;
-    }
     function normalizedAssetPath(basePath, fileName) {
       const safeBase = String(basePath || '').replace(/\/+$/, '');
       const safeFile = String(fileName || '').replace(/^\/+/, '');
@@ -4761,7 +4661,7 @@
       const claimCluster = getClaimClusterConfig();
       const layoutSizing = layout.sizing || {};
       const layoutCards = layout.cards || {};
-      const layoutCardDepth = layoutCards.depth || {};
+      const layoutCardShadow = layoutCards.shadow || {};
       const viewportLayout = layout.viewport || {};
       const handLayout = layout.hand || {};
       const tableViewLayout = layout.tableView || {};
@@ -4773,22 +4673,12 @@
         return Number.isFinite(numericValue) ? numericValue : fallback;
       };
       const cardBaseScale = clampNumber(Number(layoutCards.baseScale) || 0.25, 0.1, 0.75);
-      const cardPerspectivePx = clampNumber(numberOrDefault(layoutCardDepth.perspectivePx, 620), 420, 3000);
-      const cardPerspectiveOriginXPct = clampNumber(numberOrDefault(layoutCardDepth.originXPct, 0.5), -0.2, 1.2);
-      const cardPerspectiveOriginYPct = clampNumber(numberOrDefault(layoutCardDepth.originYPct, 0.92), 0.8, 1.8);
-      const cardTiltXDeg = clampNumber(numberOrDefault(layoutCardDepth.tiltXDeg, 8), -8, 30);
-      const cardDepthZPx = clampNumber(numberOrDefault(layoutCardDepth.depthZPx, 18), -24, 60);
-      const cardArtLiftZPx = clampNumber(numberOrDefault(layoutCardDepth.artLiftZPx, 6), -8, 28);
-      const cardShapeExtrudePx = clampNumber(numberOrDefault(layoutCardDepth.shapeExtrudePx, 4), 0, 16);
-      const cardShapeShadowAlpha = clampNumber(numberOrDefault(layoutCardDepth.shapeShadowAlpha, 0.32), 0, 0.9);
-      const cardShapeLayerOffsetXPx = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerOffsetXPx, 0.32), -4, 4);
-      const cardShapeLayerOffsetYPx = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerOffsetYPx, 1.05), -6, 8);
-      const cardShapeLayerSkewXDeg = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerSkewXDeg, -0.35), -4, 4);
-      const cardShapeLayerAlpha = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerAlpha, 0.14), 0, 0.6);
-      const cardBottomLayerOffsetXPx = clampNumber(numberOrDefault(layoutCardDepth.bottomLayerOffsetXPx, 1.1), -6, 8);
-      const cardBottomLayerOffsetYPx = clampNumber(numberOrDefault(layoutCardDepth.bottomLayerOffsetYPx, 4.2), -8, 16);
-      const cardBottomLayerSkewXDeg = clampNumber(numberOrDefault(layoutCardDepth.bottomLayerSkewXDeg, -1.8), -8, 8);
-      const cardBottomLayerAlpha = clampNumber(numberOrDefault(layoutCardDepth.bottomLayerAlpha, 0.34), 0, 0.95);
+      const cardShadowOffsetXPx = clampNumber(numberOrDefault(layoutCardShadow.offsetXPx, 2), -24, 24);
+      const cardShadowOffsetYPx = clampNumber(numberOrDefault(layoutCardShadow.offsetYPx, 18), 0, 48);
+      const cardShadowBlurPx = clampNumber(numberOrDefault(layoutCardShadow.blurPx, 24), 0, 64);
+      const cardShadowSpreadPx = clampNumber(numberOrDefault(layoutCardShadow.spreadPx, -6), -24, 24);
+      const cardShadowAlpha = clampNumber(numberOrDefault(layoutCardShadow.alpha, 0.44), 0, 0.9);
+      const cardShadowContactAlpha = clampNumber(numberOrDefault(layoutCardShadow.contactAlpha, 0.28), 0, 0.9);
       const desiredHeightFrac = clampNumber(Number(handLayout.desiredHeightFrac) || 0.20, 0.08, 0.60);
       const handHeightScale = clampNumber(Number(handLayout.heightScale) || 0.5, 0.2, 0.75);
       const configuredHandMinHeightPx = Math.max(80, Number(handLayout.minHeightPx) || 160);
@@ -4926,22 +4816,12 @@
       setCssVar('--layout-liar-burst-duration', `${liarBurstDurationSec.toFixed(3)}s`);
       setCssVar('--layout-liar-burst-end-y', `${liarBurstEndYPct.toFixed(2)}%`);
       setCssVar('--layout-ui-tabletop-url', tabletopImageSrc ? `url("${tabletopImageSrc}")` : 'none');
-      setCssVar('--layout-card-perspective', `${cardPerspectivePx.toFixed(2)}px`);
-      setCssVar('--layout-card-perspective-origin-x', `${(cardPerspectiveOriginXPct * 100).toFixed(2)}%`);
-      setCssVar('--layout-card-perspective-origin-y', `${(cardPerspectiveOriginYPct * 100).toFixed(2)}%`);
-      setCssVar('--layout-card-tilt-x', `${cardTiltXDeg.toFixed(2)}deg`);
-      setCssVar('--layout-card-depth-z', `${cardDepthZPx.toFixed(2)}px`);
-      setCssVar('--layout-card-art-z', `${cardArtLiftZPx.toFixed(2)}px`);
-      setCssVar('--layout-card-shape-extrude', `${cardShapeExtrudePx.toFixed(2)}px`);
-      setCssVar('--layout-card-shape-shadow-alpha', cardShapeShadowAlpha.toFixed(3));
-      setCssVar('--layout-card-shape-layer-offset-x', `${cardShapeLayerOffsetXPx.toFixed(2)}px`);
-      setCssVar('--layout-card-shape-layer-offset-y', `${cardShapeLayerOffsetYPx.toFixed(2)}px`);
-      setCssVar('--layout-card-shape-layer-skew-x', `${cardShapeLayerSkewXDeg.toFixed(2)}deg`);
-      setCssVar('--layout-card-shape-layer-alpha', cardShapeLayerAlpha.toFixed(3));
-      setCssVar('--layout-card-bottom-layer-offset-x', `${cardBottomLayerOffsetXPx.toFixed(2)}px`);
-      setCssVar('--layout-card-bottom-layer-offset-y', `${cardBottomLayerOffsetYPx.toFixed(2)}px`);
-      setCssVar('--layout-card-bottom-layer-skew-x', `${cardBottomLayerSkewXDeg.toFixed(2)}deg`);
-      setCssVar('--layout-card-bottom-layer-alpha', cardBottomLayerAlpha.toFixed(3));
+      setCssVar('--layout-card-shadow-offset-x', `${cardShadowOffsetXPx.toFixed(2)}px`);
+      setCssVar('--layout-card-shadow-offset-y', `${cardShadowOffsetYPx.toFixed(2)}px`);
+      setCssVar('--layout-card-shadow-blur', `${cardShadowBlurPx.toFixed(2)}px`);
+      setCssVar('--layout-card-shadow-spread', `${cardShadowSpreadPx.toFixed(2)}px`);
+      setCssVar('--layout-card-shadow-alpha', cardShadowAlpha.toFixed(3));
+      setCssVar('--layout-card-shadow-contact-alpha', cardShadowContactAlpha.toFixed(3));
       setCssVar('--layout-flame-x', `${(flameXPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-y', `${(flameYPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-core-alpha', flameCoreAlpha.toFixed(3));
@@ -5757,13 +5637,10 @@
           <div class="handScroll">
               ${player.hand.map(card => {
                 const art = resolveScratchbone2DAsset(card);
-                const flippedArt = resolveScratchbone2DAsset(card, { flipped: true });
                 const cardLabel = card.wild ? 'Wild' : `Rank ${card.rank}`;
                 const cardGlyph = card.wild ? 'W' : String(card.rank);
-                const cardDepthLayerCount = Math.max(0, Math.min(8, Number(SCRATCHBONES_GAME.layout?.cards?.depth?.shapeLayerCount) || 0));
                 return `
-                <button class="card ${card.wild ? 'wild' : ''} ${state.selectedCardIds.has(card.id) ? 'selected' : ''}" data-card-id="${card.id}" data-depth-layers="${cardDepthLayerCount}" title="${card.wild ? 'Wild card' : `Scratchbone ${card.rank}`}">
-                  ${renderCardDepthLayers(art, flippedArt, cardDepthLayerCount)}
+                <button class="card ${card.wild ? 'wild' : ''} ${state.selectedCardIds.has(card.id) ? 'selected' : ''}" data-card-id="${card.id}" title="${card.wild ? 'Wild card' : `Scratchbone ${card.rank}`}">
                   <img class="cardArt" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${card.wild ? 'Wild scratchbone card' : `Scratchbone ${card.rank} card`}">
                   <span class="cardLabel" aria-hidden="true"><span class="cardGlyph">${cardGlyph}</span><span class="cardText">${cardLabel}</span></span>
                 </button>

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -172,18 +172,14 @@
       --layout-flame-mid-alpha: 0.27;
       --layout-flame-far-alpha: 0.14;
       --layout-flame-flicker-seconds: 2.9s;
-      --layout-card-shadow-offset-x: 1.5px;
-      --layout-card-shadow-offset-y: 9px;
-      --layout-card-shadow-blur: 12px;
-      --layout-card-shadow-spread: -2px;
-      --layout-card-shadow-alpha: 0.34;
-      --layout-card-contact-alpha: 0.2;
       --layout-card-perspective: 900px;
       --layout-card-perspective-origin-x: 50%;
       --layout-card-perspective-origin-y: 92%;
       --layout-card-tilt-x: 8deg;
       --layout-card-depth-z: 18px;
       --layout-card-art-z: 6px;
+      --layout-card-shape-extrude: 4px;
+      --layout-card-shape-shadow-alpha: 0.32;
     }
     * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
     html, body { margin: 0; background: transparent; color: var(--text); font-family: 'Khymeryyanroman4', Inter, system-ui, sans-serif; letter-spacing: 0.10em; height: 100%; }
@@ -971,9 +967,7 @@
       color: var(--card-text);
       border: 3px solid transparent;
       border-radius: 0;
-      box-shadow:
-        var(--layout-card-shadow-offset-x) var(--layout-card-shadow-offset-y) var(--layout-card-shadow-blur) var(--layout-card-shadow-spread) rgba(0, 0, 0, var(--layout-card-shadow-alpha)),
-        calc(var(--layout-card-shadow-offset-x) * 0.35) calc(var(--layout-card-shadow-offset-y) * 0.35) calc(var(--layout-card-shadow-blur) * 0.35) calc(var(--layout-card-shadow-spread) * 0.6) rgba(0, 0, 0, var(--layout-card-contact-alpha));
+      box-shadow: none;
       display: flex;
       align-items: stretch;
       justify-content: stretch;
@@ -997,6 +991,8 @@
     }
     .card.selected .cardArt {
       filter:
+        drop-shadow(0 calc(var(--layout-card-shape-extrude) * 0.45) 0 rgba(0, 0, 0, var(--layout-card-shape-shadow-alpha)))
+        drop-shadow(0 calc(var(--layout-card-shape-extrude) * 0.9) calc(var(--layout-card-shape-extrude) * 0.95) rgba(0, 0, 0, calc(var(--layout-card-shape-shadow-alpha) * 0.76)))
         drop-shadow(0 0 1px rgba(98, 176, 255, 0.95))
         drop-shadow(0 0 4px rgba(98, 176, 255, 0.85))
         drop-shadow(0 0 9px rgba(98, 176, 255, 0.72));
@@ -1011,6 +1007,9 @@
       pointer-events: none;
       transform: translateZ(var(--layout-card-art-z));
       transform-origin: center;
+      filter:
+        drop-shadow(0 calc(var(--layout-card-shape-extrude) * 0.45) 0 rgba(0, 0, 0, var(--layout-card-shape-shadow-alpha)))
+        drop-shadow(0 calc(var(--layout-card-shape-extrude) * 0.9) calc(var(--layout-card-shape-extrude) * 0.95) rgba(0, 0, 0, calc(var(--layout-card-shape-shadow-alpha) * 0.76)));
     }
     .cardLabel {
       position: absolute;
@@ -2279,6 +2278,8 @@
               tiltXDeg: rawGameConfig.layout?.cards?.depth?.tiltXDeg ?? 8,
               depthZPx: rawGameConfig.layout?.cards?.depth?.depthZPx ?? 18,
               artLiftZPx: rawGameConfig.layout?.cards?.depth?.artLiftZPx ?? 6,
+              shapeExtrudePx: rawGameConfig.layout?.cards?.depth?.shapeExtrudePx ?? 4,
+              shapeShadowAlpha: rawGameConfig.layout?.cards?.depth?.shapeShadowAlpha ?? 0.32,
             },
           },
           animation: {
@@ -2425,14 +2426,6 @@
               midAlpha: rawGameConfig.layout?.lighting?.flame?.midAlpha ?? 0.27,
               farAlpha: rawGameConfig.layout?.lighting?.flame?.farAlpha ?? 0.14,
               flickerSeconds: rawGameConfig.layout?.lighting?.flame?.flickerSeconds ?? 2.9,
-            },
-            cardShadow: {
-              offsetXPx: rawGameConfig.layout?.lighting?.cardShadow?.offsetXPx ?? 1.5,
-              offsetYPx: rawGameConfig.layout?.lighting?.cardShadow?.offsetYPx ?? 9,
-              blurPx: rawGameConfig.layout?.lighting?.cardShadow?.blurPx ?? 12,
-              spreadPx: rawGameConfig.layout?.lighting?.cardShadow?.spreadPx ?? -2,
-              alpha: rawGameConfig.layout?.lighting?.cardShadow?.alpha ?? 0.34,
-              contactAlpha: rawGameConfig.layout?.lighting?.cardShadow?.contactAlpha ?? 0.2,
             },
           },
           fitter: rawGameConfig.layout?.fitter ?? null,
@@ -4686,7 +4679,6 @@
       const backgroundLayout = layout.background || {};
       const lightingLayout = layout.lighting || {};
       const flameLighting = lightingLayout.flame || {};
-      const cardShadowLighting = lightingLayout.cardShadow || {};
       const numberOrDefault = (value, fallback) => {
         const numericValue = Number(value);
         return Number.isFinite(numericValue) ? numericValue : fallback;
@@ -4698,6 +4690,8 @@
       const cardTiltXDeg = clampNumber(numberOrDefault(layoutCardDepth.tiltXDeg, 8), -8, 30);
       const cardDepthZPx = clampNumber(numberOrDefault(layoutCardDepth.depthZPx, 18), -24, 60);
       const cardArtLiftZPx = clampNumber(numberOrDefault(layoutCardDepth.artLiftZPx, 6), -8, 28);
+      const cardShapeExtrudePx = clampNumber(numberOrDefault(layoutCardDepth.shapeExtrudePx, 4), 0, 16);
+      const cardShapeShadowAlpha = clampNumber(numberOrDefault(layoutCardDepth.shapeShadowAlpha, 0.32), 0, 0.9);
       const desiredHeightFrac = clampNumber(Number(handLayout.desiredHeightFrac) || 0.20, 0.08, 0.60);
       const handHeightScale = clampNumber(Number(handLayout.heightScale) || 0.5, 0.2, 0.75);
       const configuredHandMinHeightPx = Math.max(80, Number(handLayout.minHeightPx) || 160);
@@ -4779,12 +4773,6 @@
       const flameMidAlpha = clampNumber(numberOrDefault(flameLighting.midAlpha, 0.27), 0, 0.35);
       const flameFarAlpha = clampNumber(numberOrDefault(flameLighting.farAlpha, 0.14), 0, 0.2);
       const flameFlickerSeconds = clampNumber(numberOrDefault(flameLighting.flickerSeconds, 2.9), 1.2, 8);
-      const cardShadowOffsetXPx = clampNumber(numberOrDefault(cardShadowLighting.offsetXPx, 1.5), -18, 18);
-      const cardShadowOffsetYPx = clampNumber(numberOrDefault(cardShadowLighting.offsetYPx, 9), 0, 28);
-      const cardShadowBlurPx = clampNumber(numberOrDefault(cardShadowLighting.blurPx, 12), 0, 40);
-      const cardShadowSpreadPx = clampNumber(numberOrDefault(cardShadowLighting.spreadPx, -2), -24, 24);
-      const cardShadowAlpha = clampNumber(numberOrDefault(cardShadowLighting.alpha, 0.34), 0, 0.7);
-      const cardShadowContactAlpha = clampNumber(numberOrDefault(cardShadowLighting.contactAlpha, 0.2), 0, 0.65);
       const handCardMinWidthPx = clampNumber(Number(layoutSizing.handCardMinWidthPx) || 74, 48, 180);
       const handCardMaxWidthPx = clampNumber(Number(layoutSizing.handCardMaxWidthPx) || 104, handCardMinWidthPx, 220);
       const handCardMinHeightPx = clampNumber(Number(layoutSizing.handCardMinHeightPx) || 146, 88, 280);
@@ -4847,18 +4835,14 @@
       setCssVar('--layout-card-tilt-x', `${cardTiltXDeg.toFixed(2)}deg`);
       setCssVar('--layout-card-depth-z', `${cardDepthZPx.toFixed(2)}px`);
       setCssVar('--layout-card-art-z', `${cardArtLiftZPx.toFixed(2)}px`);
+      setCssVar('--layout-card-shape-extrude', `${cardShapeExtrudePx.toFixed(2)}px`);
+      setCssVar('--layout-card-shape-shadow-alpha', cardShapeShadowAlpha.toFixed(3));
       setCssVar('--layout-flame-x', `${(flameXPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-y', `${(flameYPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-core-alpha', flameCoreAlpha.toFixed(3));
       setCssVar('--layout-flame-mid-alpha', flameMidAlpha.toFixed(3));
       setCssVar('--layout-flame-far-alpha', flameFarAlpha.toFixed(3));
       setCssVar('--layout-flame-flicker-seconds', `${flameFlickerSeconds.toFixed(3)}s`);
-      setCssVar('--layout-card-shadow-offset-x', `${cardShadowOffsetXPx.toFixed(2)}px`);
-      setCssVar('--layout-card-shadow-offset-y', `${cardShadowOffsetYPx.toFixed(2)}px`);
-      setCssVar('--layout-card-shadow-blur', `${cardShadowBlurPx.toFixed(2)}px`);
-      setCssVar('--layout-card-shadow-spread', `${cardShadowSpreadPx.toFixed(2)}px`);
-      setCssVar('--layout-card-shadow-alpha', cardShadowAlpha.toFixed(3));
-      setCssVar('--layout-card-contact-alpha', cardShadowContactAlpha.toFixed(3));
       setCssVar('--layout-table-dominance-frac', tableMinDominanceFrac.toFixed(3));
       setCssVar('--layout-action-column-height-scale', actionColumnHeightScale.toFixed(3));
       setCssVar('--layout-controls-height-scale', controlsHeightScale.toFixed(3));

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -178,6 +178,12 @@
       --layout-card-shadow-spread: -2px;
       --layout-card-shadow-alpha: 0.34;
       --layout-card-contact-alpha: 0.2;
+      --layout-card-perspective: 900px;
+      --layout-card-perspective-origin-x: 50%;
+      --layout-card-perspective-origin-y: 92%;
+      --layout-card-tilt-x: 8deg;
+      --layout-card-depth-z: 18px;
+      --layout-card-art-z: 6px;
     }
     * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
     html, body { margin: 0; background: transparent; color: var(--text); font-family: 'Khymeryyanroman4', Inter, system-ui, sans-serif; letter-spacing: 0.10em; height: 100%; }
@@ -219,6 +225,9 @@
       background-position: center center;
       background-repeat: no-repeat;
       background-size: 100% 100%;
+      perspective: var(--layout-card-perspective);
+      perspective-origin: var(--layout-card-perspective-origin-x) var(--layout-card-perspective-origin-y);
+      transform-style: preserve-3d;
       display: grid;
       container-type: size;
       grid-template-columns: minmax(0, 1fr) minmax(220px, 0.4fr) var(--layout-sidebar-width);
@@ -950,6 +959,7 @@
       min-height: 0;
     }
     .card {
+      --card-lift-y: 0px;
       width: 100%;
       min-width: var(--layout-card-hit-min-width);
       min-height: max(
@@ -970,8 +980,12 @@
       position: relative;
       overflow: hidden;
       isolation: isolate;
+      transform: translateY(var(--card-lift-y)) translateZ(var(--layout-card-depth-z)) rotateX(var(--layout-card-tilt-x));
+      transform-origin: 50% 56%;
+      transform-style: preserve-3d;
+      transition: transform 140ms ease-out, filter 140ms ease-out;
     }
-    .card.selected { transform: translateY(-4px); border-color: transparent; }
+    .card.selected { --card-lift-y: -4px; border-color: transparent; }
     .card.selected::after {
       content: '';
       position: absolute;
@@ -995,6 +1009,8 @@
       display: block;
       border-radius: 0;
       pointer-events: none;
+      transform: translateZ(var(--layout-card-art-z));
+      transform-origin: center;
     }
     .cardLabel {
       position: absolute;
@@ -1013,6 +1029,7 @@
       line-height: 1.1;
       letter-spacing: 0.04em;
       pointer-events: none;
+      transform: translateZ(calc(var(--layout-card-art-z) + 1px));
     }
     .cardGlyph {
       display: inline-flex;
@@ -2255,6 +2272,14 @@
           },
           cards: {
             baseScale: rawGameConfig.layout?.cards?.baseScale ?? 0.25,
+            depth: {
+              perspectivePx: rawGameConfig.layout?.cards?.depth?.perspectivePx ?? 900,
+              originXPct: rawGameConfig.layout?.cards?.depth?.originXPct ?? 0.5,
+              originYPct: rawGameConfig.layout?.cards?.depth?.originYPct ?? 0.92,
+              tiltXDeg: rawGameConfig.layout?.cards?.depth?.tiltXDeg ?? 8,
+              depthZPx: rawGameConfig.layout?.cards?.depth?.depthZPx ?? 18,
+              artLiftZPx: rawGameConfig.layout?.cards?.depth?.artLiftZPx ?? 6,
+            },
           },
           animation: {
             baseDurationMs: rawGameConfig.layout?.animation?.baseDurationMs ?? 400,
@@ -4654,6 +4679,7 @@
       const claimCluster = getClaimClusterConfig();
       const layoutSizing = layout.sizing || {};
       const layoutCards = layout.cards || {};
+      const layoutCardDepth = layoutCards.depth || {};
       const viewportLayout = layout.viewport || {};
       const handLayout = layout.hand || {};
       const tableViewLayout = layout.tableView || {};
@@ -4661,7 +4687,17 @@
       const lightingLayout = layout.lighting || {};
       const flameLighting = lightingLayout.flame || {};
       const cardShadowLighting = lightingLayout.cardShadow || {};
+      const numberOrDefault = (value, fallback) => {
+        const numericValue = Number(value);
+        return Number.isFinite(numericValue) ? numericValue : fallback;
+      };
       const cardBaseScale = clampNumber(Number(layoutCards.baseScale) || 0.25, 0.1, 0.75);
+      const cardPerspectivePx = clampNumber(numberOrDefault(layoutCardDepth.perspectivePx, 900), 500, 3000);
+      const cardPerspectiveOriginXPct = clampNumber(numberOrDefault(layoutCardDepth.originXPct, 0.5), -0.2, 1.2);
+      const cardPerspectiveOriginYPct = clampNumber(numberOrDefault(layoutCardDepth.originYPct, 0.92), 0.8, 1.8);
+      const cardTiltXDeg = clampNumber(numberOrDefault(layoutCardDepth.tiltXDeg, 8), -8, 30);
+      const cardDepthZPx = clampNumber(numberOrDefault(layoutCardDepth.depthZPx, 18), -24, 60);
+      const cardArtLiftZPx = clampNumber(numberOrDefault(layoutCardDepth.artLiftZPx, 6), -8, 28);
       const desiredHeightFrac = clampNumber(Number(handLayout.desiredHeightFrac) || 0.20, 0.08, 0.60);
       const handHeightScale = clampNumber(Number(handLayout.heightScale) || 0.5, 0.2, 0.75);
       const configuredHandMinHeightPx = Math.max(80, Number(handLayout.minHeightPx) || 160);
@@ -4689,10 +4725,6 @@
       const cssTargets = [root, app];
       const setCssVar = (name, value) => {
         for (const target of cssTargets) target.style.setProperty(name, value);
-      };
-      const numberOrDefault = (value, fallback) => {
-        const numericValue = Number(value);
-        return Number.isFinite(numericValue) ? numericValue : fallback;
       };
       const viewportWidthPx = Math.max(320, Number(viewportLayout.widthPx) || Number(app?.clientWidth) || 320);
       const viewportHeightPx = Math.max(180, Number(viewportLayout.heightPx) || Number(app?.clientHeight) || 180);
@@ -4809,6 +4841,12 @@
       setCssVar('--layout-liar-burst-duration', `${liarBurstDurationSec.toFixed(3)}s`);
       setCssVar('--layout-liar-burst-end-y', `${liarBurstEndYPct.toFixed(2)}%`);
       setCssVar('--layout-ui-tabletop-url', tabletopImageSrc ? `url("${tabletopImageSrc}")` : 'none');
+      setCssVar('--layout-card-perspective', `${cardPerspectivePx.toFixed(2)}px`);
+      setCssVar('--layout-card-perspective-origin-x', `${(cardPerspectiveOriginXPct * 100).toFixed(2)}%`);
+      setCssVar('--layout-card-perspective-origin-y', `${(cardPerspectiveOriginYPct * 100).toFixed(2)}%`);
+      setCssVar('--layout-card-tilt-x', `${cardTiltXDeg.toFixed(2)}deg`);
+      setCssVar('--layout-card-depth-z', `${cardDepthZPx.toFixed(2)}px`);
+      setCssVar('--layout-card-art-z', `${cardArtLiftZPx.toFixed(2)}px`);
       setCssVar('--layout-flame-x', `${(flameXPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-y', `${(flameYPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-core-alpha', flameCoreAlpha.toFixed(3));

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -642,6 +642,7 @@
       border-radius: 0;
       border: 0;
       background: transparent;
+      position: relative;
       box-shadow:
         var(--layout-card-shadow-offset-x) var(--layout-card-shadow-offset-y) var(--layout-card-shadow-blur) var(--layout-card-shadow-spread) rgba(0, 0, 0, var(--layout-card-shadow-alpha)),
         calc(var(--layout-card-shadow-offset-x) * 0.4) calc(var(--layout-card-shadow-offset-y) * 0.34) calc(var(--layout-card-shadow-blur) * 0.56) calc(var(--layout-card-shadow-spread) * 0.72) rgba(0, 0, 0, var(--layout-card-shadow-contact-alpha));
@@ -1006,7 +1007,8 @@
       opacity: var(--layout-card-underlay-alpha);
       transform:
         translate(var(--card-underlay-offset-x, 0px), var(--card-underlay-offset-y, 0px))
-        skewX(var(--card-underlay-skew-x, 0deg));
+        skewX(var(--card-underlay-skew-x, 0deg))
+        scaleX(var(--card-underlay-flip-x, 1));
       transform-origin: 50% 100%;
       filter: brightness(0.42) saturate(0.7);
       z-index: 0;
@@ -4335,7 +4337,7 @@
       const appRect = root.getBoundingClientRect();
       const anchorX = appRect.left + appRect.width * 0.5;
       const anchorY = appRect.bottom;
-      root.querySelectorAll('.card[data-card-id]').forEach((cardEl) => {
+      root.querySelectorAll('.card[data-card-id], .tableViewCard[data-card-id]').forEach((cardEl) => {
         const rect = cardEl.getBoundingClientRect();
         const centerX = rect.left + rect.width * 0.5;
         const centerY = rect.top + rect.height * 0.5;
@@ -4344,9 +4346,11 @@
         const distance = Math.hypot(dx, dy) || 1;
         const dirX = dx / distance;
         const dirY = dy / distance;
+        const topIsFlipped = cardEl.getAttribute('data-card-is-flipped') === 'true';
         cardEl.style.setProperty('--card-underlay-offset-x', `calc(var(--layout-card-underlay-strength) * ${dirX.toFixed(4)})`);
         cardEl.style.setProperty('--card-underlay-offset-y', `calc(var(--layout-card-underlay-strength) * ${dirY.toFixed(4)})`);
         cardEl.style.setProperty('--card-underlay-skew-x', `calc(var(--layout-card-underlay-skew-max) * ${dirX.toFixed(4)})`);
+        cardEl.style.setProperty('--card-underlay-flip-x', topIsFlipped ? '1' : '-1');
       });
     }
     function normalizedAssetPath(basePath, fileName) {
@@ -5471,10 +5475,11 @@
         ? claimHandCardsSource.map((card) => {
             const revealCard = cinematicRevealActive;
             const art = resolveScratchbone2DAsset(card, { flipped: !revealCard });
+            const underlayArt = resolveScratchbone2DAsset(card, { flipped: true });
             const cardAlt = revealCard
               ? (card.wild ? 'Revealed wild scratchbone card' : `Revealed scratchbone ${card.rank} card`)
               : 'Face-down scratchbone card';
-            return `<div class="tableViewCard" style="--fd:0s;" data-card-id="${card.id}"><img src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${cardAlt}"></div>`;
+            return `<div class="tableViewCard" style="--fd:0s;" data-card-id="${card.id}" data-card-is-flipped="${!revealCard ? 'true' : 'false'}"><img class="cardUnderlay" src="${underlayArt.src}" data-fallback-src="${underlayArt.fallbackSrc}" alt="" aria-hidden="true"><img class="cardTopArt" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${cardAlt}"></div>`;
           }).join('')
         : '<div class="tiny">No claim yet.</div>');
       const claimClusterShellClass = claimClusterPolicy.transparentShells ? 'floatingTransparentShell' : '';
@@ -5483,7 +5488,8 @@
           ? `<div class="tiny">Claim cluster visualization active.</div>`
           : latestPlay.cards.map(card => {
               const art = resolveScratchbone2DAsset(card, { flipped: tableCardFaceDown });
-              return `<div class="tableViewCard" data-card-id="${card.id}"><img src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${tableCardFaceDown ? 'Face-down scratchbone card' : (card.wild ? 'Wild scratchbone card' : `Scratchbone ${card.rank} card`)}"></div>`;
+              const underlayArt = resolveScratchbone2DAsset(card, { flipped: true });
+              return `<div class="tableViewCard" data-card-id="${card.id}" data-card-is-flipped="${tableCardFaceDown ? 'true' : 'false'}"><img class="cardUnderlay" src="${underlayArt.src}" data-fallback-src="${underlayArt.fallbackSrc}" alt="" aria-hidden="true"><img class="cardTopArt" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${tableCardFaceDown ? 'Face-down scratchbone card' : (card.wild ? 'Wild scratchbone card' : `Scratchbone ${card.rank} card`)}"></div>`;
             }).join(''))
         : '<div class="tiny">No cards on the table yet.</div>';
       const recentLogs = eventLogEnabled ? state.logs.slice(0, 4) : [];
@@ -5694,7 +5700,7 @@
                 const cardLabel = card.wild ? 'Wild' : `Rank ${card.rank}`;
                 const cardGlyph = card.wild ? 'W' : String(card.rank);
                 return `
-                <button class="card ${card.wild ? 'wild' : ''} ${state.selectedCardIds.has(card.id) ? 'selected' : ''}" data-card-id="${card.id}" title="${card.wild ? 'Wild card' : `Scratchbone ${card.rank}`}">
+                <button class="card ${card.wild ? 'wild' : ''} ${state.selectedCardIds.has(card.id) ? 'selected' : ''}" data-card-id="${card.id}" data-card-is-flipped="false" title="${card.wild ? 'Wild card' : `Scratchbone ${card.rank}`}">
                   <img class="cardUnderlay" src="${underlayArt.src}" data-fallback-src="${underlayArt.fallbackSrc}" alt="" aria-hidden="true">
                   <img class="cardArt" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${card.wild ? 'Wild scratchbone card' : `Scratchbone ${card.rank} card`}">
                   <span class="cardLabel" aria-hidden="true"><span class="cardGlyph">${cardGlyph}</span><span class="cardText">${cardLabel}</span></span>

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -178,6 +178,9 @@
       --layout-card-shadow-spread: -6px;
       --layout-card-shadow-alpha: 0.44;
       --layout-card-shadow-contact-alpha: 0.28;
+      --layout-card-underlay-strength: 20px;
+      --layout-card-underlay-skew-max: 12deg;
+      --layout-card-underlay-alpha: 0.94;
     }
     * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
     html, body { margin: 0; background: transparent; color: var(--text); font-family: 'Khymeryyanroman4', Inter, system-ui, sans-serif; letter-spacing: 0.10em; height: 100%; }
@@ -992,6 +995,22 @@
         drop-shadow(0 0 4px rgba(98, 176, 255, 0.85))
         drop-shadow(0 0 9px rgba(98, 176, 255, 0.72));
     }
+    .cardUnderlay {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: center;
+      pointer-events: none;
+      opacity: var(--layout-card-underlay-alpha);
+      transform:
+        translate(var(--card-underlay-offset-x, 0px), var(--card-underlay-offset-y, 0px))
+        skewX(var(--card-underlay-skew-x, 0deg));
+      transform-origin: 50% 100%;
+      filter: brightness(0.42) saturate(0.7);
+      z-index: 0;
+    }
     .cardArt {
       width: 100%;
       height: 100%;
@@ -1001,6 +1020,8 @@
       border-radius: 0;
       pointer-events: none;
       filter: none;
+      position: relative;
+      z-index: 1;
     }
     .cardLabel {
       position: absolute;
@@ -1020,6 +1041,7 @@
       letter-spacing: 0.04em;
       pointer-events: none;
       transform: none;
+      z-index: 2;
     }
     .cardGlyph {
       display: inline-flex;
@@ -2269,6 +2291,11 @@
               spreadPx: rawGameConfig.layout?.cards?.shadow?.spreadPx ?? -6,
               alpha: rawGameConfig.layout?.cards?.shadow?.alpha ?? 0.44,
               contactAlpha: rawGameConfig.layout?.cards?.shadow?.contactAlpha ?? 0.28,
+            },
+            underlay: {
+              strengthPx: rawGameConfig.layout?.cards?.underlay?.strengthPx ?? 20,
+              skewMaxDeg: rawGameConfig.layout?.cards?.underlay?.skewMaxDeg ?? 12,
+              alpha: rawGameConfig.layout?.cards?.underlay?.alpha ?? 0.94,
             },
           },
           animation: {
@@ -4303,6 +4330,25 @@
     function cardLabel(card) {
       return card.wild ? 'Wild' : String(card.rank);
     }
+    function updateCardUnderlayDirection(root = document.getElementById('app')) {
+      if (!root) return;
+      const appRect = root.getBoundingClientRect();
+      const anchorX = appRect.left + appRect.width * 0.5;
+      const anchorY = appRect.bottom;
+      root.querySelectorAll('.card[data-card-id]').forEach((cardEl) => {
+        const rect = cardEl.getBoundingClientRect();
+        const centerX = rect.left + rect.width * 0.5;
+        const centerY = rect.top + rect.height * 0.5;
+        const dx = centerX - anchorX;
+        const dy = centerY - anchorY;
+        const distance = Math.hypot(dx, dy) || 1;
+        const dirX = dx / distance;
+        const dirY = dy / distance;
+        cardEl.style.setProperty('--card-underlay-offset-x', `calc(var(--layout-card-underlay-strength) * ${dirX.toFixed(4)})`);
+        cardEl.style.setProperty('--card-underlay-offset-y', `calc(var(--layout-card-underlay-strength) * ${dirY.toFixed(4)})`);
+        cardEl.style.setProperty('--card-underlay-skew-x', `calc(var(--layout-card-underlay-skew-max) * ${dirX.toFixed(4)})`);
+      });
+    }
     function normalizedAssetPath(basePath, fileName) {
       const safeBase = String(basePath || '').replace(/\/+$/, '');
       const safeFile = String(fileName || '').replace(/^\/+/, '');
@@ -4662,6 +4708,7 @@
       const layoutSizing = layout.sizing || {};
       const layoutCards = layout.cards || {};
       const layoutCardShadow = layoutCards.shadow || {};
+      const layoutCardUnderlay = layoutCards.underlay || {};
       const viewportLayout = layout.viewport || {};
       const handLayout = layout.hand || {};
       const tableViewLayout = layout.tableView || {};
@@ -4679,6 +4726,9 @@
       const cardShadowSpreadPx = clampNumber(numberOrDefault(layoutCardShadow.spreadPx, -6), -24, 24);
       const cardShadowAlpha = clampNumber(numberOrDefault(layoutCardShadow.alpha, 0.44), 0, 0.9);
       const cardShadowContactAlpha = clampNumber(numberOrDefault(layoutCardShadow.contactAlpha, 0.28), 0, 0.9);
+      const cardUnderlayStrengthPx = clampNumber(numberOrDefault(layoutCardUnderlay.strengthPx, 20), 0, 48);
+      const cardUnderlaySkewMaxDeg = clampNumber(numberOrDefault(layoutCardUnderlay.skewMaxDeg, 12), 0, 36);
+      const cardUnderlayAlpha = clampNumber(numberOrDefault(layoutCardUnderlay.alpha, 0.94), 0, 1);
       const desiredHeightFrac = clampNumber(Number(handLayout.desiredHeightFrac) || 0.20, 0.08, 0.60);
       const handHeightScale = clampNumber(Number(handLayout.heightScale) || 0.5, 0.2, 0.75);
       const configuredHandMinHeightPx = Math.max(80, Number(handLayout.minHeightPx) || 160);
@@ -4822,6 +4872,9 @@
       setCssVar('--layout-card-shadow-spread', `${cardShadowSpreadPx.toFixed(2)}px`);
       setCssVar('--layout-card-shadow-alpha', cardShadowAlpha.toFixed(3));
       setCssVar('--layout-card-shadow-contact-alpha', cardShadowContactAlpha.toFixed(3));
+      setCssVar('--layout-card-underlay-strength', `${cardUnderlayStrengthPx.toFixed(2)}px`);
+      setCssVar('--layout-card-underlay-skew-max', `${cardUnderlaySkewMaxDeg.toFixed(2)}deg`);
+      setCssVar('--layout-card-underlay-alpha', cardUnderlayAlpha.toFixed(3));
       setCssVar('--layout-flame-x', `${(flameXPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-y', `${(flameYPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-core-alpha', flameCoreAlpha.toFixed(3));
@@ -5637,10 +5690,12 @@
           <div class="handScroll">
               ${player.hand.map(card => {
                 const art = resolveScratchbone2DAsset(card);
+                const underlayArt = resolveScratchbone2DAsset(card, { flipped: true });
                 const cardLabel = card.wild ? 'Wild' : `Rank ${card.rank}`;
                 const cardGlyph = card.wild ? 'W' : String(card.rank);
                 return `
                 <button class="card ${card.wild ? 'wild' : ''} ${state.selectedCardIds.has(card.id) ? 'selected' : ''}" data-card-id="${card.id}" title="${card.wild ? 'Wild card' : `Scratchbone ${card.rank}`}">
+                  <img class="cardUnderlay" src="${underlayArt.src}" data-fallback-src="${underlayArt.fallbackSrc}" alt="" aria-hidden="true">
                   <img class="cardArt" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${card.wild ? 'Wild scratchbone card' : `Scratchbone ${card.rank} card`}">
                   <span class="cardLabel" aria-hidden="true"><span class="cardGlyph">${cardGlyph}</span><span class="cardText">${cardLabel}</span></span>
                 </button>
@@ -5699,6 +5754,10 @@
       renderAuthoredInspector();
       updateTableCardAutoScale(app);
       syncClaimClusterCardSizeFromHand(app);
+      updateCardUnderlayDirection(app);
+      if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(() => updateCardUnderlayDirection(app));
+      }
       if (state.pendingCinematicBetAction) {
         const actionFx = state.pendingCinematicBetAction;
         state.pendingCinematicBetAction = null;
@@ -6756,6 +6815,7 @@
         }
         updateTableCardAutoScale(app);
         syncClaimClusterCardSizeFromHand(app);
+        updateCardUnderlayDirection(app);
       }, fitDebounceMs);
     }
     window.addEventListener('resize', scheduleResponsiveFitPass, { passive: true });

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -180,6 +180,10 @@
       --layout-card-art-z: 6px;
       --layout-card-shape-extrude: 4px;
       --layout-card-shape-shadow-alpha: 0.32;
+      --layout-card-shape-layer-offset-x: 0.32px;
+      --layout-card-shape-layer-offset-y: 1.05px;
+      --layout-card-shape-layer-skew-x: -0.35deg;
+      --layout-card-shape-layer-alpha: 0.14;
     }
     * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
     html, body { margin: 0; background: transparent; color: var(--text); font-family: 'Khymeryyanroman4', Inter, system-ui, sans-serif; letter-spacing: 0.10em; height: 100%; }
@@ -996,6 +1000,50 @@
         drop-shadow(0 0 1px rgba(98, 176, 255, 0.95))
         drop-shadow(0 0 4px rgba(98, 176, 255, 0.85))
         drop-shadow(0 0 9px rgba(98, 176, 255, 0.72));
+    }
+    .cardDepthStack {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      transform: translateZ(calc(var(--layout-card-art-z) - 1px));
+      transform-origin: center;
+    }
+    .cardDepthLayer {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: center;
+      pointer-events: none;
+      opacity: 0;
+      transform-origin: center;
+      filter: brightness(0.04) saturate(0.25);
+      transform:
+        translate(
+          calc(var(--layout-card-shape-layer-offset-x) * var(--depth-layer-index)),
+          calc(var(--layout-card-shape-layer-offset-y) * var(--depth-layer-index))
+        )
+        skewX(calc(var(--layout-card-shape-layer-skew-x) * var(--depth-layer-index)));
+    }
+    .cardDepthLayer[data-depth-layer="1"] { opacity: var(--layout-card-shape-layer-alpha); }
+    .cardDepthLayer[data-depth-layer="2"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.92); }
+    .cardDepthLayer[data-depth-layer="3"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.86); }
+    .cardDepthLayer[data-depth-layer="4"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.80); }
+    .cardDepthLayer[data-depth-layer="5"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.74); }
+    .cardDepthLayer[data-depth-layer="6"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.68); }
+    .cardDepthLayer[data-depth-layer="7"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.62); }
+    .cardDepthLayer[data-depth-layer="8"] { opacity: calc(var(--layout-card-shape-layer-alpha) * 0.56); }
+    .card[data-depth-layers="0"] .cardDepthStack,
+    .card[data-depth-layers="1"] .cardDepthLayer:nth-child(n+2),
+    .card[data-depth-layers="2"] .cardDepthLayer:nth-child(n+3),
+    .card[data-depth-layers="3"] .cardDepthLayer:nth-child(n+4),
+    .card[data-depth-layers="4"] .cardDepthLayer:nth-child(n+5),
+    .card[data-depth-layers="5"] .cardDepthLayer:nth-child(n+6),
+    .card[data-depth-layers="6"] .cardDepthLayer:nth-child(n+7),
+    .card[data-depth-layers="7"] .cardDepthLayer:nth-child(n+8),
+    .card[data-depth-layers="8"] .cardDepthLayer:nth-child(n+9) {
+      display: none;
     }
     .cardArt {
       width: 100%;
@@ -2280,6 +2328,11 @@
               artLiftZPx: rawGameConfig.layout?.cards?.depth?.artLiftZPx ?? 6,
               shapeExtrudePx: rawGameConfig.layout?.cards?.depth?.shapeExtrudePx ?? 4,
               shapeShadowAlpha: rawGameConfig.layout?.cards?.depth?.shapeShadowAlpha ?? 0.32,
+              shapeLayerCount: rawGameConfig.layout?.cards?.depth?.shapeLayerCount ?? 4,
+              shapeLayerOffsetXPx: rawGameConfig.layout?.cards?.depth?.shapeLayerOffsetXPx ?? 0.32,
+              shapeLayerOffsetYPx: rawGameConfig.layout?.cards?.depth?.shapeLayerOffsetYPx ?? 1.05,
+              shapeLayerSkewXDeg: rawGameConfig.layout?.cards?.depth?.shapeLayerSkewXDeg ?? -0.35,
+              shapeLayerAlpha: rawGameConfig.layout?.cards?.depth?.shapeLayerAlpha ?? 0.14,
             },
           },
           animation: {
@@ -4314,6 +4367,15 @@
     function cardLabel(card) {
       return card.wild ? 'Wild' : String(card.rank);
     }
+    function renderCardDepthLayers(art, layerCount) {
+      const safeLayerCount = Math.max(0, Math.min(8, Number(layerCount) || 0));
+      if (safeLayerCount < 1) return '';
+      const layers = [];
+      for (let index = 1; index <= safeLayerCount; index += 1) {
+        layers.push(`<img class="cardDepthLayer" data-depth-layer="${index}" style="--depth-layer-index:${index};" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="" aria-hidden="true">`);
+      }
+      return `<span class="cardDepthStack" aria-hidden="true">${layers.join('')}</span>`;
+    }
     function normalizedAssetPath(basePath, fileName) {
       const safeBase = String(basePath || '').replace(/\/+$/, '');
       const safeFile = String(fileName || '').replace(/^\/+/, '');
@@ -4692,6 +4754,10 @@
       const cardArtLiftZPx = clampNumber(numberOrDefault(layoutCardDepth.artLiftZPx, 6), -8, 28);
       const cardShapeExtrudePx = clampNumber(numberOrDefault(layoutCardDepth.shapeExtrudePx, 4), 0, 16);
       const cardShapeShadowAlpha = clampNumber(numberOrDefault(layoutCardDepth.shapeShadowAlpha, 0.32), 0, 0.9);
+      const cardShapeLayerOffsetXPx = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerOffsetXPx, 0.32), -4, 4);
+      const cardShapeLayerOffsetYPx = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerOffsetYPx, 1.05), -6, 8);
+      const cardShapeLayerSkewXDeg = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerSkewXDeg, -0.35), -4, 4);
+      const cardShapeLayerAlpha = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerAlpha, 0.14), 0, 0.6);
       const desiredHeightFrac = clampNumber(Number(handLayout.desiredHeightFrac) || 0.20, 0.08, 0.60);
       const handHeightScale = clampNumber(Number(handLayout.heightScale) || 0.5, 0.2, 0.75);
       const configuredHandMinHeightPx = Math.max(80, Number(handLayout.minHeightPx) || 160);
@@ -4837,6 +4903,10 @@
       setCssVar('--layout-card-art-z', `${cardArtLiftZPx.toFixed(2)}px`);
       setCssVar('--layout-card-shape-extrude', `${cardShapeExtrudePx.toFixed(2)}px`);
       setCssVar('--layout-card-shape-shadow-alpha', cardShapeShadowAlpha.toFixed(3));
+      setCssVar('--layout-card-shape-layer-offset-x', `${cardShapeLayerOffsetXPx.toFixed(2)}px`);
+      setCssVar('--layout-card-shape-layer-offset-y', `${cardShapeLayerOffsetYPx.toFixed(2)}px`);
+      setCssVar('--layout-card-shape-layer-skew-x', `${cardShapeLayerSkewXDeg.toFixed(2)}deg`);
+      setCssVar('--layout-card-shape-layer-alpha', cardShapeLayerAlpha.toFixed(3));
       setCssVar('--layout-flame-x', `${(flameXPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-y', `${(flameYPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-core-alpha', flameCoreAlpha.toFixed(3));
@@ -5654,8 +5724,10 @@
                 const art = resolveScratchbone2DAsset(card);
                 const cardLabel = card.wild ? 'Wild' : `Rank ${card.rank}`;
                 const cardGlyph = card.wild ? 'W' : String(card.rank);
+                const cardDepthLayerCount = Math.max(0, Math.min(8, Number(SCRATCHBONES_GAME.layout?.cards?.depth?.shapeLayerCount) || 0));
                 return `
-                <button class="card ${card.wild ? 'wild' : ''} ${state.selectedCardIds.has(card.id) ? 'selected' : ''}" data-card-id="${card.id}" title="${card.wild ? 'Wild card' : `Scratchbone ${card.rank}`}">
+                <button class="card ${card.wild ? 'wild' : ''} ${state.selectedCardIds.has(card.id) ? 'selected' : ''}" data-card-id="${card.id}" data-depth-layers="${cardDepthLayerCount}" title="${card.wild ? 'Wild card' : `Scratchbone ${card.rank}`}">
+                  ${renderCardDepthLayers(art, cardDepthLayerCount)}
                   <img class="cardArt" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${card.wild ? 'Wild scratchbone card' : `Scratchbone ${card.rank} card`}">
                   <span class="cardLabel" aria-hidden="true"><span class="cardGlyph">${cardGlyph}</span><span class="cardText">${cardLabel}</span></span>
                 </button>

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -172,7 +172,7 @@
       --layout-flame-mid-alpha: 0.27;
       --layout-flame-far-alpha: 0.14;
       --layout-flame-flicker-seconds: 2.9s;
-      --layout-card-perspective: 900px;
+      --layout-card-perspective: 620px;
       --layout-card-perspective-origin-x: 50%;
       --layout-card-perspective-origin-y: 92%;
       --layout-card-tilt-x: 8deg;
@@ -184,6 +184,10 @@
       --layout-card-shape-layer-offset-y: 1.05px;
       --layout-card-shape-layer-skew-x: -0.35deg;
       --layout-card-shape-layer-alpha: 0.14;
+      --layout-card-bottom-layer-offset-x: 1.1px;
+      --layout-card-bottom-layer-offset-y: 4.2px;
+      --layout-card-bottom-layer-skew-x: -1.8deg;
+      --layout-card-bottom-layer-alpha: 0.34;
     }
     * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
     html, body { margin: 0; background: transparent; color: var(--text); font-family: 'Khymeryyanroman4', Inter, system-ui, sans-serif; letter-spacing: 0.10em; height: 100%; }
@@ -1006,6 +1010,21 @@
       inset: 0;
       pointer-events: none;
       transform: translateZ(calc(var(--layout-card-art-z) - 1px));
+      transform-origin: center;
+    }
+    .cardDepthBase {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: center;
+      pointer-events: none;
+      opacity: var(--layout-card-bottom-layer-alpha);
+      filter: brightness(0.06) saturate(0.35);
+      transform:
+        translate(var(--layout-card-bottom-layer-offset-x), var(--layout-card-bottom-layer-offset-y))
+        skewX(var(--layout-card-bottom-layer-skew-x));
       transform-origin: center;
     }
     .cardDepthLayer {
@@ -2320,7 +2339,7 @@
           cards: {
             baseScale: rawGameConfig.layout?.cards?.baseScale ?? 0.25,
             depth: {
-              perspectivePx: rawGameConfig.layout?.cards?.depth?.perspectivePx ?? 900,
+              perspectivePx: rawGameConfig.layout?.cards?.depth?.perspectivePx ?? 620,
               originXPct: rawGameConfig.layout?.cards?.depth?.originXPct ?? 0.5,
               originYPct: rawGameConfig.layout?.cards?.depth?.originYPct ?? 0.92,
               tiltXDeg: rawGameConfig.layout?.cards?.depth?.tiltXDeg ?? 8,
@@ -2333,6 +2352,10 @@
               shapeLayerOffsetYPx: rawGameConfig.layout?.cards?.depth?.shapeLayerOffsetYPx ?? 1.05,
               shapeLayerSkewXDeg: rawGameConfig.layout?.cards?.depth?.shapeLayerSkewXDeg ?? -0.35,
               shapeLayerAlpha: rawGameConfig.layout?.cards?.depth?.shapeLayerAlpha ?? 0.14,
+              bottomLayerOffsetXPx: rawGameConfig.layout?.cards?.depth?.bottomLayerOffsetXPx ?? 1.1,
+              bottomLayerOffsetYPx: rawGameConfig.layout?.cards?.depth?.bottomLayerOffsetYPx ?? 4.2,
+              bottomLayerSkewXDeg: rawGameConfig.layout?.cards?.depth?.bottomLayerSkewXDeg ?? -1.8,
+              bottomLayerAlpha: rawGameConfig.layout?.cards?.depth?.bottomLayerAlpha ?? 0.34,
             },
           },
           animation: {
@@ -2497,7 +2520,7 @@
           cardHudBasePath: rawGameConfig.assets?.cards?.hudBasePath ?? './docs/assets/hud/',
           wildCardSrc: rawGameConfig.assets?.cards?.wild?.src ?? '2DScratchBoneWild.png',
           wildCardFallbackSrc: rawGameConfig.assets?.cards?.wild?.fallbackSrc ?? '2DScratchBoneWild.png',
-          flippedCardSrc: rawGameConfig.assets?.cards?.flipped?.src ?? '2DScratchboneFlipped.png',
+          flippedCardSrc: rawGameConfig.assets?.cards?.flipped?.src ?? '2DScratchBoneFlipped.png',
           flippedCardFallbackSrc: rawGameConfig.assets?.cards?.flipped?.fallbackSrc ?? '2DScratchBoneFlipped.png',
           rankCardTemplateSrc: rawGameConfig.assets?.cards?.rankTemplate?.src ?? '2DScratchbone{rank}.png',
           rankCardTemplateFallbackSrc: rawGameConfig.assets?.cards?.rankTemplate?.fallbackSrc ?? '2DScratchbones{rank}.png',
@@ -4367,10 +4390,14 @@
     function cardLabel(card) {
       return card.wild ? 'Wild' : String(card.rank);
     }
-    function renderCardDepthLayers(art, layerCount) {
+    function renderCardDepthLayers(art, flippedArt, layerCount) {
       const safeLayerCount = Math.max(0, Math.min(8, Number(layerCount) || 0));
-      if (safeLayerCount < 1) return '';
+      const hasFlippedArt = Boolean(flippedArt?.src && flippedArt?.fallbackSrc);
+      if (safeLayerCount < 1 && !hasFlippedArt) return '';
       const layers = [];
+      if (hasFlippedArt) {
+        layers.push(`<img class="cardDepthBase" src="${flippedArt.src}" data-fallback-src="${flippedArt.fallbackSrc}" alt="" aria-hidden="true">`);
+      }
       for (let index = 1; index <= safeLayerCount; index += 1) {
         layers.push(`<img class="cardDepthLayer" data-depth-layer="${index}" style="--depth-layer-index:${index};" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="" aria-hidden="true">`);
       }
@@ -4746,7 +4773,7 @@
         return Number.isFinite(numericValue) ? numericValue : fallback;
       };
       const cardBaseScale = clampNumber(Number(layoutCards.baseScale) || 0.25, 0.1, 0.75);
-      const cardPerspectivePx = clampNumber(numberOrDefault(layoutCardDepth.perspectivePx, 900), 500, 3000);
+      const cardPerspectivePx = clampNumber(numberOrDefault(layoutCardDepth.perspectivePx, 620), 420, 3000);
       const cardPerspectiveOriginXPct = clampNumber(numberOrDefault(layoutCardDepth.originXPct, 0.5), -0.2, 1.2);
       const cardPerspectiveOriginYPct = clampNumber(numberOrDefault(layoutCardDepth.originYPct, 0.92), 0.8, 1.8);
       const cardTiltXDeg = clampNumber(numberOrDefault(layoutCardDepth.tiltXDeg, 8), -8, 30);
@@ -4758,6 +4785,10 @@
       const cardShapeLayerOffsetYPx = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerOffsetYPx, 1.05), -6, 8);
       const cardShapeLayerSkewXDeg = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerSkewXDeg, -0.35), -4, 4);
       const cardShapeLayerAlpha = clampNumber(numberOrDefault(layoutCardDepth.shapeLayerAlpha, 0.14), 0, 0.6);
+      const cardBottomLayerOffsetXPx = clampNumber(numberOrDefault(layoutCardDepth.bottomLayerOffsetXPx, 1.1), -6, 8);
+      const cardBottomLayerOffsetYPx = clampNumber(numberOrDefault(layoutCardDepth.bottomLayerOffsetYPx, 4.2), -8, 16);
+      const cardBottomLayerSkewXDeg = clampNumber(numberOrDefault(layoutCardDepth.bottomLayerSkewXDeg, -1.8), -8, 8);
+      const cardBottomLayerAlpha = clampNumber(numberOrDefault(layoutCardDepth.bottomLayerAlpha, 0.34), 0, 0.95);
       const desiredHeightFrac = clampNumber(Number(handLayout.desiredHeightFrac) || 0.20, 0.08, 0.60);
       const handHeightScale = clampNumber(Number(handLayout.heightScale) || 0.5, 0.2, 0.75);
       const configuredHandMinHeightPx = Math.max(80, Number(handLayout.minHeightPx) || 160);
@@ -4907,6 +4938,10 @@
       setCssVar('--layout-card-shape-layer-offset-y', `${cardShapeLayerOffsetYPx.toFixed(2)}px`);
       setCssVar('--layout-card-shape-layer-skew-x', `${cardShapeLayerSkewXDeg.toFixed(2)}deg`);
       setCssVar('--layout-card-shape-layer-alpha', cardShapeLayerAlpha.toFixed(3));
+      setCssVar('--layout-card-bottom-layer-offset-x', `${cardBottomLayerOffsetXPx.toFixed(2)}px`);
+      setCssVar('--layout-card-bottom-layer-offset-y', `${cardBottomLayerOffsetYPx.toFixed(2)}px`);
+      setCssVar('--layout-card-bottom-layer-skew-x', `${cardBottomLayerSkewXDeg.toFixed(2)}deg`);
+      setCssVar('--layout-card-bottom-layer-alpha', cardBottomLayerAlpha.toFixed(3));
       setCssVar('--layout-flame-x', `${(flameXPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-y', `${(flameYPct * 100).toFixed(2)}%`);
       setCssVar('--layout-flame-core-alpha', flameCoreAlpha.toFixed(3));
@@ -5722,12 +5757,13 @@
           <div class="handScroll">
               ${player.hand.map(card => {
                 const art = resolveScratchbone2DAsset(card);
+                const flippedArt = resolveScratchbone2DAsset(card, { flipped: true });
                 const cardLabel = card.wild ? 'Wild' : `Rank ${card.rank}`;
                 const cardGlyph = card.wild ? 'W' : String(card.rank);
                 const cardDepthLayerCount = Math.max(0, Math.min(8, Number(SCRATCHBONES_GAME.layout?.cards?.depth?.shapeLayerCount) || 0));
                 return `
                 <button class="card ${card.wild ? 'wild' : ''} ${state.selectedCardIds.has(card.id) ? 'selected' : ''}" data-card-id="${card.id}" data-depth-layers="${cardDepthLayerCount}" title="${card.wild ? 'Wild card' : `Scratchbone ${card.rank}`}">
-                  ${renderCardDepthLayers(art, cardDepthLayerCount)}
+                  ${renderCardDepthLayers(art, flippedArt, cardDepthLayerCount)}
                   <img class="cardArt" src="${art.src}" data-fallback-src="${art.fallbackSrc}" alt="${card.wild ? 'Wild scratchbone card' : `Scratchbone ${card.rank} card`}">
                   <span class="cardLabel" aria-hidden="true"><span class="cardGlyph">${cardGlyph}</span><span class="cardText">${cardLabel}</span></span>
                 </button>

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -161,7 +161,15 @@ window.SCRATCHBONES_CONFIG = {
         }
       },
       "cards": {
-        "baseScale": 0.5
+        "baseScale": 0.5,
+        "depth": {
+          "perspectivePx": 900,
+          "originXPct": 0.5,
+          "originYPct": 0.92,
+          "tiltXDeg": 8,
+          "depthZPx": 18,
+          "artLiftZPx": 6
+        }
       },
       "sizing": {
         "sidebarWidthFrac": 0.15,

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -168,7 +168,9 @@ window.SCRATCHBONES_CONFIG = {
           "originYPct": 0.92,
           "tiltXDeg": 8,
           "depthZPx": 18,
-          "artLiftZPx": 6
+          "artLiftZPx": 6,
+          "shapeExtrudePx": 4,
+          "shapeShadowAlpha": 0.32
         }
       },
       "sizing": {
@@ -369,14 +371,6 @@ window.SCRATCHBONES_CONFIG = {
           "midAlpha": 0.27,
           "farAlpha": 0.14,
           "flickerSeconds": 2.9
-        },
-        "cardShadow": {
-          "offsetXPx": 1.5,
-          "offsetYPx": 9,
-          "blurPx": 12,
-          "spreadPx": -2,
-          "alpha": 0.34,
-          "contactAlpha": 0.2
         }
       },
       "fitter": {

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -169,6 +169,11 @@ window.SCRATCHBONES_CONFIG = {
           "spreadPx": -6,
           "alpha": 0.44,
           "contactAlpha": 0.28
+        },
+        "underlay": {
+          "strengthPx": 20,
+          "skewMaxDeg": 12,
+          "alpha": 0.94
         }
       },
       "sizing": {

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -162,24 +162,13 @@ window.SCRATCHBONES_CONFIG = {
       },
       "cards": {
         "baseScale": 0.5,
-        "depth": {
-          "perspectivePx": 620,
-          "originXPct": 0.5,
-          "originYPct": 0.92,
-          "tiltXDeg": 8,
-          "depthZPx": 18,
-          "artLiftZPx": 6,
-          "shapeExtrudePx": 4,
-          "shapeShadowAlpha": 0.32,
-          "shapeLayerCount": 4,
-          "shapeLayerOffsetXPx": 0.32,
-          "shapeLayerOffsetYPx": 1.05,
-          "shapeLayerSkewXDeg": -0.35,
-          "shapeLayerAlpha": 0.14,
-          "bottomLayerOffsetXPx": 1.1,
-          "bottomLayerOffsetYPx": 4.2,
-          "bottomLayerSkewXDeg": -1.8,
-          "bottomLayerAlpha": 0.34
+        "shadow": {
+          "offsetXPx": 2,
+          "offsetYPx": 18,
+          "blurPx": 24,
+          "spreadPx": -6,
+          "alpha": 0.44,
+          "contactAlpha": 0.28
         }
       },
       "sizing": {

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -170,7 +170,12 @@ window.SCRATCHBONES_CONFIG = {
           "depthZPx": 18,
           "artLiftZPx": 6,
           "shapeExtrudePx": 4,
-          "shapeShadowAlpha": 0.32
+          "shapeShadowAlpha": 0.32,
+          "shapeLayerCount": 4,
+          "shapeLayerOffsetXPx": 0.32,
+          "shapeLayerOffsetYPx": 1.05,
+          "shapeLayerSkewXDeg": -0.35,
+          "shapeLayerAlpha": 0.14
         }
       },
       "sizing": {

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -163,7 +163,7 @@ window.SCRATCHBONES_CONFIG = {
       "cards": {
         "baseScale": 0.5,
         "depth": {
-          "perspectivePx": 900,
+          "perspectivePx": 620,
           "originXPct": 0.5,
           "originYPct": 0.92,
           "tiltXDeg": 8,
@@ -175,7 +175,11 @@ window.SCRATCHBONES_CONFIG = {
           "shapeLayerOffsetXPx": 0.32,
           "shapeLayerOffsetYPx": 1.05,
           "shapeLayerSkewXDeg": -0.35,
-          "shapeLayerAlpha": 0.14
+          "shapeLayerAlpha": 0.14,
+          "bottomLayerOffsetXPx": 1.1,
+          "bottomLayerOffsetYPx": 4.2,
+          "bottomLayerSkewXDeg": -1.8,
+          "bottomLayerAlpha": 0.34
         }
       },
       "sizing": {
@@ -818,7 +822,7 @@ window.SCRATCHBONES_CONFIG = {
           "fallbackSrc": "2DScratchBoneWild.png"
         },
         "flipped": {
-          "src": "2DScratchboneFlipped.png",
+          "src": "2DScratchBoneFlipped.png",
           "fallbackSrc": "2DScratchBoneFlipped.png"
         },
         "rankTemplate": {


### PR DESCRIPTION
### Motivation
- Ensure `layout.cards.depth` runtime knobs can be set to `0` (e.g., to disable tilt/depth) instead of being treated as falsy and silently falling back to defaults. 
- Make the pseudo‑3D camera read more like a seated head/desk viewpoint rather than an extreme overhead camera.

### Description
- Replaced `Number(...) || <default>` parsing with a `numberOrDefault` helper and use it when normalizing `layout.cards.depth` fields so explicit `0` values are preserved and then clamped with `clampNumber` (`applyLayoutContract` now uses `numberOrDefault(layoutCardDepth.*, <default>)`).
- Moved the `numberOrDefault` helper into the `applyLayoutContract` scope before it's consumed to avoid temporal ordering issues.
- Retuned default camera/depth values in both the runtime CSS defaults and the docs config: `perspectivePx: 900`, `originYPct: 0.92`, `tiltXDeg: 8`, `depthZPx: 18`, `artLiftZPx: 6` (changes applied in `ScratchbonesBluffGame.html` and `docs/config/scratchbones-config.js`).
- Wire-up kept intact end-to-end: `docs/config` -> normalized `SCRATCHBONES_GAME.layout.cards.depth` -> `applyLayoutContract` -> CSS custom properties (`--layout-card-perspective`, `--layout-card-perspective-origin-*`, `--layout-card-tilt-x`, `--layout-card-depth-z`, `--layout-card-art-z`) consumed by `#app`, `.card`, `.cardArt`, and `.cardLabel` styles.

### Testing
- Ran `npm test -- --runInBand tests/asset-manifest-clean.test.js` and it passed (1 test, 1 suite, 0 failures). 
- Note: visual verification (browser screenshot) was not executed because the headless browser tooling is unavailable in this environment; visual tuning should be validated in a browser preview.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb623ae39083268f14c218ffa40269)