### PR TITLE
Follow-up: include projection-role selectors in candlelight tracked state

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -7154,8 +7154,13 @@
       const legacySelector = LEGACY_PROJ_ID_TO_BACKLIT[projId];
       return legacySelector ? [legacySelector] : [];
     }
+    function flattenProjectionRoleSelectors(projectionRoles) {
+      if (!projectionRoles || typeof projectionRoles !== 'object') return [];
+      return Object.values(projectionRoles).flatMap(roleMap => flattenTargetSelectors(roleMap));
+    }
     const BACKLIT_SELECTORS = uniqSelectors([
       ...flattenTargetSelectors(candlelightTargets.backlit),
+      ...flattenProjectionRoleSelectors(candlelightProjectionRoles),
       ...Object.values(LEGACY_PROJ_ID_TO_BACKLIT),
     ]);
     const IMMUNE_CAPABLE_SELECTORS = uniqSelectors([


### PR DESCRIPTION
### Motivation
- Fix a high-priority regression where role-based candlelight calls like `setBacklit(projectionId, role, on)` and `setImmune(...)` could become no-ops for scoped selectors defined in `projectionRoles`, because those selectors were not included in the tracked selector/state initialization.

### Description
- Added `flattenProjectionRoleSelectors(projectionRoles)` to collect all selectors declared under `candlelight.projectionRoles` in `ScratchbonesBluffGame.html`.
- Included flattened projection-role selectors when building `BACKLIT_SELECTORS` so they are present in `TRACKED_CANDLE_SELECTORS` and thus in `backlitState`.
- This ensures role-scoped selectors (e.g. `#aiSidebar .seatAvatarBox`) resolve to tracked state and that the role-based API paths affect rendering as intended.

### Testing
- Ran `git diff --check` to validate the diff for whitespace/issues and it passed.
- Extracted the inline game `<script>` and validated it parses with Node via `new Function(targetScript)`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef58ae945883268984dd843bc609b4)