### PR TITLE
Play boneclack SFX when card lerp animations complete

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -5217,10 +5217,14 @@
                   requestAnimationFrame(() => {
                     clone.style.transition = `transform ${FLY_MS}ms cubic-bezier(0.4,0,0.2,1)`;
                     clone.style.transform = 'none';
+                    let finished = false;
                     const done = () => {
+                      if (finished) return;
+                      finished = true;
                       clone.remove();
                       if (activeClones.get(id) === clone) activeClones.delete(id);
                       img.style.opacity = '';
+                      SCRATCHBONES_AUDIO.playMovement('lerpComplete');
                     };
                     clone.addEventListener('transitionend', done, { once: true });
                     setTimeout(done, FLY_MS + 100);
@@ -5273,10 +5277,14 @@
             requestAnimationFrame(() => {
               clone.style.transition = `transform ${FLY_MS}ms cubic-bezier(0.4,0,0.2,1)`;
               clone.style.transform = 'none';
+              let finished = false;
               const done = () => {
+                if (finished) return;
+                finished = true;
                 clone.remove();
                 if (activeClones.get(id) === clone) activeClones.delete(id);
                 img.style.opacity = '';
+                SCRATCHBONES_AUDIO.playMovement('lerpComplete');
               };
               clone.addEventListener('transitionend', done, { once: true });
               setTimeout(done, FLY_MS + 100);

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -840,7 +840,8 @@ window.SCRATCHBONES_CONFIG = {
           "tableToClaim": { "url": "./docs/assets/audio/scratchbones/sfx/table-to-claim.mp3", "pitch": 1.08, "tempo": 1.0, "volume": 0.9 },
           "claimToHand": { "url": "./docs/assets/audio/scratchbones/sfx/claim-to-hand.mp3", "pitch": 0.92, "tempo": 0.98, "volume": 0.94 },
           "opponentToTable": { "url": "./docs/assets/audio/scratchbones/sfx/opponent-to-table.mp3", "pitch": 0.88, "tempo": 0.94, "volume": 0.9 },
-          "fadeIn": { "url": "./docs/assets/audio/scratchbones/sfx/card-fade.mp3", "pitch": 1.0, "tempo": 1.02, "volume": 0.78 }
+          "fadeIn": { "url": "./docs/assets/audio/scratchbones/sfx/card-fade.mp3", "pitch": 1.0, "tempo": 1.02, "volume": 0.78 },
+          "lerpComplete": { "url": "./docs/assets/audio/sfx/tablesounds/boneclack1.m4a", "pitch": 1.0, "tempo": 1.0, "volume": 0.9 }
         },
         "challenge": {
           "start": { "url": "./docs/assets/audio/scratchbones/sfx/challenge-start.mp3", "pitch": 1.0, "tempo": 1.0, "volume": 1.0 },


### PR DESCRIPTION
### Motivation
- Add audible feedback when a card finishes its lerp/flight animation using the supplied `boneclack1.m4a` asset.  
- Traced the card animation path end-to-end: `render()` → `cardAnimator.capturePreRender()` → `cardAnimator.animatePostRender()` → clone element transform transition → `transitionend` / timeout fallback, and chose the completion point for SFX playback.  
- Keep asset paths configurable instead of hardcoding by placing the new cue in the existing audio config object.

### Description
- Play the new movement cue by calling `SCRATCHBONES_AUDIO.playMovement('lerpComplete')` at the end of both clone-based card transform completion handlers in `ScratchbonesBluffGame.html`.  
- Add `finished` guards in both completion callbacks so cleanup and sound playback run only once even if both `transitionend` and the timeout fallback fire.  
- Add `movement.lerpComplete` entry to `docs/config/scratchbones-config.js` pointing to `./docs/assets/audio/sfx/tablesounds/boneclack1.m4a` so the SFX is controlled by config rather than hardcoded.

### Testing
- Ran `git diff --check` to verify no whitespace/errors and it passed.  
- Reviewed diffs with `git diff -- ScratchbonesBluffGame.html docs/config/scratchbones-config.js` and verified the SFX is invoked only on lerp completion paths.  
- Confirmed changes staged and committed with `git add` + `git commit` (commit message: "Play bone clack SFX when card lerp animations complete").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd707f4b88326b1847cbd6aa9031b)