### PR TITLE
Add delayed SFX and lerp-complete audio hooks; make challenge timer configurable and robust

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2689,6 +2689,17 @@
         audio.playbackRate = playbackRate;
         safePlay(audio);
       }
+      function playSfxDelayed(entry, delayMs = 0) {
+        if (!cfg.enabled || !entry || !isUrl(entry.url)) return;
+        const delay = Math.max(0, Number(delayMs) || 0);
+        if (delay === 0) {
+          playSfx(entry);
+          return;
+        }
+        setTimeout(() => {
+          playSfx(entry);
+        }, delay);
+      }
       function fadeTo(audio, targetVolume, durationMs, onDone) {
         if (!audio) { onDone?.(); return; }
         const duration = Math.max(1, Number(durationMs) || 1);
@@ -2773,8 +2784,20 @@
         challengeBgmActive = false;
         playNextPlaylistTrack();
       }
+      function playLerpComplete({ durationMs = 0, cardIndex = 0, staggerMs = 0 } = {}) {
+        const entry = cfg.movement?.lerpComplete;
+        if (!entry || !isUrl(entry.url)) return;
+        const leadMs = Math.max(0, Number(entry.leadMs) || 0);
+        const extraCardDelayMs = Math.max(0, Number(entry.extraCardDelayMs) || 0);
+        const travelDuration = Math.max(0, Number(durationMs) || 0);
+        const cardDelay = Math.max(0, Number(cardIndex) || 0) * Math.max(0, Number(staggerMs) || 0);
+        const staggeredExtraDelay = Math.max(0, Number(cardIndex) || 0) * extraCardDelayMs;
+        const playDelayMs = Math.max(0, cardDelay + travelDuration - leadMs + staggeredExtraDelay);
+        playSfxDelayed(entry, playDelayMs);
+      }
       return {
         playMovement(type) { playSfx(cfg.movement?.[type]); },
+        playLerpComplete,
         playChallengeStart() { playSfx(cfg.challenge?.start); },
         playChallengeEnd() { playSfx(cfg.challenge?.end); },
         startPlaylist,
@@ -3424,12 +3447,16 @@
         }, cumulativeDelay);
       }
       if (playerIndex === 0) {
-        setTimeout(() => {
-          if (state.challengeDecisionSession !== challengeSessionId) return;
-          if (state.challengeWindow && !state.challengeIntro && !state.betting && !state.gameOver && state.challengeWindow.lastPlay?.playerIndex === playerIndex) {
-            advanceAfterNoChallenge(playerIndex);
-          }
-        }, cumulativeDelay + 30);
+        const countdownDurationMs = cumulativeDelay + 30;
+        startChallengeTimer({
+          durationMs: countdownDurationMs,
+          onExpire: () => {
+            if (state.challengeDecisionSession !== challengeSessionId) return;
+            if (state.challengeWindow && !state.challengeIntro && !state.betting && !state.gameOver && state.challengeWindow.lastPlay?.playerIndex === playerIndex) {
+              advanceAfterNoChallenge(playerIndex);
+            }
+          },
+        });
       }
     }
     function humanChallenge() {
@@ -4378,19 +4405,23 @@
       cluster.appendChild(shell);
       setTimeout(() => { if (shell.parentNode) shell.remove(); }, durationMs + 100);
     }
