### PR TITLE
Add CandleLightOverlay2D – animated candlelight overlay for game stage

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -7080,29 +7080,32 @@
       return cachedOccluders;
     }
 
-    // Light zones: lighting is clipped to .handWrap and .claimCluster only
-    let lastZoneMs = 0, cachedZones = [];
+    // Punch-outs: lighting covers all of #app; excluded rects are cut out with evenodd.
+    // .claimCluster is excluded while the challenge red background is active.
+    let lastZoneMs = 0, cachedPunchOuts = [];
     function maybeLightZones(app) {
       const now = performance.now();
       if (now - lastZoneMs < 100) return;
       lastZoneMs = now;
-      const ar = app.getBoundingClientRect();
-      cachedZones = [];
-      for (const sel of ['.handWrap', '.claimCluster']) {
-        const el = app.querySelector(sel);
-        if (!el) continue;
-        const r = el.getBoundingClientRect();
-        if (r.width < 1 || r.height < 1) continue;
-        cachedZones.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
+      cachedPunchOuts = [];
+      if (app.classList.contains('challenge-visuals-active')) {
+        const ar = app.getBoundingClientRect();
+        const cc = app.querySelector('.claimCluster');
+        if (cc) {
+          const r = cc.getBoundingClientRect();
+          if (r.width > 0 && r.height > 0)
+            cachedPunchOuts.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
+        }
       }
     }
 
     function withClip(ctx, fn) {
-      if (!cachedZones.length) { fn(); return; }
+      if (!cachedPunchOuts.length) { fn(); return; }
       ctx.save();
       ctx.beginPath();
-      for (const z of cachedZones) ctx.rect(z.x, z.y, z.w, z.h);
-      ctx.clip();
+      ctx.rect(0, 0, w, h);
+      for (const p of cachedPunchOuts) ctx.rect(p.x, p.y, p.w, p.h);
+      ctx.clip('evenodd');
       fn();
       ctx.restore();
     }

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -7080,31 +7080,30 @@
       return cachedOccluders;
     }
 
-    // Punch-outs: lighting covers all of #app except these immune elements.
-    const IMMUNE_SELECTORS = ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'];
-    let lastZoneMs = 0, cachedPunchOuts = [];
+    // Light zones: clip to every <img> visible inside #app.
+    // CSS-rendered panels (seats, spotlight, topbar) have no <img>, so they
+    // are immune without any explicit exclusion list or layer-order dependency.
+    let lastZoneMs = 0, cachedZones = [];
     function maybeLightZones(app) {
       const now = performance.now();
       if (now - lastZoneMs < 100) return;
       lastZoneMs = now;
       const ar = app.getBoundingClientRect();
-      cachedPunchOuts = [];
-      for (const sel of IMMUNE_SELECTORS) {
-        const el = app.querySelector(sel);
-        if (!el) continue;
-        const r = el.getBoundingClientRect();
-        if (r.width > 0 && r.height > 0)
-          cachedPunchOuts.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
-      }
+      cachedZones = [];
+      app.querySelectorAll('img').forEach(img => {
+        if (!img.complete || !img.naturalWidth) return;
+        const r = img.getBoundingClientRect();
+        if (r.width < 2 || r.height < 2) return;
+        cachedZones.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
+      });
     }
 
     function withClip(ctx, fn) {
-      if (!cachedPunchOuts.length) { fn(); return; }
+      if (!cachedZones.length) { fn(); return; }
       ctx.save();
       ctx.beginPath();
-      ctx.rect(0, 0, w, h);
-      for (const p of cachedPunchOuts) ctx.rect(p.x, p.y, p.w, p.h);
-      ctx.clip('evenodd');
+      for (const z of cachedZones) ctx.rect(z.x, z.y, z.w, z.h);
+      ctx.clip();
       fn();
       ctx.restore();
     }

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -5364,6 +5364,7 @@
                 const dy = avatarCy - cardCy;
                 const clone = document.createElement('img');
                 clone.src = img.src;
+                clone.dataset.candleLerpClone = '1';
                 clone.style.cssText = [
                   'position:fixed',
                   `left:${newRect.left}px`, `top:${newRect.top}px`,
@@ -5422,6 +5423,7 @@
             if (Math.abs(dx) < 2 && Math.abs(dy) < 2 && Math.abs(scaleX - 1) < 0.05) return;
             const clone = document.createElement('img');
             clone.src = snapshot.src;
+            clone.dataset.candleLerpClone = '1';
             clone.style.cssText = [
               'position:fixed',
               `left:${newRect.left}px`, `top:${newRect.top}px`,
@@ -7078,6 +7080,33 @@
       return cachedOccluders;
     }
 
+    // Light zones: lighting is clipped to .handWrap and .claimCluster only
+    let lastZoneMs = 0, cachedZones = [];
+    function maybeLightZones(app) {
+      const now = performance.now();
+      if (now - lastZoneMs < 100) return;
+      lastZoneMs = now;
+      const ar = app.getBoundingClientRect();
+      cachedZones = [];
+      for (const sel of ['.handWrap', '.claimCluster']) {
+        const el = app.querySelector(sel);
+        if (!el) continue;
+        const r = el.getBoundingClientRect();
+        if (r.width < 1 || r.height < 1) continue;
+        cachedZones.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
+      }
+    }
+
+    function withClip(ctx, fn) {
+      if (!cachedZones.length) { fn(); return; }
+      ctx.save();
+      ctx.beginPath();
+      for (const z of cachedZones) ctx.rect(z.x, z.y, z.w, z.h);
+      ctx.clip();
+      fn();
+      ctx.restore();
+    }
+
     function resize(app) {
       const rect = app.getBoundingClientRect();
       w = Math.max(1, Math.round(rect.width));
@@ -7129,6 +7158,22 @@
 
       addImgs(CARD_IMG_SEL, CARD_SHADOW_HEIGHT);
       addImgs(COIN_IMG_SEL, COIN_SHADOW_HEIGHT);
+
+      // Card lerp clones live on document.body — include their shadows too
+      document.querySelectorAll('[data-candle-lerp-clone]').forEach(el => {
+        if (!el.complete || !el.naturalWidth) return;
+        const r = el.getBoundingClientRect();
+        if (r.width < 2 || r.height < 2) return;
+        occluders.push({
+          img: el,
+          cx:  r.left - appRect.left + r.width  * 0.5,
+          cy:  r.top  - appRect.top  + r.height * 0.5,
+          iw:  r.width,
+          ih:  r.height,
+          sh:  CARD_SHADOW_HEIGHT,
+        });
+      });
+
       return occluders;
     }
 
@@ -7172,11 +7217,7 @@
         }
       });
 
-      // Single blur pass — far cheaper than per-step filter
-      shadowCtx.clearRect(0, 0, w, h);
-      shadowCtx.filter = 'blur(3px)';
-      shadowCtx.drawImage(workShadow, 0, 0);
-      shadowCtx.filter = 'none';
+      // workShadow holds unblurred steps; caller blits with clip + blur
     }
 
     function draw(time) {
@@ -7197,9 +7238,18 @@
       const pulse  = clamp(0.86 + (flick - 1) * 0.8, 0.68, 1.18);
       const alpha  = clamp(0.5 * INTENSITY * pulse, 0.08, 1.25);
 
+      // Refresh light zone clip rects (hand panel + claim cluster)
+      maybeLightZones(appRef);
+
       // ── Shadow layer ────────────────────────────────────────────────────────
       const occluders = maybeGather(appRef);
       drawOccluderShadows(lx, ly, INTENSITY * pulse, occluders);
+      shadowCtx.clearRect(0, 0, w, h);
+      withClip(shadowCtx, () => {
+        shadowCtx.filter = 'blur(3px)';
+        shadowCtx.drawImage(workShadow, 0, 0);
+        shadowCtx.filter = 'none';
+      });
 
       // ── Darkness layer ─────────────────────────────────────────────────────
       wdCtx.clearRect(0, 0, w, h);
@@ -7212,7 +7262,7 @@
       wdCtx.fillStyle = dg;
       wdCtx.fillRect(0, 0, w, h);
       darkCtx.clearRect(0, 0, w, h);
-      darkCtx.drawImage(workDark, 0, 0);
+      withClip(darkCtx, () => { darkCtx.drawImage(workDark, 0, 0); });
 
       // ── Glow layer ─────────────────────────────────────────────────────────
       wgCtx.clearRect(0, 0, w, h);
@@ -7262,7 +7312,21 @@
       }
 
       glowCtx.clearRect(0, 0, w, h);
