### PR TITLE
Add debug logging for audio playback and update default BGM playlist

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2761,8 +2761,10 @@
         const old = bgmAudio;
         const next = buildAudio(url, 0);
         if (!next) return;
+        console.debug('[scratchbones audio] setTrack', { url, loop, fadeMs, targetVolume });
         next.loop = !!loop;
         next.addEventListener('error', () => {
+          console.debug('[scratchbones audio] track error', { url, loop, challengeBgmActive });
           if (!challengeBgmActive && !loop) {
             failedPlaylistTracks.add(url);
             playNextPlaylistTrack();
@@ -2799,6 +2801,12 @@
           attempts -= 1;
           const url = playlist[idx];
           if (!isUrl(url) || failedPlaylistTracks.has(url)) continue;
+          console.debug('[scratchbones audio] selecting playlist track', {
+            url,
+            idx,
+            playlistSize: playlist.length,
+            failedCount: failedPlaylistTracks.size,
+          });
           setTrack(url, { loop: false });
           if (bgmAudio) {
             bgmAudio.onended = () => {

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -905,8 +905,7 @@ window.SCRATCHBONES_CONFIG = {
         },
         "bgm": {
           "playlist": [
-            "./docs/assets/audio/scratchbones/bgm/table-loop-01.mp3",
-            "./docs/assets/audio/scratchbones/bgm/table-loop-02.mp3"
+            "./docs/assets/audio/bgm/tankan_nocturne.m4a"
           ],
           "challenge": "./docs/assets/audio/scratchbones/bgm/challenge-loop.mp3"
         }


### PR DESCRIPTION
### Motivation

- Improve observability of the in-page audio system to make it easier to diagnose failing BGM tracks and playlist selection behavior. 
- Update the example/default documentation playlist to use a new single BGM asset.

### Description

- Add `console.debug` logging in `setTrack` to report track changes and in the track `error` handler to report load failures and `challengeBgmActive` state. 
- Add `console.debug` logging in `playNextPlaylistTrack` to show which playlist track is being selected along with index and failure counts. 
- Replace the two example playlist entries in `docs/config/scratchbones-config.js` with a single default BGM entry `./docs/assets/audio/bgm/tankan_nocturne.m4a`.
- No changes were made to fade, playback logic, or playlist failure handling beyond the logging statements.

### Testing

- No automated tests were added for this change. 
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef29c852c832685e9336b6af0f0d7)