### PR TITLE
Schedule lerp-complete audio for card movement and add config

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -5134,6 +5134,17 @@
       const OPPONENT_STAGGER_MS = 40;
       const snapshots = new Map();
       const activeClones = new Map();
+      function scheduleLerpCompletionAudio(cardCount, flyDurationMs) {
+        if (!Number.isFinite(cardCount) || cardCount <= 0) return;
+        const lerpAudioCfg = SCRATCHBONES_GAME.assets?.audio?.movement?.lerpComplete || {};
+        const leadMs = Math.max(0, Number(lerpAudioCfg.leadMs) || 500);
+        const extraCardDelayMs = Math.max(0, Number(lerpAudioCfg.extraCardDelayMs) || 35);
+        const firstDelayMs = Math.max(0, Number(flyDurationMs) - leadMs);
+        for (let i = 0; i < cardCount; i++) {
+          const delayMs = firstDelayMs + (i * extraCardDelayMs);
+          setTimeout(() => SCRATCHBONES_AUDIO.playMovement('lerpComplete'), delayMs);
+        }
+      }
 
       function getContainerType(el) {
         if (el.closest('.handScroll')) return 'hand';
@@ -5179,6 +5190,7 @@
 
         requestAnimationFrame(() => requestAnimationFrame(() => {
           let opponentCardIdx = 0;
+          let lerpCardCount = 0;
 
           newCards.forEach(({ id, img, containerType }) => {
             const snapshot = snapshots.get(id);
@@ -5191,6 +5203,7 @@
                 SCRATCHBONES_AUDIO.playMovement('opponentToTable');
                 const staggerDelay = opponentCardIdx * OPPONENT_STAGGER_MS;
                 opponentCardIdx++;
+                lerpCardCount += 1;
                 const existing = activeClones.get(id);
                 if (existing) existing.remove();
                 const avatarCx = actorRect.left + actorRect.width / 2;
@@ -5217,7 +5230,10 @@
                   requestAnimationFrame(() => {
                     clone.style.transition = `transform ${FLY_MS}ms cubic-bezier(0.4,0,0.2,1)`;
                     clone.style.transform = 'none';
+                    let finished = false;
                     const done = () => {
+                      if (finished) return;
+                      finished = true;
                       clone.remove();
                       if (activeClones.get(id) === clone) activeClones.delete(id);
                       img.style.opacity = '';
@@ -5270,10 +5286,14 @@
             document.body.appendChild(clone);
             activeClones.set(id, clone);
             img.style.opacity = '0';
+            lerpCardCount += 1;
             requestAnimationFrame(() => {
               clone.style.transition = `transform ${FLY_MS}ms cubic-bezier(0.4,0,0.2,1)`;
               clone.style.transform = 'none';
+              let finished = false;
               const done = () => {
+                if (finished) return;
+                finished = true;
                 clone.remove();
                 if (activeClones.get(id) === clone) activeClones.delete(id);
                 img.style.opacity = '';
@@ -5282,6 +5302,7 @@
               setTimeout(done, FLY_MS + 100);
             });
           });
+          scheduleLerpCompletionAudio(lerpCardCount, FLY_MS);
           snapshots.clear();
         }));
       }

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -840,7 +840,15 @@ window.SCRATCHBONES_CONFIG = {
           "tableToClaim": { "url": "./docs/assets/audio/scratchbones/sfx/table-to-claim.mp3", "pitch": 1.08, "tempo": 1.0, "volume": 0.9 },
           "claimToHand": { "url": "./docs/assets/audio/scratchbones/sfx/claim-to-hand.mp3", "pitch": 0.92, "tempo": 0.98, "volume": 0.94 },
           "opponentToTable": { "url": "./docs/assets/audio/scratchbones/sfx/opponent-to-table.mp3", "pitch": 0.88, "tempo": 0.94, "volume": 0.9 },
-          "fadeIn": { "url": "./docs/assets/audio/scratchbones/sfx/card-fade.mp3", "pitch": 1.0, "tempo": 1.02, "volume": 0.78 }
+          "fadeIn": { "url": "./docs/assets/audio/scratchbones/sfx/card-fade.mp3", "pitch": 1.0, "tempo": 1.02, "volume": 0.78 },
+          "lerpComplete": {
+            "url": "./docs/assets/audio/sfx/tablesounds/boneclack1.m4a",
+            "pitch": 1.0,
+            "tempo": 1.0,
+            "volume": 0.9,
+            "leadMs": 500,
+            "extraCardDelayMs": 35
+          }
         },
         "challenge": {
           "start": { "url": "./docs/assets/audio/scratchbones/sfx/challenge-start.mp3", "pitch": 1.0, "tempo": 1.0, "volume": 1.0 },


### PR DESCRIPTION
### Motivation

- Play a short "lerp complete" sound timed to card-flight animations so movement feels more responsive when multiple cards animate into place.

### Description

- Add `scheduleLerpCompletionAudio` function in the `cardAnimator` to schedule `SCRATCHBONES_AUDIO.playMovement('lerpComplete')` calls spaced from the end of flight using `leadMs` and `extraCardDelayMs` timing. 
- Track animated card count via `lerpCardCount` for both avatar-origin flights and snapshot-based lerps, and call `scheduleLerpCompletionAudio(lerpCardCount, FLY_MS)` after preparing clones. 
- Prevent duplicate clone cleanup by guarding the `done` handler with a `finished` boolean to ensure removal runs once. 
- Add a `lerpComplete` audio entry to `docs/config/scratchbones-config.js` under `audio.movement` including `url`, sound properties, and timing controls `leadMs` and `extraCardDelayMs`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd707f4b88326b1847cbd6aa9031b)