### PR TITLE
Fix duplicate claim-cluster card landing SFX replay

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -5134,18 +5134,6 @@
       const OPPONENT_STAGGER_MS = 40;
       const snapshots = new Map();
       const activeClones = new Map();
-      function scheduleLerpCompletionAudio(cardCount, flyDurationMs) {
-        if (!Number.isFinite(cardCount) || cardCount <= 0) return;
-        const lerpAudioCfg = SCRATCHBONES_GAME.assets?.audio?.movement?.lerpComplete || {};
-        const leadMs = Math.max(0, Number(lerpAudioCfg.leadMs) || 500);
-        const extraCardDelayMs = Math.max(0, Number(lerpAudioCfg.extraCardDelayMs) || 35);
-        const firstDelayMs = Math.max(0, Number(flyDurationMs) - leadMs);
-        for (let i = 0; i < cardCount; i++) {
-          const delayMs = firstDelayMs + (i * extraCardDelayMs);
-          setTimeout(() => SCRATCHBONES_AUDIO.playMovement('lerpComplete'), delayMs);
-        }
-      }
-
       function getContainerType(el) {
         if (el.closest('.handScroll')) return 'hand';
         if (el.closest('.tableViewCards')) return 'table';
@@ -5190,7 +5178,6 @@
 
         requestAnimationFrame(() => requestAnimationFrame(() => {
           let opponentCardIdx = 0;
-          let lerpCardCount = 0;
 
           newCards.forEach(({ id, img, containerType }) => {
             const snapshot = snapshots.get(id);
@@ -5203,7 +5190,6 @@
                 SCRATCHBONES_AUDIO.playMovement('opponentToTable');
                 const staggerDelay = opponentCardIdx * OPPONENT_STAGGER_MS;
                 opponentCardIdx++;
-                lerpCardCount += 1;
                 const existing = activeClones.get(id);
                 if (existing) existing.remove();
                 const avatarCx = actorRect.left + actorRect.width / 2;
@@ -5287,7 +5273,6 @@
             document.body.appendChild(clone);
             activeClones.set(id, clone);
             img.style.opacity = '0';
-            lerpCardCount += 1;
             requestAnimationFrame(() => {
               clone.style.transition = `transform ${FLY_MS}ms cubic-bezier(0.4,0,0.2,1)`;
               clone.style.transform = 'none';
@@ -5304,7 +5289,6 @@
               setTimeout(done, FLY_MS + 100);
             });
           });
-          scheduleLerpCompletionAudio(lerpCardCount, FLY_MS);
           snapshots.clear();
         }));
       }


### PR DESCRIPTION
### Motivation
- Players reported the card-count "boneclack" / `lerpComplete` sound playing a second time ~1s after cards land in the claim cluster; tracing `cardAnimator.animatePostRender()` showed the same `lerpComplete` was fired both from each clone's transition-complete callback and again from a delayed batch scheduler, causing the duplicate SFX.

### Description
- Removed the delayed batch helper `scheduleLerpCompletionAudio` and its invocation to prevent a second, delayed `SCRATCHBONES_AUDIO.playMovement('lerpComplete')` from firing.
- Removed now-unused bookkeeping for `lerpCardCount` that was only used to drive the removed scheduler.
- Kept the transition-end callback (`SCRATCHBONES_AUDIO.playMovement('lerpComplete')`) on clone completion as the single source of truth for card-landing audio in `cardAnimator`.
- File modified: `ScratchbonesBluffGame.html` (removed helper and related increments/call sites).

### Testing
- Ran the repository test target focused on conflict checks with `npm test -- --runInBand tests/no-conflicts.test.js`, which failed due to a pre-existing unrelated issue (`docs/js/app.js` contains a git merge marker); the failure is unrelated to the audio change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec187d45fc832690a2768699fddcd7)