### PR TITLE
Reconnect Scratchbones card placement lerp-complete SFX

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2689,6 +2689,17 @@
         audio.playbackRate = playbackRate;
         safePlay(audio);
       }
+      function playSfxDelayed(entry, delayMs = 0) {
+        if (!cfg.enabled || !entry || !isUrl(entry.url)) return;
+        const delay = Math.max(0, Number(delayMs) || 0);
+        if (delay === 0) {
+          playSfx(entry);
+          return;
+        }
+        setTimeout(() => {
+          playSfx(entry);
+        }, delay);
+      }
       function fadeTo(audio, targetVolume, durationMs, onDone) {
         if (!audio) { onDone?.(); return; }
         const duration = Math.max(1, Number(durationMs) || 1);
@@ -2773,8 +2784,20 @@
         challengeBgmActive = false;
         playNextPlaylistTrack();
       }
+      function playLerpComplete({ durationMs = 0, cardIndex = 0, staggerMs = 0 } = {}) {
+        const entry = cfg.movement?.lerpComplete;
+        if (!entry || !isUrl(entry.url)) return;
+        const leadMs = Math.max(0, Number(entry.leadMs) || 0);
+        const extraCardDelayMs = Math.max(0, Number(entry.extraCardDelayMs) || 0);
+        const travelDuration = Math.max(0, Number(durationMs) || 0);
+        const cardDelay = Math.max(0, Number(cardIndex) || 0) * Math.max(0, Number(staggerMs) || 0);
+        const staggeredExtraDelay = Math.max(0, Number(cardIndex) || 0) * extraCardDelayMs;
+        const playDelayMs = Math.max(0, cardDelay + travelDuration - leadMs + staggeredExtraDelay);
+        playSfxDelayed(entry, playDelayMs);
+      }
       return {
         playMovement(type) { playSfx(cfg.movement?.[type]); },
+        playLerpComplete,
         playChallengeStart() { playSfx(cfg.challenge?.start); },
         playChallengeEnd() { playSfx(cfg.challenge?.end); },
         startPlaylist,
@@ -5221,6 +5244,11 @@
                 // Opponent card: fly from cluster avatar center, start tiny
                 SCRATCHBONES_AUDIO.playMovement('opponentToTable');
                 const staggerDelay = opponentCardIdx * OPPONENT_STAGGER_MS;
+                SCRATCHBONES_AUDIO.playLerpComplete({
+                  durationMs: FLY_MS,
+                  cardIndex: opponentCardIdx,
+                  staggerMs: OPPONENT_STAGGER_MS,
+                });
                 opponentCardIdx++;
                 const existing = activeClones.get(id);
                 if (existing) existing.remove();
@@ -5280,6 +5308,7 @@
                     ? 'claimToHand'
                     : 'fadeIn';
             SCRATCHBONES_AUDIO.playMovement(movementType);
+            SCRATCHBONES_AUDIO.playLerpComplete({ durationMs: FLY_MS });
             const existing = activeClones.get(id);
             if (existing) existing.remove();
             const dx = snapshot.rect.left - newRect.left;


### PR DESCRIPTION
### Motivation
- Card-placement completion SFX stopped firing after a merge even though `docs/config/scratchbones-config.js` still defines `assets.audio.movement.lerpComplete`, so the runtime needed to consume that cue and schedule it relative to card flight timing. 
- The intent is to play the final clack when cards settle (timed to animation duration and stagger), not only at movement start, so timing must be driven from config values and flight metrics.

### Description
- Added `playSfxDelayed(entry, delayMs)` to the Scratchbones audio controller to support scheduled SFX playback. 
- Added `playLerpComplete({ durationMs, cardIndex, staggerMs })` which reads `movement.lerpComplete` config (`leadMs` and `extraCardDelayMs`) and schedules the completion clack relative to travel duration and card index. 
- Wired `playLerpComplete` into both the opponent staggered flight path and the normal inter-container lerp path so the completion clack fires when cards settle again. 
- All changes are contained in `ScratchbonesBluffGame.html` and leverage the existing `docs/config/scratchbones-config.js` movement configuration without changing config files.

### Testing
- Ran the test suite with `npm test -- --runInBand`; the targeted audio wiring and modified HTML parse and load, but the full suite fails due to unrelated baseline test failures. 
- Noted failing tests include angle conversion centralization (`tests/angle-conversion.test.js`) and an attack timeline state test (`tests/attack-timeline-state.test.js`), which are unrelated to this audio change. 
- The new SFX scheduling logic is exercised via the runtime wiring and uses config values from `docs/config/scratchbones-config.js` (`movement.lerpComplete.leadMs` and `extraCardDelayMs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec297897d4832684cbc21199d24d26)