### PR TITLE
Ensure Scratchbones SFX can play before first human action (audio unlock + queued SFX)

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2634,11 +2634,58 @@
       const cfg = SCRATCHBONES_GAME.assets?.audio || {};
       const clamp = (value, min, max) => Math.min(max, Math.max(min, Number(value) || 0));
       const isUrl = (value) => typeof value === 'string' && value.trim().length > 0;
+      const unlockEvents = ['pointerdown', 'keydown', 'touchstart', 'mousedown'];
       let bgmAudio = null;
       let bgmPlaylistIndex = 0;
       let challengeBgmActive = false;
       const failedPlaylistTracks = new Set();
       let playlistExhausted = false;
+      let unlockHooksAttached = false;
+      let audioUnlocked = false;
+      const pendingSfx = [];
+
+      function cloneSfxEntry(entry) {
+        if (!entry) return null;
+        return {
+          url: entry.url,
+          pitch: entry.pitch,
+          tempo: entry.tempo,
+          volume: entry.volume,
+        };
+      }
+
+      function queuePendingSfx(entry) {
+        const pendingEntry = cloneSfxEntry(entry);
+        if (!pendingEntry) return;
+        pendingSfx.push(pendingEntry);
+        if (pendingSfx.length > 16) pendingSfx.shift();
+      }
+
+      function flushPendingSfx() {
+        if (!audioUnlocked || !pendingSfx.length) return;
+        const queued = pendingSfx.splice(0, pendingSfx.length);
+        queued.forEach((entry) => playSfx(entry, { queueIfBlocked: false }));
+      }
+
+      function markAudioUnlocked() {
+        if (audioUnlocked) return;
+        audioUnlocked = true;
+        flushPendingSfx();
+      }
+
+      function attachAudioUnlockHooks() {
+        if (unlockHooksAttached || !cfg.enabled) return;
+        unlockHooksAttached = true;
+        const unlock = () => {
+          unlockEvents.forEach((eventName) => {
+            window.removeEventListener(eventName, unlock, true);
+          });
+          markAudioUnlocked();
+        };
+        unlockEvents.forEach((eventName) => {
+          window.addEventListener(eventName, unlock, { once: true, passive: true, capture: true });
+        });
+      }
 
       function buildAudio(url, volume) {
         if (!cfg.enabled || !isUrl(url)) return null;
@@ -2652,12 +2699,19 @@
           return null;
         }
       }
-      function safePlay(audio) {
+      function safePlay(audio, { onBlocked } = {}) {
         if (!audio) return;
         const p = audio.play?.();
-        if (p && typeof p.catch === 'function') p.catch(() => {});
+        if (p && typeof p.then === 'function') {
+          p.then(() => {
+            markAudioUnlocked();
+          }).catch((error) => {
+            const blockedByPolicy = error?.name === 'NotAllowedError';
+            if (blockedByPolicy) onBlocked?.();
+          });
+        }
       }
-      function playSfx(entry) {
+      function playSfx(entry, { queueIfBlocked = true } = {}) {
         if (!cfg.enabled || !entry || !isUrl(entry.url)) return;
         const playbackRate = clamp((Number(entry.pitch) || 1) * (Number(entry.tempo) || 1), 0.5, 2);
         const baseVolume = clamp(cfg.sfxVolume ?? 1, 0, 1);
@@ -2665,7 +2719,11 @@
         const audio = buildAudio(entry.url, volume);
         if (!audio) return;
         audio.playbackRate = playbackRate;
-        safePlay(audio);
+        safePlay(audio, {
+          onBlocked: () => {
+            if (queueIfBlocked) queuePendingSfx(entry);
+          },
+        });
       }
       function fadeTo(audio, targetVolume, durationMs, onDone) {
         if (!audio) { onDone?.(); return; }
@@ -2751,6 +2809,7 @@
         challengeBgmActive = false;
         playNextPlaylistTrack();
       }
+      attachAudioUnlockHooks();
       return {
         playMovement(type) { playSfx(cfg.movement?.[type]); },
         playChallengeStart() { playSfx(cfg.challenge?.start); },


### PR DESCRIPTION
### Motivation
- Fix an issue where early movement SFX (e.g. boneclack on opponent card plays / lerpComplete) were dropped until the player first interacted, caused by browser autoplay policy blocking `Audio.play()` and the code swallowing promise rejections. 
- Provide a robust, input-driven unlock path so SFX triggered by opponent actions play or are replayed once audio becomes available.

### Description
- Add an input-driven audio unlock lifecycle (`unlockEvents`, `attachAudioUnlockHooks`, `markAudioUnlocked`) that listens for first user input and marks audio as unlocked. 
- Introduce a bounded pending SFX queue (`pendingSfx`) with `cloneSfxEntry`, `queuePendingSfx`, and `flushPendingSfx` to retain attempts to play small SFX and replay them after unlock. 
- Update `safePlay` to observe the `Audio.play()` promise, call `markAudioUnlocked()` on success, and invoke an `onBlocked` callback when the promise rejects with `NotAllowedError`. 
- Update `playSfx` to accept a `queueIfBlocked` option and enqueue blocked SFX instead of silently dropping them, and wire `attachAudioUnlockHooks()` so unlock hooks are installed at module initialization.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran `npm run test:unit` and the test suite failed due to pre-existing unrelated failures in the repository (unit run summary: 318 passed, 29 failed); no new test failures were introduced by this change according to the traced SFX call path inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec207fa288832698ffb45425d59d6b)