### PR TITLE
Fix lerp-complete timing and preserve explicit zero audio timing config

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -5134,6 +5134,21 @@
       const OPPONENT_STAGGER_MS = 40;
       const snapshots = new Map();
       const activeClones = new Map();
+      function readNonNegativeNumber(rawValue, fallbackValue) {
+        const parsedValue = Number(rawValue);
+        return Number.isFinite(parsedValue) && parsedValue >= 0 ? parsedValue : fallbackValue;
+      }
+      function scheduleLerpCompletionAudio(cardCount, flyDurationMs) {
+        if (!Number.isFinite(cardCount) || cardCount <= 0) return;
+        const lerpAudioCfg = SCRATCHBONES_GAME.assets?.audio?.movement?.lerpComplete || {};
+        const leadMs = readNonNegativeNumber(lerpAudioCfg.leadMs, 0);
+        const extraCardDelayMs = readNonNegativeNumber(lerpAudioCfg.extraCardDelayMs, 0);
+        const firstDelayMs = Math.max(0, Number(flyDurationMs) - leadMs);
+        for (let i = 0; i < cardCount; i++) {
+          const delayMs = firstDelayMs + (i * extraCardDelayMs);
+          setTimeout(() => SCRATCHBONES_AUDIO.playMovement('lerpComplete'), delayMs);
+        }
+      }
 
       function getContainerType(el) {
         if (el.closest('.handScroll')) return 'hand';
@@ -5179,6 +5194,7 @@
 
         requestAnimationFrame(() => requestAnimationFrame(() => {
           let opponentCardIdx = 0;
+          let lerpCardCount = 0;
 
           newCards.forEach(({ id, img, containerType }) => {
             const snapshot = snapshots.get(id);
@@ -5191,6 +5207,7 @@
                 SCRATCHBONES_AUDIO.playMovement('opponentToTable');
                 const staggerDelay = opponentCardIdx * OPPONENT_STAGGER_MS;
                 opponentCardIdx++;
+                lerpCardCount += 1;
                 const existing = activeClones.get(id);
                 if (existing) existing.remove();
                 const avatarCx = actorRect.left + actorRect.width / 2;
@@ -5217,7 +5234,10 @@
                   requestAnimationFrame(() => {
                     clone.style.transition = `transform ${FLY_MS}ms cubic-bezier(0.4,0,0.2,1)`;
                     clone.style.transform = 'none';
+                    let finished = false;
                     const done = () => {
+                      if (finished) return;
+                      finished = true;
                       clone.remove();
                       if (activeClones.get(id) === clone) activeClones.delete(id);
                       img.style.opacity = '';
@@ -5270,10 +5290,14 @@
             document.body.appendChild(clone);
             activeClones.set(id, clone);
             img.style.opacity = '0';
+            lerpCardCount += 1;
             requestAnimationFrame(() => {
               clone.style.transition = `transform ${FLY_MS}ms cubic-bezier(0.4,0,0.2,1)`;
               clone.style.transform = 'none';
+              let finished = false;
               const done = () => {
+                if (finished) return;
+                finished = true;
                 clone.remove();
                 if (activeClones.get(id) === clone) activeClones.delete(id);
                 img.style.opacity = '';
@@ -5282,6 +5306,7 @@
               setTimeout(done, FLY_MS + 100);
             });
           });
+          scheduleLerpCompletionAudio(lerpCardCount, FLY_MS);
           snapshots.clear();
         }));
       }

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -840,7 +840,15 @@ window.SCRATCHBONES_CONFIG = {
           "tableToClaim": { "url": "./docs/assets/audio/scratchbones/sfx/table-to-claim.mp3", "pitch": 1.08, "tempo": 1.0, "volume": 0.9 },
           "claimToHand": { "url": "./docs/assets/audio/scratchbones/sfx/claim-to-hand.mp3", "pitch": 0.92, "tempo": 0.98, "volume": 0.94 },
           "opponentToTable": { "url": "./docs/assets/audio/scratchbones/sfx/opponent-to-table.mp3", "pitch": 0.88, "tempo": 0.94, "volume": 0.9 },
-          "fadeIn": { "url": "./docs/assets/audio/scratchbones/sfx/card-fade.mp3", "pitch": 1.0, "tempo": 1.02, "volume": 0.78 }
+          "fadeIn": { "url": "./docs/assets/audio/scratchbones/sfx/card-fade.mp3", "pitch": 1.0, "tempo": 1.02, "volume": 0.78 },
+          "lerpComplete": {
+            "url": "./docs/assets/audio/sfx/tablesounds/boneclack1.m4a",
+            "pitch": 1.0,
+            "tempo": 1.0,
+            "volume": 0.9,
+            "leadMs": 120,
+            "extraCardDelayMs": 35
+          }
         },
         "challenge": {
           "start": { "url": "./docs/assets/audio/scratchbones/sfx/challenge-start.mp3", "pitch": 1.0, "tempo": 1.0, "volume": 1.0 },


### PR DESCRIPTION
### Motivation

- The lerp-complete SFX was being mis-timed because the shipped `leadMs` (500ms) exceeded the default card flight duration (400ms), causing the cue to fire at animation start instead of near completion. 
- The timing parsing used `Number(...) || default`, which treated explicit `0` values as falsy and silently replaced them with defaults, making precise tuning impossible.

### Description

- Added a small helper `readNonNegativeNumber(rawValue, fallbackValue)` inside the `cardAnimator` in `ScratchbonesBluffGame.html` to parse non-negative numeric config values while preserving explicit `0` values. 
- Updated `scheduleLerpCompletionAudio` to use `readNonNegativeNumber` for `leadMs` and `extraCardDelayMs` and to fall back to `0` instead of using a falsy-OR pattern. 
- Tuned the shipped config `assets.audio.movement.lerpComplete.leadMs` in `docs/config/scratchbones-config.js` from `500` to `120` so the default cue lands near the end of the default 400ms flight. 
- Left the scheduling logic (`firstDelayMs = Math.max(0, Number(flyDurationMs) - leadMs)` and the per-card stagger loop) intact so the fix is localized to parsing and default values.

### Testing

- Ran `git diff --check` with no problems reported. 
- Inspected the diff for `ScratchbonesBluffGame.html` and `docs/config/scratchbones-config.js` via `git diff -- ScratchbonesBluffGame.html docs/config/scratchbones-config.js` to verify the intended changes. 
- Verified workspace status with `git status --short` and prepared the change for commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd707f4b88326b1847cbd6aa9031b)