-      glowCtx.drawImage(workGlow, 0, 0);
+      withClip(glowCtx, () => { glowCtx.drawImage(workGlow, 0, 0); });
+
+      // ── Lerp clone lighting ─────────────────────────────────────────────────
+      // Clones on document.body get a CSS filter that approximates their position
+      // in the candlelight (dark + warm near source, dim + cool far from it).
+      const ar = appRef.getBoundingClientRect();
+      document.querySelectorAll('[data-candle-lerp-clone]').forEach(el => {
+        const r  = el.getBoundingClientRect();
+        const cx = r.left + r.width  * 0.5 - ar.left;
+        const cy = r.top  + r.height * 0.5 - ar.top;
+        const falloff = Math.max(0, 1 - Math.hypot(cx - lx, cy - ly) / radius);
+        el.style.filter =
+          `brightness(${(0.28 + falloff * 0.72 * pulse).toFixed(3)})` +
+          ` sepia(${(falloff * 0.5).toFixed(3)})`;
+      });
     }
 
     function start() {

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -7045,12 +7045,14 @@
     const glowCtx   = glowCanvas.getContext('2d',   { alpha: true });
 
     // Off-screen work buffers
-    const workDark   = document.createElement('canvas');
-    const workGlow   = document.createElement('canvas');
-    const workShadow = document.createElement('canvas');
-    const wdCtx  = workDark.getContext('2d',   { alpha: true });
-    const wgCtx  = workGlow.getContext('2d',   { alpha: true });
-    const wsCtx  = workShadow.getContext('2d', { alpha: true });
+    const workDark    = document.createElement('canvas');
+    const workGlow    = document.createElement('canvas');
+    const workShadow  = document.createElement('canvas');
+    const workBacklit = document.createElement('canvas');
+    const wdCtx  = workDark.getContext('2d',    { alpha: true });
+    const wgCtx  = workGlow.getContext('2d',    { alpha: true });
+    const wsCtx  = workShadow.getContext('2d',  { alpha: true });
+    const wbCtx  = workBacklit.getContext('2d', { alpha: true });
 
     // Silhouette cache: pre-render each unique img.src as a black shape once
     const silhouetteCache = new Map();
@@ -7080,35 +7082,62 @@
       return cachedOccluders;
     }
 
-    // Backlit UI panels: these elements get their own element-shaped glow source
-    // so they read as self-illuminated objects inside the full-app vignette.
-    const BACKLIT_SELECTORS = ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'];
-    let lastBacklitMs = 0, cachedBacklit = [];
+    // ── Backlit UI panels ─────────────────────────────────────────────────────
+    // Each panel gets its own element-shaped light source: the box IS the core,
+    // glow spills from the edges via blur-blit (no hard edge, low desaturation).
+    const BACKLIT_SELECTORS   = ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'];
+    const PROJ_ID_TO_BACKLIT  = { 'sidebar': '#aiSidebar', 'human-seat-zone': '.humanSeatZone', 'turn-spotlight': '.turnSpotlight' };
+    // Mutable runtime parameters (exposed on window.__candleLight for the UI)
+    let BACKLIT_ALPHA = 0.14;   // overall glow opacity (screen blend)
+    let BACKLIT_BLUR  = 0;      // px; 0 = auto (35% of element min-dimension)
+    // Per-selector state
+    const backlitState = new Map(BACKLIT_SELECTORS.map(s => [s, { backlit: true, immune: false }]));
+    let lastBacklitMs = 0, cachedBacklit = [], cachedImmune = [];
     function maybeGatherBacklit(app) {
       const now = performance.now();
       if (now - lastBacklitMs < 100) return;
       lastBacklitMs = now;
       const ar = app.getBoundingClientRect();
-      cachedBacklit = [];
+      cachedBacklit = []; cachedImmune = [];
       for (const sel of BACKLIT_SELECTORS) {
+        const st = backlitState.get(sel);
         const el = app.querySelector(sel);
         if (!el) continue;
         const r = el.getBoundingClientRect();
-        if (r.width > 0 && r.height > 0)
-          cachedBacklit.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
+        if (r.width < 1 || r.height < 1) continue;
+        const rect = { x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height };
+        if (st?.immune) { cachedImmune.push(rect); continue; }
+        if (st?.backlit !== false) cachedBacklit.push(rect);
       }
     }
 
-    // Draw a box-shaped backlight: the element rect IS the bright core,
-    // with a low-radius glow spilling outward from its edges via shadowBlur.
-    function drawBacklitPanel(ctx, x, y, bw, bh, alpha) {
-      const glowR = clamp(Math.min(bw, bh) * 0.18, 10, 26);
+    // Punch out immune element rects from any canvas (destination-out erase).
+    function punchOutImmune(ctx) {
+      if (!cachedImmune.length) return;
       ctx.save();
-      ctx.shadowColor = `rgba(255, 228, 185, ${alpha * 0.88})`;
-      ctx.shadowBlur  = glowR;
-      ctx.fillStyle   = `rgba(255, 228, 185, ${alpha})`;
-      ctx.fillRect(x, y, bw, bh);
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.fillStyle = '#000';
+      for (const r of cachedImmune) ctx.fillRect(r.x, r.y, r.w, r.h);
       ctx.restore();
+    }
+
+    // Draw all backlit panels: fill to workBacklit, blit with blur → glow canvas.
+    // Blur spreads the fill outward, naturally softening the edges with no hard
+    // boundary. Saturated amber (not near-white) keeps desaturation minimal.
+    function drawBacklitPanels(ctx) {
+      if (!cachedBacklit.length) return;
+      for (const b of cachedBacklit) {
+        wbCtx.clearRect(0, 0, w, h);
+        wbCtx.fillStyle = 'rgba(255, 168, 60, 1)';
+        wbCtx.fillRect(b.x, b.y, b.w, b.h);
+        const blurR = BACKLIT_BLUR > 0 ? BACKLIT_BLUR : Math.min(b.w, b.h) * 0.35;
+        ctx.save();
+        ctx.globalAlpha = BACKLIT_ALPHA;
+        ctx.filter = `blur(${blurR.toFixed(1)}px)`;
+        ctx.drawImage(workBacklit, 0, 0);
+        ctx.filter = 'none';
+        ctx.restore();
+      }
     }
 
     function resize(app) {
@@ -7125,9 +7154,10 @@
       shadowCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
       darkCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
       glowCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      workDark.width   = w; workDark.height   = h;
-      workGlow.width   = w; workGlow.height   = h;
-      workShadow.width = w; workShadow.height = h;
+      workDark.width    = w; workDark.height    = h;
+      workGlow.width    = w; workGlow.height    = h;
+      workShadow.width  = w; workShadow.height  = h;
+      workBacklit.width = w; workBacklit.height = h;
     }
 
     function ensureInApp(app) {
@@ -7252,6 +7282,7 @@
       shadowCtx.filter = 'blur(3px)';
       shadowCtx.drawImage(workShadow, 0, 0);
       shadowCtx.filter = 'none';
+      punchOutImmune(shadowCtx);
 
       // ── Darkness layer ─────────────────────────────────────────────────────
       wdCtx.clearRect(0, 0, w, h);
@@ -7265,6 +7296,7 @@
       wdCtx.fillRect(0, 0, w, h);
       darkCtx.clearRect(0, 0, w, h);
       darkCtx.drawImage(workDark, 0, 0);
+      punchOutImmune(darkCtx);
 
       // ── Glow layer ─────────────────────────────────────────────────────────
       wgCtx.clearRect(0, 0, w, h);
@@ -7313,15 +7345,13 @@
         wgCtx.stroke();
       }
 
-      // Backlit panels — element-shaped source, glow spills from box edges
+      // Backlit panels — element-shaped amber glow, soft blur edges
       wgCtx.globalCompositeOperation = 'source-over';
-      const backlitAlpha = 0.16 * Math.min(pulse, 1.05);
-      for (const b of cachedBacklit) {
-        drawBacklitPanel(wgCtx, b.x, b.y, b.w, b.h, backlitAlpha);
-      }
+      drawBacklitPanels(wgCtx);
 
       glowCtx.clearRect(0, 0, w, h);
       glowCtx.drawImage(workGlow, 0, 0);
+      punchOutImmune(glowCtx);
 
       // ── Lerp clone lighting ─────────────────────────────────────────────────
       // Clones on document.body get a CSS filter that approximates their position
@@ -7354,10 +7384,88 @@
       requestAnimationFrame(ms => draw(ms / 1000));
     }
 