-    function startChallengeTimer() {
+    function startChallengeTimer({ durationMs = CHALLENGE_TIMER_SECS * 1000, onExpire = null } = {}) {
       clearChallengeTimer();
-      const durationMs = CHALLENGE_TIMER_SECS * 1000;
-      const tickMs = Math.round(durationMs / 3);
-      showChallengeCountdownBurst(3, tickMs - 80);
-      state.challengeTimerT1 = setTimeout(() => showChallengeCountdownBurst(2, tickMs - 80), tickMs);
-      state.challengeTimerT2 = setTimeout(() => showChallengeCountdownBurst(1, tickMs - 80), tickMs * 2);
+      const totalDurationMs = Math.max(1, Number(durationMs) || (CHALLENGE_TIMER_SECS * 1000));
+      const tickMs = Math.max(1, Math.round(totalDurationMs / 3));
+      const burstDurationMs = Math.max(120, tickMs - 80);
+      const expireHandler = typeof onExpire === 'function'
+        ? onExpire
+        : () => humanAcceptNoChallenge();
+      showChallengeCountdownBurst(3, burstDurationMs);
+      state.challengeTimerT1 = setTimeout(() => showChallengeCountdownBurst(2, burstDurationMs), tickMs);
+      state.challengeTimerT2 = setTimeout(() => showChallengeCountdownBurst(1, burstDurationMs), tickMs * 2);
       state.challengeTimer = setTimeout(() => {
         state.challengeTimer = null;
         if (state.challengeWindow && !state.betting && !state.gameOver) {
-          humanAcceptNoChallenge();
+          expireHandler();
         }
-      }, durationMs);
+      }, totalDurationMs);
     }
     function clearChallengeTimer() {
       clearTimeout(state.challengeTimer);
@@ -5210,6 +5241,12 @@
 
         requestAnimationFrame(() => requestAnimationFrame(() => {
           let opponentCardIdx = 0;
+          const lerpCompleteScheduledIds = new Set();
+          const scheduleLerpComplete = (cardId, opts) => {
+            if (lerpCompleteScheduledIds.has(cardId)) return;
+            lerpCompleteScheduledIds.add(cardId);
+            SCRATCHBONES_AUDIO.playLerpComplete(opts);
+          };
 
           newCards.forEach(({ id, img, containerType }) => {
             const snapshot = snapshots.get(id);
@@ -5221,6 +5258,11 @@
                 // Opponent card: fly from cluster avatar center, start tiny
                 SCRATCHBONES_AUDIO.playMovement('opponentToTable');
                 const staggerDelay = opponentCardIdx * OPPONENT_STAGGER_MS;
+                scheduleLerpComplete(id, {
+                  durationMs: FLY_MS,
+                  cardIndex: opponentCardIdx,
+                  staggerMs: OPPONENT_STAGGER_MS,
+                });
                 opponentCardIdx++;
                 const existing = activeClones.get(id);
                 if (existing) existing.remove();
@@ -5280,6 +5322,7 @@
                     ? 'claimToHand'
                     : 'fadeIn';
             SCRATCHBONES_AUDIO.playMovement(movementType);
+            scheduleLerpComplete(id, { durationMs: FLY_MS });
             const existing = activeClones.get(id);
             if (existing) existing.remove();
             const dx = snapshot.rect.left - newRect.left;


### PR DESCRIPTION
### Motivation

- Provide a way to play sound effects delayed to align with card movement animations and avoid duplicate lerp triggers. 
- Replace a raw timeout-based challenge countdown with a configurable timer API that supports custom expiration handlers and safer duration math. 

### Description

- Added `playSfxDelayed(entry, delayMs)` to audio utilities and exposed `playLerpComplete({durationMs, cardIndex, staggerMs})` on `SCRATCHBONES_AUDIO` to schedule movement-completion SFX using configurable lead/extra delays. 
- Introduced deduplication for lerp-complete scheduling (`lerpCompleteScheduledIds`) and `scheduleLerpComplete` in `animatePostRender` to call `SCRATCHBONES_AUDIO.playLerpComplete` for new or moved cards. 
- Replaced a direct `setTimeout` used when scheduling the player countdown expiry in `scheduleAiChallengeWindowDecisions` with `startChallengeTimer({ durationMs, onExpire })` so the countdown can be customized and canceled correctly. 
- Reworked `startChallengeTimer` signature to accept `{durationMs, onExpire}` with bounds checks and improved tick/burst timing, and preserved the original behavior by defaulting `onExpire` to `humanAcceptNoChallenge`. 

### Testing

- Ran the project linting (`npm run lint`) and the test suite (`npm test`), with no new failures observed. 
- Performed a headless integration smoke run of animation and audio flows, verifying that scheduled lerp-complete SFX fire and challenge countdowns expire via the provided handler; the smoke checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec297897d4832684cbc21199d24d26)