+    // ── Public API (used by the Vars panel controls) ──────────────────────────
+    window.__candleLight = {
+      get backlitAlpha()   { return BACKLIT_ALPHA; },
+      set backlitAlpha(v)  { BACKLIT_ALPHA = clamp(Number(v) || 0, 0, 1); },
+      get backlitBlur()    { return BACKLIT_BLUR; },
+      set backlitBlur(v)   { BACKLIT_BLUR = Math.max(0, Number(v) || 0); },
+      getState(sel)        { return backlitState.get(sel); },
+      setBacklit(sel, on)  { const s = backlitState.get(sel); if (s) { s.backlit = !!on; lastBacklitMs = 0; } },
+      setImmune(sel, on)   { const s = backlitState.get(sel); if (s) { s.immune = !!on; lastBacklitMs = 0; } },
+      selectors:           BACKLIT_SELECTORS,
+      projIdMap:           PROJ_ID_TO_BACKLIT,
+    };
+
+    // ── Candlelight controls in the Vars panel ────────────────────────────────
+    function initCandleLightControls() {
+      const panelBody = document.getElementById('projVarPanelBody');
+      const panelTitle = document.getElementById('projVarPanelTitle');
+      if (!panelBody || !panelTitle) return;
+
+      function getSelectedSel() {
+        const txt = panelTitle.textContent || '';
+        const sep = txt.indexOf(' · ');
+        const projId = sep >= 0 ? txt.slice(sep + 3).trim() : null;
+        return projId ? window.__candleLight.projIdMap[projId] || null : null;
+      }
+
+      function buildSection() {
+        const sel = getSelectedSel();
+        const st  = sel ? window.__candleLight.getState(sel) : null;
+        const sec = document.createElement('div');
+        sec.className = 'candleLightSection';
+        sec.style.cssText = 'border-top:1px solid rgba(200,170,120,0.22);margin-top:10px;padding-top:8px';
+        sec.innerHTML = `
+          <div class="projVarHint" style="color:#c89952;font-weight:600;margin-bottom:4px">Candlelight</div>
+          <label class="projVarRow"><span class="projVarLabel">backlit-alpha</span>
+            <input class="projVarInput" type="number" data-cl="backlitAlpha" step="0.01" min="0" max="1" value="${window.__candleLight.backlitAlpha.toFixed(2)}">
+            <input class="projVarInput" type="range"  data-cl="backlitAlpha" step="0.01" min="0" max="1" value="${window.__candleLight.backlitAlpha.toFixed(2)}">
+          </label>
+          <label class="projVarRow"><span class="projVarLabel">backlit-blur (0=auto)</span>
+            <input class="projVarInput" type="number" data-cl="backlitBlur" step="1" min="0" max="300" value="${window.__candleLight.backlitBlur}">
+            <input class="projVarInput" type="range"  data-cl="backlitBlur" step="1" min="0" max="300" value="${window.__candleLight.backlitBlur}">
+          </label>
+          ${st ? `<div style="margin-top:6px;font-size:0.82em;color:#cdbb9f;margin-bottom:2px">${sel}</div>
+          <label class="projVarRow" style="gap:8px;align-items:center">
+            <span class="projVarLabel">backlit</span>
+            <input type="checkbox" data-cl="backlit" data-sel="${sel}" ${st.backlit ? 'checked' : ''}>
+          </label>
+          <label class="projVarRow" style="gap:8px;align-items:center">
+            <span class="projVarLabel">immune (fully unaffected)</span>
+            <input type="checkbox" data-cl="immune" data-sel="${sel}" ${st.immune ? 'checked' : ''}>
+          </label>` : ''}
+        `;
+        sec.addEventListener('input', e => {
+          const key = e.target.dataset.cl;
+          const elSel = e.target.dataset.sel;
+          if (!key) return;
+          if (key === 'backlitAlpha') {
+            window.__candleLight.backlitAlpha = e.target.value;
+            sec.querySelectorAll('[data-cl="backlitAlpha"]').forEach(i => { if (i !== e.target) i.value = e.target.value; });
+          } else if (key === 'backlitBlur') {
+            window.__candleLight.backlitBlur = e.target.value;
+            sec.querySelectorAll('[data-cl="backlitBlur"]').forEach(i => { if (i !== e.target) i.value = e.target.value; });
+          } else if (key === 'backlit' && elSel) {
+            window.__candleLight.setBacklit(elSel, e.target.checked);
+          } else if (key === 'immune' && elSel) {
+            window.__candleLight.setImmune(elSel, e.target.checked);
+          }
+        });
+        return sec;
+      }
+
+      new MutationObserver(() => {
+        if (!panelBody.querySelector('.candleLightSection'))
+          panelBody.appendChild(buildSection());
+      }).observe(panelBody, { childList: true });
+    }
+
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', start);
+      document.addEventListener('DOMContentLoaded', () => { start(); initCandleLightControls(); });
     } else {
       start();
+      initCandleLightControls();
     }
   })();
   </script>

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2121,6 +2121,21 @@
     body.proj-mapping .card {
       pointer-events: none !important;
     }
+    /* ── Candlelight overlay canvases ─────────────────────────────────────── */
+    /* Injected into #app via JS; inline styles set position/z-index but these
+       rules ensure mix-blend-mode is applied even before paint. */
+    #candleDarknessCanvas,
+    #candleGlowCanvas {
+      position: absolute !important;
+      inset: 0;
+      width: 100% !important;
+      height: 100% !important;
+      pointer-events: none !important;
+      z-index: 2 !important;
+      border-radius: inherit;
+    }
+    #candleDarknessCanvas { mix-blend-mode: multiply; }
+    #candleGlowCanvas     { mix-blend-mode: screen; }
   </style>
 </head>
 <body>
@@ -6948,6 +6963,201 @@
     window.addEventListener('pointerdown', () => SCRATCHBONES_AUDIO.startPlaylist(), { once: true, passive: true });
     window.addEventListener('keydown', () => SCRATCHBONES_AUDIO.startPlaylist(), { once: true, passive: true });
     startGame();
+  </script>
+
+  <!-- ── Candlelight overlay ─────────────────────────────────────────────────
+       Two canvas layers inside #app that survive innerHTML replacements via a
+       MutationObserver.  They blend directly with cards, coins, and the tabletop
+       PNG without touching game logic.
+
+       Positions and rendering settings come from the exported tablelight2.json:
+         light  x: 61 px  →  6.1 / 1920  ≈ 3.2 % of #app width
+                y: 360 px →  360 / 1080  = 33.3 % of #app height
+         intensity  : 0.77   radius (ref) : 1200 px @ 1080 px height
+         speed      : 4.17   turbulence   : 1.0
+  ──────────────────────────────────────────────────────────────────────────── -->
+  <script>
+  (function initCandleLight() {
+    const APP_REF_W = 1920, APP_REF_H = 1080;
+
+    // Light position normalised from tablelight2.json (x:61, y:360) @ 1920×1080
+    const LIGHT_NORM_X = 61  / APP_REF_W;   // ≈ 0.032
+    const LIGHT_NORM_Y = 360 / APP_REF_H;   // ≈ 0.333
+
+    // Controls from tablelight2.json
+    const INTENSITY  = 0.77;
+    const RADIUS_REF = 1200;   // px measured at APP_REF_H
+    const SPEED      = 4.17;
+    const TURBULENCE = 1.0;
+
+    function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
+
+    function smoothNoise(t) {
+      return (
+        Math.sin(t * 1.7)         * 0.44 +
+        Math.sin(t * 4.9  + 1.8) * 0.31 +
+        Math.sin(t * 9.3  + 4.2) * 0.18 +
+        Math.sin(t * 17.1 + 0.7) * 0.07
+      );
+    }
+
+    let w = 0, h = 0;
+
+    // ── Canvas: darkness / depth vignette (mix-blend-mode: multiply) ────────
+    // Warm amber near candle → deep dark at edges.
+    // multiply(white card, warm-amber) = warm-tinted card near candle.
+    // multiply(white card, near-black) = dark card far from candle.
+    const darkCanvas = document.createElement('canvas');
+    darkCanvas.id = 'candleDarknessCanvas';
+    darkCanvas.setAttribute('aria-hidden', 'true');
+
+    // ── Canvas: warm glow (mix-blend-mode: screen) ───────────────────────────
+    // Adds bright amber light on dark surfaces (panels, tabletop PNG) near candle.
+    const glowCanvas = document.createElement('canvas');
+    glowCanvas.id = 'candleGlowCanvas';
+    glowCanvas.setAttribute('aria-hidden', 'true');
+
+    const darkCtx = darkCanvas.getContext('2d', { alpha: true });
+    const glowCtx = glowCanvas.getContext('2d', { alpha: true });
+
+    // Off-screen work buffers (no DPR scaling, drawn then blitted)
+    const workDark = document.createElement('canvas');
+    const workGlow = document.createElement('canvas');
+    const wdCtx    = workDark.getContext('2d', { alpha: true });
+    const wgCtx    = workGlow.getContext('2d', { alpha: true });
+
+    function resize(app) {
+      const rect = app.getBoundingClientRect();
+      w = Math.max(1, Math.round(rect.width));
+      h = Math.max(1, Math.round(rect.height));
+      const dpr = Math.min(devicePixelRatio || 1, 2);
+      for (const cv of [darkCanvas, glowCanvas]) {
+        cv.width  = w * dpr;
+        cv.height = h * dpr;
+        cv.style.width  = w + 'px';
+        cv.style.height = h + 'px';
+      }
+      darkCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      glowCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      workDark.width = w;  workDark.height = h;
+      workGlow.width = w;  workGlow.height = h;
+    }
+
+    function ensureInApp(app) {
+      if (darkCanvas.parentNode !== app) app.appendChild(darkCanvas);
+      if (glowCanvas.parentNode !== app) app.appendChild(glowCanvas);
+    }
+
+    function draw(time) {
+      requestAnimationFrame(ms => draw(ms / 1000));
+      if (!w || !h) return;
+
+      // Scale radius to match the current #app height vs reference
+      const radius = RADIUS_REF * (h / APP_REF_H);
+
+      // Flicker
+      const noise  = smoothNoise(time * SPEED);
+      const qp     = Math.sin(time * 31.0) * 0.025;
+      const flick  = clamp(1 + noise * 0.16 * TURBULENCE + qp, 0.72, 1.28);
+      const driftX = Math.sin(time * 2.2) * 16 * TURBULENCE + noise * 10 * TURBULENCE;
+      const driftY = Math.cos(time * 2.9) * 10 * TURBULENCE;
+      const lx     = LIGHT_NORM_X * w + driftX;
+      const ly     = LIGHT_NORM_Y * h - 12 + driftY;
+      const pulse  = clamp(0.86 + (flick - 1) * 0.8, 0.68, 1.18);
+      const alpha  = clamp(0.5 * INTENSITY * pulse, 0.08, 1.25);
+
+      // ── Darkness layer ─────────────────────────────────────────────────────
+      // Radial: warm amber at candle → deep dark at edges.
+      // Warm amber × white card = amber-tinted card (depth & warmth near candle).
+      // Near-black × white card = darkened card (shadow far from candle).
+      wdCtx.clearRect(0, 0, w, h);
+      const dg = wdCtx.createRadialGradient(lx, ly, 0, lx, ly, radius * 1.45);
+      dg.addColorStop(0,    `rgba(255, 200, 100, ${0.04 * flick})`);  // faint warm glow at candle
+      dg.addColorStop(0.18, 'rgba(200, 140, 60, 0.18)');              // warm mid-distance
+      dg.addColorStop(0.40, 'rgba(60, 36, 14, 0.54)');               // warm-dark transition
+      dg.addColorStop(0.68, 'rgba(16, 10, 4, 0.76)');                // deep shadow
+      dg.addColorStop(1,    'rgba(6, 3, 1, 0.88)');                  // near-black edge
+      wdCtx.fillStyle = dg;
+      wdCtx.fillRect(0, 0, w, h);
+      darkCtx.clearRect(0, 0, w, h);
+      darkCtx.drawImage(workDark, 0, 0);
+
+      // ── Glow layer ─────────────────────────────────────────────────────────
+      // Adds warm amber light on dark surfaces (tabletop, panels) near candle.
+      wgCtx.clearRect(0, 0, w, h);
+      wgCtx.globalCompositeOperation = 'source-over';
+
+      // Main warm elliptical pool
+      wgCtx.save();
+      wgCtx.translate(lx, ly + radius * 0.12);
+      wgCtx.scale(1.12, 0.72);
+      const gg = wgCtx.createRadialGradient(0, 0, 0, 0, 0, radius);
+      gg.addColorStop(0,    `rgba(255, 223, 136, ${alpha})`);
+      gg.addColorStop(0.14, `rgba(255, 223, 136, ${alpha})`);
+      gg.addColorStop(0.55, `rgba(255, 166, 54, ${alpha * 0.5})`);
+      gg.addColorStop(1,    'rgba(255, 120, 16, 0)');
+      wgCtx.fillStyle = gg;
+      wgCtx.beginPath();
+      wgCtx.arc(0, 0, radius, 0, Math.PI * 2);
+      wgCtx.fill();
+      wgCtx.restore();
+
+      // Bright core flare
+      const cg = wgCtx.createRadialGradient(lx, ly - 18, 0, lx, ly - 18, radius * 0.07);
+      cg.addColorStop(0, `rgba(255, 248, 200, ${alpha * 0.9})`);
+      cg.addColorStop(1, 'rgba(255, 145, 32, 0)');
+      wgCtx.fillStyle = cg;
+      wgCtx.beginPath();
+      wgCtx.arc(lx, ly - 18, radius * 0.07, 0, Math.PI * 2);
+      wgCtx.fill();
+
+      // Specular streaks
+      wgCtx.globalCompositeOperation = 'screen';
+      wgCtx.lineWidth = 1;
+      for (let i = 0; i < 14; i++) {
+        const ang    = (i / 14) * Math.PI * 2 + Math.sin(time + i) * 0.08;
+        const len    = radius * (0.42 + (i % 4) * 0.055);
+        const start  = 34 + (i % 3) * 10;
+        const wobble = Math.sin(time * (2.1 + i * 0.13) + i) * 18 * TURBULENCE;
+        const x1 = lx + Math.cos(ang) * start  + wobble;
+        const y1 = ly + Math.sin(ang) * start  * 0.64;
+        const x2 = lx + Math.cos(ang) * len    + wobble * 0.45;
+        const y2 = ly + Math.sin(ang) * len    * 0.64;
+        const sg = wgCtx.createLinearGradient(x1, y1, x2, y2);
+        sg.addColorStop(0, `rgba(255, 221, 140, ${alpha * 0.11})`);
+        sg.addColorStop(1, 'rgba(255, 130, 28, 0)');
+        wgCtx.strokeStyle = sg;
+        wgCtx.beginPath();
+        wgCtx.moveTo(x1, y1);
+        wgCtx.lineTo(x2, y2);
+        wgCtx.stroke();
+      }
+
+      glowCtx.clearRect(0, 0, w, h);
+      glowCtx.drawImage(workGlow, 0, 0);
+    }
+
+    function start() {
+      const app = document.getElementById('app');
+      if (!app) { setTimeout(start, 80); return; }
+
+      resize(app);
+      ensureInApp(app);
+
+      new ResizeObserver(() => resize(app)).observe(app);
+
+      // Re-inject canvases each time app.innerHTML is replaced
+      new MutationObserver(() => ensureInApp(app)).observe(app, { childList: true });
+
+      requestAnimationFrame(ms => draw(ms / 1000));
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', start);
+    } else {
+      start();
+    }
+  })();
   </script>
 </body>
 </html>

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -7043,10 +7043,40 @@
     const glowCtx   = glowCanvas.getContext('2d',   { alpha: true });
 
     // Off-screen work buffers
-    const workDark = document.createElement('canvas');
-    const workGlow = document.createElement('canvas');
-    const wdCtx    = workDark.getContext('2d', { alpha: true });
-    const wgCtx    = workGlow.getContext('2d', { alpha: true });
+    const workDark   = document.createElement('canvas');
+    const workGlow   = document.createElement('canvas');
+    const workShadow = document.createElement('canvas');
+    const wdCtx  = workDark.getContext('2d',   { alpha: true });
+    const wgCtx  = workGlow.getContext('2d',   { alpha: true });
+    const wsCtx  = workShadow.getContext('2d', { alpha: true });
+
+    // Silhouette cache: pre-render each unique img.src as a black shape once
+    const silhouetteCache = new Map();
+    function getSilhouette(img) {
+      const key = img.src;
+      if (silhouetteCache.has(key)) return silhouetteCache.get(key);
+      const nw = img.naturalWidth  || 1;
+      const nh = img.naturalHeight || 1;
+      const oc = document.createElement('canvas');
+      oc.width = nw; oc.height = nh;
+      const octx = oc.getContext('2d');
+      octx.drawImage(img, 0, 0);
+      octx.globalCompositeOperation = 'source-atop';
+      octx.fillStyle = '#000';
+      octx.fillRect(0, 0, nw, nh);
+      silhouetteCache.set(key, oc);
+      return oc;
+    }
+
+    // Throttled occluder cache (~12 fps gather, 60 fps render)
+    let lastGatherMs = 0, cachedOccluders = [];
+    function maybeGather(app) {
+      const now = performance.now();
+      if (now - lastGatherMs < 80) return cachedOccluders;
+      lastGatherMs = now;
+      cachedOccluders = gatherOccluders(app);
+      return cachedOccluders;
+    }
 
     function resize(app) {
       const rect = app.getBoundingClientRect();
@@ -7062,8 +7092,9 @@
       shadowCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
       darkCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
       glowCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      workDark.width = w;  workDark.height = h;
-      workGlow.width = w;  workGlow.height = h;
+      workDark.width   = w; workDark.height   = h;
+      workGlow.width   = w; workGlow.height   = h;
+      workShadow.width = w; workShadow.height = h;
     }
 
     function ensureInApp(app) {
@@ -7101,12 +7132,16 @@
       return occluders;
     }
 
-    // ── Shadow drawing (ported from candlelight demo occluder logic) ──────────
+    // ── Shadow drawing ────────────────────────────────────────────────────────
+    // Steps rendered to workShadow with NO per-step blur; a single blur blit
+    // to shadowCtx replaces the old per-step brightness(0)+blur filter chain.
     function drawOccluderShadows(lx, ly, intensity, occluders) {
-      shadowCtx.clearRect(0, 0, w, h);
-      if (!occluders.length) return;
+      wsCtx.clearRect(0, 0, w, h);
 
       occluders.forEach(occ => {
+        const sil = getSilhouette(occ.img);
+        if (!sil || !sil.width || !sil.height) return;
+
         const dx   = occ.cx - lx;
         const dy   = occ.cy - ly;
         const dist = Math.hypot(dx, dy) || 1;
@@ -7114,30 +7149,34 @@
         const dirY = dy / dist;
 
         const shadowLength = occ.sh * 1.35;
-        const spread   = 1 + occ.sh * 0.0022;
-        const softness = clamp(lerp(1.2, 10, occ.sh / 260), 1.2, 12);
+        const spread    = 1 + occ.sh * 0.0022;
         const baseAlpha = clamp(0.34 + intensity * 0.22, 0.15, 0.72);
+        // Scale silhouette canvas coords → screen coords
+        const sx = occ.iw / sil.width;
+        const sy = occ.ih / sil.height;
 
-        for (let step = 1; step <= 6; step++) {
-          const t      = step / 6;
-          const blurPx = softness * t;
-          const alpha  = baseAlpha * Math.pow(1 - t + 0.02, 1.35);
-
-          shadowCtx.save();
-          shadowCtx.translate(
+        for (let step = 1; step <= 4; step++) {
+          const t = step / 4;
+          wsCtx.save();
+          wsCtx.globalAlpha = baseAlpha * Math.pow(1 - t + 0.02, 1.35);
+          wsCtx.translate(
             occ.cx + dirX * shadowLength * t,
             occ.cy + dirY * shadowLength * t
           );
-          shadowCtx.scale(
-            1 + t * (spread - 1) * 0.85,
-            1 + t * (spread - 1)
+          wsCtx.scale(
+            (1 + t * (spread - 1) * 0.85) * sx,
+            (1 + t * (spread - 1))        * sy
           );
-          shadowCtx.filter      = `brightness(0) blur(${blurPx}px)`;
-          shadowCtx.globalAlpha = alpha;
-          shadowCtx.drawImage(occ.img, -occ.iw * 0.5, -occ.ih * 0.5, occ.iw, occ.ih);
-          shadowCtx.restore();
+          wsCtx.drawImage(sil, -sil.width * 0.5, -sil.height * 0.5);
+          wsCtx.restore();
         }
       });
+
+      // Single blur pass — far cheaper than per-step filter
+      shadowCtx.clearRect(0, 0, w, h);
+      shadowCtx.filter = 'blur(3px)';
+      shadowCtx.drawImage(workShadow, 0, 0);
+      shadowCtx.filter = 'none';
     }
 
     function draw(time) {
@@ -7159,7 +7198,7 @@
       const alpha  = clamp(0.5 * INTENSITY * pulse, 0.08, 1.25);
 
       // ── Shadow layer ────────────────────────────────────────────────────────
-      const occluders = gatherOccluders(appRef);
+      const occluders = maybeGather(appRef);
       drawOccluderShadows(lx, ly, INTENSITY * pulse, occluders);
 
       // ── Darkness layer ─────────────────────────────────────────────────────

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -7080,31 +7080,34 @@
       return cachedOccluders;
     }
 
-    // Light zones: clip to every <img> visible inside #app.
-    // CSS-rendered panels (seats, spotlight, topbar) have no <img>, so they
-    // are immune without any explicit exclusion list or layer-order dependency.
-    let lastZoneMs = 0, cachedZones = [];
-    function maybeLightZones(app) {
+    // Backlit UI panels: these elements get their own element-shaped glow source
+    // so they read as self-illuminated objects inside the full-app vignette.
+    const BACKLIT_SELECTORS = ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'];
+    let lastBacklitMs = 0, cachedBacklit = [];
+    function maybeGatherBacklit(app) {
       const now = performance.now();
-      if (now - lastZoneMs < 100) return;
-      lastZoneMs = now;
+      if (now - lastBacklitMs < 100) return;
+      lastBacklitMs = now;
       const ar = app.getBoundingClientRect();
-      cachedZones = [];
-      app.querySelectorAll('img').forEach(img => {
-        if (!img.complete || !img.naturalWidth) return;
-        const r = img.getBoundingClientRect();
-        if (r.width < 2 || r.height < 2) return;
-        cachedZones.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
-      });
+      cachedBacklit = [];
+      for (const sel of BACKLIT_SELECTORS) {
+        const el = app.querySelector(sel);
+        if (!el) continue;
+        const r = el.getBoundingClientRect();
+        if (r.width > 0 && r.height > 0)
+          cachedBacklit.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
+      }
     }
 
-    function withClip(ctx, fn) {
-      if (!cachedZones.length) { fn(); return; }
+    // Draw a box-shaped backlight: the element rect IS the bright core,
+    // with a low-radius glow spilling outward from its edges via shadowBlur.
+    function drawBacklitPanel(ctx, x, y, bw, bh, alpha) {
+      const glowR = clamp(Math.min(bw, bh) * 0.18, 10, 26);
       ctx.save();
-      ctx.beginPath();
-      for (const z of cachedZones) ctx.rect(z.x, z.y, z.w, z.h);
-      ctx.clip();
-      fn();
+      ctx.shadowColor = `rgba(255, 228, 185, ${alpha * 0.88})`;
+      ctx.shadowBlur  = glowR;
+      ctx.fillStyle   = `rgba(255, 228, 185, ${alpha})`;
+      ctx.fillRect(x, y, bw, bh);
       ctx.restore();
     }
 
@@ -7239,18 +7242,16 @@
       const pulse  = clamp(0.86 + (flick - 1) * 0.8, 0.68, 1.18);
       const alpha  = clamp(0.5 * INTENSITY * pulse, 0.08, 1.25);
 
-      // Refresh light zone clip rects (hand panel + claim cluster)
-      maybeLightZones(appRef);
+      // Gather backlit panel rects (~10 fps)
+      maybeGatherBacklit(appRef);
 
       // ── Shadow layer ────────────────────────────────────────────────────────
       const occluders = maybeGather(appRef);
       drawOccluderShadows(lx, ly, INTENSITY * pulse, occluders);
       shadowCtx.clearRect(0, 0, w, h);
-      withClip(shadowCtx, () => {
-        shadowCtx.filter = 'blur(3px)';
-        shadowCtx.drawImage(workShadow, 0, 0);
-        shadowCtx.filter = 'none';
-      });
+      shadowCtx.filter = 'blur(3px)';
+      shadowCtx.drawImage(workShadow, 0, 0);
+      shadowCtx.filter = 'none';
 
       // ── Darkness layer ─────────────────────────────────────────────────────
       wdCtx.clearRect(0, 0, w, h);
@@ -7263,7 +7264,7 @@
       wdCtx.fillStyle = dg;
       wdCtx.fillRect(0, 0, w, h);
       darkCtx.clearRect(0, 0, w, h);
-      withClip(darkCtx, () => { darkCtx.drawImage(workDark, 0, 0); });
+      darkCtx.drawImage(workDark, 0, 0);
 
       // ── Glow layer ─────────────────────────────────────────────────────────
       wgCtx.clearRect(0, 0, w, h);
@@ -7312,8 +7313,15 @@
         wgCtx.stroke();
       }
 
+      // Backlit panels — element-shaped source, glow spills from box edges
+      wgCtx.globalCompositeOperation = 'source-over';
+      const backlitAlpha = 0.16 * Math.min(pulse, 1.05);
+      for (const b of cachedBacklit) {
+        drawBacklitPanel(wgCtx, b.x, b.y, b.w, b.h, backlitAlpha);
+      }
+
       glowCtx.clearRect(0, 0, w, h);
-      withClip(glowCtx, () => { glowCtx.drawImage(workGlow, 0, 0); });
+      glowCtx.drawImage(workGlow, 0, 0);
 
       // ── Lerp clone lighting ─────────────────────────────────────────────────
       // Clones on document.body get a CSS filter that approximates their position

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2124,6 +2124,7 @@
     /* ── Candlelight overlay canvases ─────────────────────────────────────── */
     /* Injected into #app via JS; inline styles set position/z-index but these
        rules ensure mix-blend-mode is applied even before paint. */
+    #candleShadowCanvas,
     #candleDarknessCanvas,
     #candleGlowCanvas {
       position: absolute !important;
@@ -2134,6 +2135,7 @@
       z-index: 2 !important;
       border-radius: inherit;
     }
+    #candleShadowCanvas   { mix-blend-mode: multiply; }
     #candleDarknessCanvas { mix-blend-mode: multiply; }
     #candleGlowCanvas     { mix-blend-mode: screen; }
   </style>
@@ -6966,12 +6968,20 @@
   </script>
 
   <!-- ── Candlelight overlay ─────────────────────────────────────────────────
-       Two canvas layers inside #app that survive innerHTML replacements via a
+       Three canvas layers inside #app that survive innerHTML replacements via a
        MutationObserver.  They blend directly with cards, coins, and the tabletop
        PNG without touching game logic.
 
+       Shadow canvas  (multiply) – card/coin PNGs cast shaped shadows from their
+                                   actual <img> elements; height 36 for cards, 11
+                                   for coins.
+       Darkness canvas (multiply) – warm-amber-to-black radial vignette; gives
+                                    white card/coin surfaces depth.
+       Glow canvas    (screen)   – animated amber ellipse + specular streaks on
+                                   dark surfaces.
+
        Positions and rendering settings come from the exported tablelight2.json:
-         light  x: 61 px  →  6.1 / 1920  ≈ 3.2 % of #app width
+         light  x: 61 px  →  61 / 1920  ≈ 3.2 % of #app width
                 y: 360 px →  360 / 1080  = 33.3 % of #app height
          intensity  : 0.77   radius (ref) : 1200 px @ 1080 px height
          speed      : 4.17   turbulence   : 1.0
@@ -6990,7 +7000,16 @@
     const SPEED      = 4.17;
     const TURBULENCE = 1.0;
 
+    // Shadow height parameters (demo occluder convention)
+    const CARD_SHADOW_HEIGHT = 36;
+    const COIN_SHADOW_HEIGHT = 11;
+
+    // CSS selectors that identify card and coin <img> elements
+    const CARD_IMG_SEL = '.handScroll .cardArt, .tableViewCard img, .seatHandCard img';
+    const COIN_IMG_SEL = '.stakeTierBtn img, .stakeAnchor img';
+
     function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
+    function lerp(a, b, t)    { return a + (b - a) * t; }
 
     function smoothNoise(t) {
       return (
@@ -7001,26 +7020,29 @@
       );
     }
 
-    let w = 0, h = 0;
+    let w = 0, h = 0, appRef = null;
+
+    // ── Canvas: occluder shadows (mix-blend-mode: multiply) ──────────────────
+    // Black silhouettes of the actual card/coin PNGs cast away from the light.
+    const shadowCanvas = document.createElement('canvas');
+    shadowCanvas.id = 'candleShadowCanvas';
+    shadowCanvas.setAttribute('aria-hidden', 'true');
 
     // ── Canvas: darkness / depth vignette (mix-blend-mode: multiply) ────────
-    // Warm amber near candle → deep dark at edges.
-    // multiply(white card, warm-amber) = warm-tinted card near candle.
-    // multiply(white card, near-black) = dark card far from candle.
     const darkCanvas = document.createElement('canvas');
     darkCanvas.id = 'candleDarknessCanvas';
     darkCanvas.setAttribute('aria-hidden', 'true');
 
     // ── Canvas: warm glow (mix-blend-mode: screen) ───────────────────────────
-    // Adds bright amber light on dark surfaces (panels, tabletop PNG) near candle.
     const glowCanvas = document.createElement('canvas');
     glowCanvas.id = 'candleGlowCanvas';
     glowCanvas.setAttribute('aria-hidden', 'true');
 
-    const darkCtx = darkCanvas.getContext('2d', { alpha: true });
-    const glowCtx = glowCanvas.getContext('2d', { alpha: true });
+    const shadowCtx = shadowCanvas.getContext('2d', { alpha: true });
+    const darkCtx   = darkCanvas.getContext('2d',   { alpha: true });
+    const glowCtx   = glowCanvas.getContext('2d',   { alpha: true });
 
-    // Off-screen work buffers (no DPR scaling, drawn then blitted)
+    // Off-screen work buffers
     const workDark = document.createElement('canvas');
     const workGlow = document.createElement('canvas');
     const wdCtx    = workDark.getContext('2d', { alpha: true });
@@ -7031,12 +7053,13 @@
       w = Math.max(1, Math.round(rect.width));
       h = Math.max(1, Math.round(rect.height));
       const dpr = Math.min(devicePixelRatio || 1, 2);
-      for (const cv of [darkCanvas, glowCanvas]) {
+      for (const cv of [shadowCanvas, darkCanvas, glowCanvas]) {
         cv.width  = w * dpr;
         cv.height = h * dpr;
         cv.style.width  = w + 'px';
         cv.style.height = h + 'px';
       }
+      shadowCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
       darkCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
       glowCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
       workDark.width = w;  workDark.height = h;
@@ -7044,13 +7067,82 @@
     }
 
     function ensureInApp(app) {
-      if (darkCanvas.parentNode !== app) app.appendChild(darkCanvas);
-      if (glowCanvas.parentNode !== app) app.appendChild(glowCanvas);
+      // Append in order: shadow first (deepest), then dark, then glow (topmost)
+      if (shadowCanvas.parentNode !== app) app.appendChild(shadowCanvas);
+      if (darkCanvas.parentNode   !== app) app.appendChild(darkCanvas);
+      if (glowCanvas.parentNode   !== app) app.appendChild(glowCanvas);
+    }
+
+    // ── Occluder gathering ────────────────────────────────────────────────────
+    // Query every card/coin <img> that is loaded and visible, return lightweight
+    // objects holding their center position and dimensions relative to #app.
+    function gatherOccluders(app) {
+      const appRect = app.getBoundingClientRect();
+      const occluders = [];
+
+      function addImgs(selector, shadowHeight) {
+        app.querySelectorAll(selector).forEach(img => {
+          if (!img.complete || !img.naturalWidth) return;
+          const r = img.getBoundingClientRect();
+          if (r.width < 2 || r.height < 2) return;
+          occluders.push({
+            img,
+            cx: r.left - appRect.left + r.width  * 0.5,
+            cy: r.top  - appRect.top  + r.height * 0.5,
+            iw: r.width,
+            ih: r.height,
+            sh: shadowHeight
+          });
+        });
+      }
+
+      addImgs(CARD_IMG_SEL, CARD_SHADOW_HEIGHT);
+      addImgs(COIN_IMG_SEL, COIN_SHADOW_HEIGHT);
+      return occluders;
+    }
+
+    // ── Shadow drawing (ported from candlelight demo occluder logic) ──────────
+    function drawOccluderShadows(lx, ly, intensity, occluders) {
+      shadowCtx.clearRect(0, 0, w, h);
+      if (!occluders.length) return;
+
+      occluders.forEach(occ => {
+        const dx   = occ.cx - lx;
+        const dy   = occ.cy - ly;
+        const dist = Math.hypot(dx, dy) || 1;
+        const dirX = dx / dist;
+        const dirY = dy / dist;
+
+        const shadowLength = occ.sh * 1.35;
+        const spread   = 1 + occ.sh * 0.0022;
+        const softness = clamp(lerp(1.2, 10, occ.sh / 260), 1.2, 12);
+        const baseAlpha = clamp(0.34 + intensity * 0.22, 0.15, 0.72);
+
+        for (let step = 1; step <= 6; step++) {
+          const t      = step / 6;
+          const blurPx = softness * t;
+          const alpha  = baseAlpha * Math.pow(1 - t + 0.02, 1.35);
+
+          shadowCtx.save();
+          shadowCtx.translate(
+            occ.cx + dirX * shadowLength * t,
+            occ.cy + dirY * shadowLength * t
+          );
+          shadowCtx.scale(
+            1 + t * (spread - 1) * 0.85,
+            1 + t * (spread - 1)
+          );
+          shadowCtx.filter      = `brightness(0) blur(${blurPx}px)`;
+          shadowCtx.globalAlpha = alpha;
+          shadowCtx.drawImage(occ.img, -occ.iw * 0.5, -occ.ih * 0.5, occ.iw, occ.ih);
+          shadowCtx.restore();
+        }
+      });
     }
 
     function draw(time) {
       requestAnimationFrame(ms => draw(ms / 1000));
-      if (!w || !h) return;
+      if (!w || !h || !appRef) return;
 
       // Scale radius to match the current #app height vs reference
       const radius = RADIUS_REF * (h / APP_REF_H);
@@ -7066,28 +7158,27 @@
       const pulse  = clamp(0.86 + (flick - 1) * 0.8, 0.68, 1.18);
       const alpha  = clamp(0.5 * INTENSITY * pulse, 0.08, 1.25);
 
+      // ── Shadow layer ────────────────────────────────────────────────────────
+      const occluders = gatherOccluders(appRef);
+      drawOccluderShadows(lx, ly, INTENSITY * pulse, occluders);
+
       // ── Darkness layer ─────────────────────────────────────────────────────
-      // Radial: warm amber at candle → deep dark at edges.
-      // Warm amber × white card = amber-tinted card (depth & warmth near candle).
-      // Near-black × white card = darkened card (shadow far from candle).
       wdCtx.clearRect(0, 0, w, h);
       const dg = wdCtx.createRadialGradient(lx, ly, 0, lx, ly, radius * 1.45);
-      dg.addColorStop(0,    `rgba(255, 200, 100, ${0.04 * flick})`);  // faint warm glow at candle
-      dg.addColorStop(0.18, 'rgba(200, 140, 60, 0.18)');              // warm mid-distance
-      dg.addColorStop(0.40, 'rgba(60, 36, 14, 0.54)');               // warm-dark transition
-      dg.addColorStop(0.68, 'rgba(16, 10, 4, 0.76)');                // deep shadow
-      dg.addColorStop(1,    'rgba(6, 3, 1, 0.88)');                  // near-black edge
+      dg.addColorStop(0,    `rgba(255, 200, 100, ${0.04 * flick})`);
+      dg.addColorStop(0.18, 'rgba(200, 140, 60, 0.18)');
+      dg.addColorStop(0.40, 'rgba(60, 36, 14, 0.54)');
+      dg.addColorStop(0.68, 'rgba(16, 10, 4, 0.76)');
+      dg.addColorStop(1,    'rgba(6, 3, 1, 0.88)');
       wdCtx.fillStyle = dg;
       wdCtx.fillRect(0, 0, w, h);
       darkCtx.clearRect(0, 0, w, h);
       darkCtx.drawImage(workDark, 0, 0);
 
       // ── Glow layer ─────────────────────────────────────────────────────────
-      // Adds warm amber light on dark surfaces (tabletop, panels) near candle.
       wgCtx.clearRect(0, 0, w, h);
       wgCtx.globalCompositeOperation = 'source-over';
 
-      // Main warm elliptical pool
       wgCtx.save();
       wgCtx.translate(lx, ly + radius * 0.12);
       wgCtx.scale(1.12, 0.72);
@@ -7102,7 +7193,6 @@
       wgCtx.fill();
       wgCtx.restore();
 
-      // Bright core flare
       const cg = wgCtx.createRadialGradient(lx, ly - 18, 0, lx, ly - 18, radius * 0.07);
       cg.addColorStop(0, `rgba(255, 248, 200, ${alpha * 0.9})`);
       cg.addColorStop(1, 'rgba(255, 145, 32, 0)');
@@ -7111,7 +7201,6 @@
       wgCtx.arc(lx, ly - 18, radius * 0.07, 0, Math.PI * 2);
       wgCtx.fill();
 
-      // Specular streaks
       wgCtx.globalCompositeOperation = 'screen';
       wgCtx.lineWidth = 1;
       for (let i = 0; i < 14; i++) {
@@ -7140,6 +7229,7 @@
     function start() {
       const app = document.getElementById('app');
       if (!app) { setTimeout(start, 80); return; }
+      appRef = app;
 
       resize(app);
       ensureInApp(app);

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -7081,7 +7081,7 @@
     }
 
     // Punch-outs: lighting covers all of #app except these immune elements.
-    const IMMUNE_SELECTORS = ['#aiSidebar', '.humanSeatZone', '.turnSpotlight', '.claimCluster'];
+    const IMMUNE_SELECTORS = ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'];
     let lastZoneMs = 0, cachedPunchOuts = [];
     function maybeLightZones(app) {
       const now = performance.now();

--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -7080,22 +7080,21 @@
       return cachedOccluders;
     }
 
-    // Punch-outs: lighting covers all of #app; excluded rects are cut out with evenodd.
-    // .claimCluster is excluded while the challenge red background is active.
+    // Punch-outs: lighting covers all of #app except these immune elements.
+    const IMMUNE_SELECTORS = ['#aiSidebar', '.humanSeatZone', '.turnSpotlight', '.claimCluster'];
     let lastZoneMs = 0, cachedPunchOuts = [];
     function maybeLightZones(app) {
       const now = performance.now();
       if (now - lastZoneMs < 100) return;
       lastZoneMs = now;
+      const ar = app.getBoundingClientRect();
       cachedPunchOuts = [];
-      if (app.classList.contains('challenge-visuals-active')) {
-        const ar = app.getBoundingClientRect();
-        const cc = app.querySelector('.claimCluster');
-        if (cc) {
-          const r = cc.getBoundingClientRect();
-          if (r.width > 0 && r.height > 0)
-            cachedPunchOuts.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
-        }
+      for (const sel of IMMUNE_SELECTORS) {
+        const el = app.querySelector(sel);
+        if (!el) continue;
+        const r = el.getBoundingClientRect();
+        if (r.width > 0 && r.height > 0)
+          cachedPunchOuts.push({ x: r.left - ar.left, y: r.top - ar.top, w: r.width, h: r.height });
       }
     }
 

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -7399,6 +7399,13 @@ function boot(){
     window.GAME.__appInitialized = true;
     console.log('[app] ✅ App initialization complete - now loading map...');
 
+    // Candlelight overlay – isolated dynamic import so a failure can't crash boot
+    import('../lighting/CandleLightOverlay2D.js').then(({ initCandleLightOverlay }) => {
+      initCandleLightOverlay();
+    }).catch((err) => {
+      console.warn('[app] CandleLightOverlay2D failed to load:', err);
+    });
+
     // CRITICAL: Use dynamic import to load map-bootstrap AFTER app is ready
     // Static import causes race condition where both modules load in parallel
     console.log('🟡🟡🟡 [app/boot] 🚀 ABOUT TO IMPORT map-bootstrap.js 🟡🟡🟡');

--- a/docs/lighting/CandleLightOverlay2D.js
+++ b/docs/lighting/CandleLightOverlay2D.js
@@ -1,0 +1,364 @@
+/**
+ * CandleLightOverlay2D.js
+ *
+ * Self-contained 2D canvas overlay that renders an animated flickering candlelight
+ * glow on top of the game stage.  Designed as a drop-in module: it creates its own
+ * canvas inside a given container, manages its own RAF loop, and optionally connects
+ * to window.dayNightSystem so it only renders when candles should be lit.
+ *
+ * Quick start (from app.js):
+ *   const { initCandleLightOverlay } = await import('../lighting/CandleLightOverlay2D.js');
+ *   initCandleLightOverlay();
+ *
+ * Advanced:
+ *   import { CandleLightOverlay2D } from '../lighting/CandleLightOverlay2D.js';
+ *   const overlay = new CandleLightOverlay2D(stageEl, { intensity: 0.9, radius: 500 });
+ *   overlay.attach(dayNightSystem);   // optional – auto-polls window.dayNightSystem by default
+ *   // ...later:
+ *   overlay.destroy();
+ */
+
+export class CandleLightOverlay2D {
+  /**
+   * @param {HTMLElement} container  - Element to inject the overlay canvas into (e.g. #gameStage).
+   * @param {object}      [options]
+   * @param {number}  [options.intensity=0.77]   - Overall brightness multiplier (0.2–2.2).
+   * @param {number}  [options.radius=480]        - Falloff radius in CSS px.
+   * @param {number}  [options.speed=4.17]        - Flicker animation speed.
+   * @param {number}  [options.turbulence=1.0]    - Amount of position/intensity drift (0–1).
+   * @param {number}  [options.posNormX=0.5]      - Horizontal light position as 0–1 fraction.
+   * @param {number}  [options.posNormY=0.66]     - Vertical light position as 0–1 fraction.
+   * @param {number}  [options.zIndex=2]          - CSS z-index of the overlay canvas.
+   * @param {boolean} [options.autoConnect=true]  - Poll for window.dayNightSystem automatically.
+   */
+  constructor(container, options = {}) {
+    this._container = container;
+    this._destroyed = false;
+    this._afId = null;
+    this._pollTimer = null;
+    this._dayNight = null;
+    this._visible = true;
+    this._w = 0;
+    this._h = 0;
+
+    // Rendering parameters
+    this.intensity  = options.intensity  ?? 0.77;
+    this.radius     = options.radius     ?? 480;
+    this.speed      = options.speed      ?? 4.17;
+    this.turbulence = options.turbulence ?? 1.0;
+
+    // Light position as fraction of container size
+    this._posNormX = options.posNormX ?? 0.5;
+    this._posNormY = options.posNormY ?? 0.66;
+
+    // Bound event handler kept so it can be removed later
+    this._onTimeChange = () => {
+      this._visible = this._dayNight ? this._dayNight.areCandlesLit() : true;
+    };
+
+    // Output canvas – sits above canvas#game (z-index 1), below .controls-overlay (z-index 4)
+    this._canvas = document.createElement('canvas');
+    this._canvas.style.cssText = [
+      'position:absolute',
+      'inset:0',
+      'width:100%',
+      'height:100%',
+      'pointer-events:none',
+      `z-index:${options.zIndex ?? 2}`,
+      'border-radius:inherit',
+    ].join(';');
+    this._canvas.setAttribute('aria-hidden', 'true');
+    this._ctx = this._canvas.getContext('2d', { alpha: true });
+
+    // Off-screen composition layer (CSS px dimensions, no DPR scaling needed)
+    this._lightCanvas = document.createElement('canvas');
+    this._lightCtx = this._lightCanvas.getContext('2d', { alpha: true });
+
+    container.appendChild(this._canvas);
+
+    this._ro = new ResizeObserver(() => this._onResize());
+    this._ro.observe(container);
+    this._onResize();
+
+    this._startLoop();
+
+    if (options.autoConnect !== false) {
+      this._autoPoll();
+    }
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  /**
+   * Apply numeric control settings from a demo-exported JSON object.
+   * Image data (surface / occluders) is intentionally ignored.
+   *
+   * @param {object} json - Parsed JSON from the candlelight demo's "Export Settings" button.
+   */
+  loadSettings(json) {
+    if (!json || typeof json !== 'object') return;
+    const c = json.controls || {};
+    if (c.intensity  != null) this.intensity  = Number(c.intensity);
+    if (c.radius     != null) this.radius     = Number(c.radius);
+    if (c.speed      != null) this.speed      = Number(c.speed);
+    if (c.turbulence != null) this.turbulence = Number(c.turbulence);
+  }
+
+  /**
+   * Manually attach to a DayNightSystem instance.
+   * The overlay will show only when dayNightSystem.areCandlesLit() returns true.
+   *
+   * @param {import('../../src/lighting/DayNightSystem.js').DayNightSystem} dayNightSystem
+   */
+  attach(dayNightSystem) {
+    this.detach();
+    this._dayNight = dayNightSystem;
+    this._dayNight.on('timeChange', this._onTimeChange);
+    this._visible = this._dayNight.areCandlesLit();
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+  }
+
+  /** Disconnect from the DayNightSystem; overlay stays visible until destroyed. */
+  detach() {
+    if (!this._dayNight) return;
+    this._dayNight.off('timeChange', this._onTimeChange);
+    this._dayNight = null;
+  }
+
+  /** Set light position as a 0–1 fraction of the container size. */
+  setPositionNorm(x, y) {
+    this._posNormX = x;
+    this._posNormY = y;
+  }
+
+  /** Remove the overlay from the DOM and stop all timers. */
+  destroy() {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this.detach();
+    cancelAnimationFrame(this._afId);
+    if (this._pollTimer) clearInterval(this._pollTimer);
+    this._ro.disconnect();
+    if (this._canvas.parentNode) this._canvas.parentNode.removeChild(this._canvas);
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  _onResize() {
+    const rect = this._container.getBoundingClientRect();
+    const w = Math.max(1, Math.round(rect.width));
+    const h = Math.max(1, Math.round(rect.height));
+    const dpr = Math.min(devicePixelRatio || 1, 2);
+
+    this._canvas.width  = w * dpr;
+    this._canvas.height = h * dpr;
+    this._canvas.style.width  = `${w}px`;
+    this._canvas.style.height = `${h}px`;
+    this._ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    this._lightCanvas.width  = w;
+    this._lightCanvas.height = h;
+    this._w = w;
+    this._h = h;
+  }
+
+  _autoPoll() {
+    if (typeof window === 'undefined') return;
+    const tryConnect = () => {
+      if (this._destroyed || this._dayNight) {
+        clearInterval(this._pollTimer);
+        this._pollTimer = null;
+        return;
+      }
+      if (window.dayNightSystem) {
+        this.attach(window.dayNightSystem);
+      }
+    };
+    tryConnect();
+    if (!this._dayNight) {
+      this._pollTimer = setInterval(tryConnect, 500);
+    }
+  }
+
+  _startLoop() {
+    const loop = (ms) => {
+      if (this._destroyed) return;
+      this._afId = requestAnimationFrame(loop);
+      this._draw(ms / 1000);
+    };
+    this._afId = requestAnimationFrame(loop);
+  }
+
+  // ── Rendering helpers (ported from the candlelight demo) ─────────────────
+
+  _clamp(v, lo, hi) {
+    return v < lo ? lo : v > hi ? hi : v;
+  }
+
+  _smoothNoise(t) {
+    return (
+      Math.sin(t * 1.7)         * 0.44 +
+      Math.sin(t * 4.9  + 1.8) * 0.31 +
+      Math.sin(t * 9.3  + 4.2) * 0.18 +
+      Math.sin(t * 17.1 + 0.7) * 0.07
+    );
+  }
+
+  _drawSoftEllipse(tCtx, x, y, radiusX, radiusY, coreRadiusY, alpha, innerColor, outerColor) {
+    const safeRY   = Math.max(1, radiusY);
+    const coreStop = this._clamp(coreRadiusY / safeRY, 0, 0.94);
+    const midStop  = this._clamp(coreStop + (1 - coreStop) * 0.32, coreStop, 0.98);
+
+    tCtx.save();
+    tCtx.translate(x, y);
+    tCtx.scale(radiusX / safeRY, 1);
+
+    const g = tCtx.createRadialGradient(0, 0, 0, 0, 0, safeRY);
+    g.addColorStop(0,        innerColor);
+    g.addColorStop(coreStop, innerColor);
+    g.addColorStop(midStop,  `rgba(255,166,54,${alpha * 0.5})`);
+    g.addColorStop(1,        outerColor);
+
+    tCtx.fillStyle = g;
+    tCtx.beginPath();
+    tCtx.arc(0, 0, safeRY, 0, Math.PI * 2);
+    tCtx.fill();
+    tCtx.restore();
+  }
+
+  _drawSpecularStreaks(tCtx, x, y, radius, alpha, time, turbulence) {
+    const streakCount = 14;
+    tCtx.lineWidth = 1;
+
+    for (let i = 0; i < streakCount; i++) {
+      const angle  = (i / streakCount) * Math.PI * 2 + Math.sin(time + i) * 0.08;
+      const length = radius * (0.42 + (i % 4) * 0.055);
+      const start  = 34 + (i % 3) * 10;
+      const wobble = Math.sin(time * (2.1 + i * 0.13) + i) * 18 * turbulence;
+
+      const x1 = x + Math.cos(angle) * start  + wobble;
+      const y1 = y + Math.sin(angle) * start  * 0.64;
+      const x2 = x + Math.cos(angle) * length + wobble * 0.45;
+      const y2 = y + Math.sin(angle) * length * 0.64;
+
+      const g = tCtx.createLinearGradient(x1, y1, x2, y2);
+      g.addColorStop(0, `rgba(255,221,140,${alpha * 0.11})`);
+      g.addColorStop(1, 'rgba(255,130,28,0)');
+
+      tCtx.strokeStyle = g;
+      tCtx.beginPath();
+      tCtx.moveTo(x1, y1);
+      tCtx.lineTo(x2, y2);
+      tCtx.stroke();
+    }
+  }
+
+  _draw(time) {
+    const w = this._w;
+    const h = this._h;
+    if (!w || !h) return;
+
+    const ctx = this._ctx;
+
+    if (!this._visible) {
+      ctx.clearRect(0, 0, w, h);
+      return;
+    }
+
+    const intensity     = this.intensity;
+    const falloffRadius = this.radius;
+    const turbulence    = this.turbulence;
+
+    const noise      = this._smoothNoise(time * this.speed);
+    const quickPulse = Math.sin(time * 31.0) * 0.025;
+    const flicker    = this._clamp(1 + noise * 0.16 * turbulence + quickPulse, 0.72, 1.28);
+
+    const driftX = Math.sin(time * 2.2) * 16 * turbulence + noise * 10 * turbulence;
+    const driftY = Math.cos(time * 2.9) * 10 * turbulence;
+
+    const lx = this._posNormX * w + driftX;
+    const ly = this._posNormY * h - 12 + driftY;
+
+    const pulseAlpha = this._clamp(0.86 + (flicker - 1) * 0.8, 0.68, 1.18);
+    const alpha      = this._clamp(0.5 * intensity * pulseAlpha, 0.08, 1.25);
+
+    // ── Compose light layer ────────────────────────────────────────────────
+    const lCtx = this._lightCtx;
+    lCtx.clearRect(0, 0, w, h);
+
+    // Warm glow pool
+    lCtx.globalCompositeOperation = 'source-over';
+    this._drawSoftEllipse(
+      lCtx,
+      lx, ly + falloffRadius * 0.12,
+      Math.max(60, falloffRadius * 1.12),
+      Math.max(42, falloffRadius * 0.7),
+      46,
+      alpha,
+      `rgba(255,223,136,${alpha})`,
+      'rgba(255,120,16,0)'
+    );
+
+    // Bright core at the candle point
+    this._drawSoftEllipse(
+      lCtx,
+      lx, ly - 18,
+      102, 72, 16,
+      alpha * 0.82,
+      `rgba(255,245,196,${alpha * 0.8})`,
+      'rgba(255,145,32,0)'
+    );
+
+    // Vignette sharpens the outer falloff edge
+    lCtx.globalCompositeOperation = 'multiply';
+    const vig = lCtx.createRadialGradient(lx, ly, 22, lx, ly, falloffRadius);
+    vig.addColorStop(0,    'rgba(255,255,255,1)');
+    vig.addColorStop(0.56, 'rgba(255,218,184,0.13)');
+    vig.addColorStop(1,    'rgba(0,0,0,0.3)');
+    lCtx.fillStyle = vig;
+    lCtx.fillRect(0, 0, w, h);
+
+    // Specular streaks on top
+    lCtx.globalCompositeOperation = 'screen';
+    this._drawSpecularStreaks(lCtx, lx, ly, falloffRadius, alpha, time, turbulence);
+
+    // ── Blit to output canvas ──────────────────────────────────────────────
+    ctx.clearRect(0, 0, w, h);
+    ctx.drawImage(this._lightCanvas, 0, 0, w, h);
+  }
+}
+
+// ── Convenience initializer ───────────────────────────────────────────────────
+
+/**
+ * Initialize a CandleLightOverlay2D on #gameStage.
+ * Safe to call multiple times; only one overlay is created.
+ * Auto-polls for window.dayNightSystem and attaches when found.
+ *
+ * @param {object} [options] - Passed through to CandleLightOverlay2D constructor.
+ * @returns {CandleLightOverlay2D|null}
+ */
+export function initCandleLightOverlay(options = {}) {
+  if (typeof window !== 'undefined' && window.__candleLightOverlay) {
+    return window.__candleLightOverlay;
+  }
+
+  const container = document.getElementById('gameStage');
+  if (!container) {
+    console.warn('[CandleLightOverlay2D] #gameStage not found – overlay skipped');
+    return null;
+  }
+
+  try {
+    const overlay = new CandleLightOverlay2D(container, options);
+    window.__candleLightOverlay = overlay;
+    console.log('[CandleLightOverlay2D] Initialized on #gameStage');
+    return overlay;
+  } catch (err) {
+    console.error('[CandleLightOverlay2D] Failed to initialize:', err);
+    return null;
+  }
+}

--- a/docs/lighting/CandleLightOverlay2D.js
+++ b/docs/lighting/CandleLightOverlay2D.js
@@ -93,15 +93,36 @@ export class CandleLightOverlay2D {
    * Apply numeric control settings from a demo-exported JSON object.
    * Image data (surface / occluders) is intentionally ignored.
    *
-   * @param {object} json - Parsed JSON from the candlelight demo's "Export Settings" button.
+   * Radius and light position are scaled from the demo's reference viewport to the
+   * current stage size.  The demo does not embed its viewport dimensions, so we
+   * assume 1280×720 by default – override with the optional second argument if you
+   * know the exact screen size the JSON was exported from.
+   *
+   * @param {object} json             - Parsed JSON from the candlelight demo's "Export Settings" button.
+   * @param {object} [refViewport]    - Reference viewport the JSON was created on.
+   * @param {number} [refViewport.width=1280]
+   * @param {number} [refViewport.height=720]
    */
-  loadSettings(json) {
+  loadSettings(json, { width: refW = 1280, height: refH = 720 } = {}) {
     if (!json || typeof json !== 'object') return;
     const c = json.controls || {};
+
     if (c.intensity  != null) this.intensity  = Number(c.intensity);
-    if (c.radius     != null) this.radius     = Number(c.radius);
     if (c.speed      != null) this.speed      = Number(c.speed);
     if (c.turbulence != null) this.turbulence = Number(c.turbulence);
+
+    // Scale radius from reference viewport to current stage size
+    if (c.radius != null) {
+      const stageMin = Math.min(this._w || refW, this._h || refH);
+      const refMin   = Math.min(refW, refH);
+      this.radius = Number(c.radius) * (stageMin / refMin);
+    }
+
+    // Translate absolute light position to 0–1 fractions
+    if (json.light) {
+      if (typeof json.light.x === 'number') this._posNormX = json.light.x / refW;
+      if (typeof json.light.y === 'number') this._posNormY = json.light.y / refH;
+    }
   }
 
   /**


### PR DESCRIPTION
Extracts the core rendering engine from the standalone candlelight demo
into a self-contained ES6 module at docs/lighting/CandleLightOverlay2D.js.
Wires it into app.js via an isolated dynamic import (failure cannot crash boot).

Key design decisions:
- Own canvas injected into #gameStage at z-index 2 (above game, below controls)
- Own RAF loop decoupled from the main game loop
- Auto-polls for window.dayNightSystem; attaches when found and respects
  areCandlesLit() so the overlay is only active during night/candle hours
- loadSettings(json) applies numeric controls from the demo's exported JSON
  while ignoring surface/occluder image data
- destroy() cleans up canvas, timers, and ResizeObserver

https://claude.ai/code/session_019uGytFqRGj6UAy5Eohnz3o