### PR TITLE
Config-drive Scratchbones candlelight selectors/defaults and sub-element support

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2431,35 +2431,7 @@
               contactAlpha: rawGameConfig.layout?.lighting?.cardShadow?.contactAlpha ?? 0.2,
             },
             candlelight: {
-              targets: {
-                backlit: {
-                  container: rawGameConfig.layout?.lighting?.candlelight?.targets?.backlit?.container ?? ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'],
-                  avatar: rawGameConfig.layout?.lighting?.candlelight?.targets?.backlit?.avatar ?? ['.seatAvatarBox', '.turnSpotlightAvatar', '.cin-avatar'],
-                  text: rawGameConfig.layout?.lighting?.candlelight?.targets?.backlit?.text ?? ['.seatName', '.seatMeta', '.seatStatus', '.turnSpotlightNameBar', '.cin-name'],
-                },
-                immuneCapable: {
-                  container: rawGameConfig.layout?.lighting?.candlelight?.targets?.immuneCapable?.container ?? ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'],
-                  avatar: rawGameConfig.layout?.lighting?.candlelight?.targets?.immuneCapable?.avatar ?? ['.seatAvatarBox', '.turnSpotlightAvatar', '.cin-avatar'],
-                  text: rawGameConfig.layout?.lighting?.candlelight?.targets?.immuneCapable?.text ?? ['.seatName', '.seatMeta', '.seatStatus', '.turnSpotlightNameBar', '.cin-name'],
-                },
-              },
-              projectionRoles: rawGameConfig.layout?.lighting?.candlelight?.projectionRoles ?? {
-                'sidebar': {
-                  container: ['#aiSidebar'],
-                  avatar: ['#aiSidebar .seatAvatarBox'],
-                  text: ['#aiSidebar .seatName', '#aiSidebar .seatMeta', '#aiSidebar .seatStatus'],
-                },
-                'human-seat-zone': {
-                  container: ['.humanSeatZone'],
-                  avatar: ['.humanSeatZone .seatAvatarBox'],
-                  text: ['.humanSeatZone .seatName', '.humanSeatZone .seatMeta', '.humanSeatZone .seatStatus'],
-                },
-                'turn-spotlight': {
-                  container: ['.turnSpotlight'],
-                  avatar: ['.turnSpotlightAvatar'],
-                  text: ['.turnSpotlightNameBar', '.cin-name'],
-                },
-              },
+              ...(rawGameConfig.layout?.lighting?.candlelight || {}),
             },
           },
           fitter: rawGameConfig.layout?.fitter ?? null,
@@ -7124,11 +7096,72 @@
     // ── Backlit UI panels ─────────────────────────────────────────────────────
     // Each panel gets its own element-shaped light source: the box IS the core,
     // glow spills from the edges via blur-blit (no hard edge, low desaturation).
-    const CANDLELIGHT_ROLE_KEYS = ['container', 'avatar', 'text'];
+    const CANDLELIGHT_ROLE_KEYS = ['container', 'avatar', 'text', 'sub'];
     const candlelightConfig = SCRATCHBONES_GAME.layout?.lighting?.candlelight || {};
     const candlelightMaskingConfig = candlelightConfig.masking || {};
-    const candlelightTargets = candlelightConfig.targets || {};
-    const candlelightProjectionRoles = candlelightConfig.projectionRoles || {};
+    const CANDLELIGHT_FALLBACKS = {
+      backlitAlphaDefault: 0.14,
+      backlitBlurDefault: 0,
+      selectorGroups: {
+        backlit: {
+          container: ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'],
+          avatar: ['.seatAvatarBox', '.turnSpotlightAvatar', '.cin-avatar'],
+          text: ['.seatName', '.seatMeta', '.seatStatus', '.turnSpotlightNameBar', '.cin-name'],
+          sub: ['[data-stake-left-contribution-anchor]', '[data-stake-right-contribution-anchor]', '[data-stake-betting-choice-anchor]', '.stakeTierBtnRow'],
+        },
+        immuneCapable: {
+          container: ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'],
+          avatar: ['.seatAvatarBox', '.turnSpotlightAvatar', '.cin-avatar'],
+          text: ['.seatName', '.seatMeta', '.seatStatus', '.turnSpotlightNameBar', '.cin-name'],
+          sub: ['[data-stake-left-contribution-anchor]', '[data-stake-right-contribution-anchor]', '[data-stake-betting-choice-anchor]', '.stakeTierBtnRow'],
+        },
+      },
+      projectionMappings: {
+        'sidebar': {
+          container: ['#aiSidebar'],
+          avatar: ['#aiSidebar .seatAvatarBox'],
+          text: ['#aiSidebar .seatName', '#aiSidebar .seatMeta', '#aiSidebar .seatStatus'],
+        },
+        'human-seat-zone': {
+          container: ['.humanSeatZone'],
+          avatar: ['.humanSeatZone .seatAvatarBox'],
+          text: ['.humanSeatZone .seatName', '.humanSeatZone .seatMeta', '.humanSeatZone .seatStatus'],
+        },
+        'turn-spotlight': {
+          container: ['.turnSpotlight'],
+          avatar: ['.turnSpotlightAvatar'],
+          text: ['.turnSpotlightNameBar', '.cin-name'],
+        },
+        'betting-left-contribution-anchor': { sub: ['[data-stake-left-contribution-anchor]'] },
+        'betting-right-contribution-anchor': { sub: ['[data-stake-right-contribution-anchor]'] },
+        'betting-choice-anchor': { sub: ['[data-stake-betting-choice-anchor]'] },
+        'betting-tier-buttons': { sub: ['.stakeTierBtnRow'] },
+      },
+      selectorDefaults: {},
+    };
+    const candlelightTargets = candlelightConfig.selectorGroups || candlelightConfig.targets || {};
+    const candlelightProjectionRoles = candlelightConfig.projectionMappings || candlelightConfig.projectionRoles || {};
+    const candlelightSelectorDefaults = candlelightConfig.selectorDefaults && typeof candlelightConfig.selectorDefaults === 'object'
+      ? candlelightConfig.selectorDefaults
+      : CANDLELIGHT_FALLBACKS.selectorDefaults;
+    const candlelightFallbackNotices = new Set();
+    function warnCandlelightFallbackOnce(key, fallbackValue) {
+      if (candlelightFallbackNotices.has(key)) return;
+      candlelightFallbackNotices.add(key);
+      console.warn(`[CandleLight] Missing config "${key}" in docs/config/scratchbones-config.js. Using fallback.`, fallbackValue);
+    }
+    if (!Number.isFinite(Number(candlelightConfig.backlitAlphaDefault))) {
+      warnCandlelightFallbackOnce('layout.lighting.candlelight.backlitAlphaDefault', CANDLELIGHT_FALLBACKS.backlitAlphaDefault);
+    }
+    if (!Number.isFinite(Number(candlelightConfig.backlitBlurDefault))) {
+      warnCandlelightFallbackOnce('layout.lighting.candlelight.backlitBlurDefault', CANDLELIGHT_FALLBACKS.backlitBlurDefault);
+    }
+    if (!candlelightConfig.selectorGroups && !candlelightConfig.targets) {
+      warnCandlelightFallbackOnce('layout.lighting.candlelight.selectorGroups', CANDLELIGHT_FALLBACKS.selectorGroups);
+    }
+    if (!candlelightConfig.projectionMappings && !candlelightConfig.projectionRoles) {
+      warnCandlelightFallbackOnce('layout.lighting.candlelight.projectionMappings', CANDLELIGHT_FALLBACKS.projectionMappings);
+    }
     const LEGACY_PROJ_ID_TO_BACKLIT = {
       'sidebar': '#aiSidebar',
       'human-seat-zone': '.humanSeatZone',
@@ -7155,12 +7188,16 @@
       const legacySelector = LEGACY_PROJ_ID_TO_BACKLIT[projId];
       return legacySelector ? [legacySelector] : [];
     }
+    const selectorGroups = {
+      backlit: candlelightTargets.backlit || CANDLELIGHT_FALLBACKS.selectorGroups.backlit,
+      immuneCapable: candlelightTargets.immuneCapable || CANDLELIGHT_FALLBACKS.selectorGroups.immuneCapable,
+    };
     const BACKLIT_SELECTORS = uniqSelectors([
-      ...flattenTargetSelectors(candlelightTargets.backlit),
+      ...flattenTargetSelectors(selectorGroups.backlit),
       ...Object.values(LEGACY_PROJ_ID_TO_BACKLIT),
     ]);
     const IMMUNE_CAPABLE_SELECTORS = uniqSelectors([
-      ...flattenTargetSelectors(candlelightTargets.immuneCapable),
+      ...flattenTargetSelectors(selectorGroups.immuneCapable),
       ...BACKLIT_SELECTORS,
     ]);
     const BACKLIT_SELECTOR_SET = new Set(BACKLIT_SELECTORS);
@@ -7174,8 +7211,8 @@
         });
       });
     }
-    registerSelectorRoles(candlelightTargets.backlit);
-    registerSelectorRoles(candlelightTargets.immuneCapable);
+    registerSelectorRoles(selectorGroups.backlit);
+    registerSelectorRoles(selectorGroups.immuneCapable);
     BACKLIT_SELECTORS.forEach(sel => {
       if (!CANDLE_SELECTOR_ROLES.has(sel)) CANDLE_SELECTOR_ROLES.set(sel, 'container');
     });
@@ -7183,11 +7220,24 @@
       Object.keys(LEGACY_PROJ_ID_TO_BACKLIT).map(projId => [projId, getProjectionRoleSelectors(projId, 'container')[0] || LEGACY_PROJ_ID_TO_BACKLIT[projId]])
     );
     // Mutable runtime parameters (exposed on window.__candleLight for the UI)
-    let BACKLIT_ALPHA = 0.14;   // overall glow opacity (screen blend)
-    let BACKLIT_BLUR  = 0;      // px; 0 = auto (35% of element min-dimension)
+    let BACKLIT_ALPHA = clamp(Number(candlelightConfig.backlitAlphaDefault), 0, 1);
+    if (!Number.isFinite(BACKLIT_ALPHA)) BACKLIT_ALPHA = CANDLELIGHT_FALLBACKS.backlitAlphaDefault;
+    let BACKLIT_BLUR = Math.max(0, Number(candlelightConfig.backlitBlurDefault));
+    if (!Number.isFinite(BACKLIT_BLUR)) BACKLIT_BLUR = CANDLELIGHT_FALLBACKS.backlitBlurDefault;
     // Per-selector state
-    const TRACKED_CANDLE_SELECTORS = uniqSelectors([...BACKLIT_SELECTORS, ...IMMUNE_CAPABLE_SELECTORS]);
-    const backlitState = new Map(TRACKED_CANDLE_SELECTORS.map(s => [s, { backlit: true, immune: false }]));
+    const TRACKED_CANDLE_SELECTORS = uniqSelectors([
+      ...BACKLIT_SELECTORS,
+      ...IMMUNE_CAPABLE_SELECTORS,
+      ...Object.keys(candlelightSelectorDefaults),
+      ...Object.values(candlelightProjectionRoles).flatMap(entry => flattenTargetSelectors(entry)),
+    ]);
+    const backlitState = new Map(TRACKED_CANDLE_SELECTORS.map(s => {
+      const cfg = candlelightSelectorDefaults[s] || {};
+      return [s, {
+        backlit: cfg.backlit !== false,
+        immune: cfg.immune === true,
+      }];
+    }));
     const IMMUNE_GATHER_CADENCE_MS = Math.max(16, Number(candlelightMaskingConfig.gatherCadenceMs) || 100);
     const IMMUNE_TEXT_MASK_PADDING_PX = Math.max(0, Number(candlelightMaskingConfig.textMaskPaddingPx) || 1);
     let DEBUG_IMMUNE_MASKS = Boolean(candlelightMaskingConfig.debugImmuneMasks);
@@ -7694,6 +7744,14 @@
       set backlitAlpha(v)  { BACKLIT_ALPHA = clamp(Number(v) || 0, 0, 1); },
       get backlitBlur()    { return BACKLIT_BLUR; },
       set backlitBlur(v)   { BACKLIT_BLUR = Math.max(0, Number(v) || 0); },
+      get backlitAlphaDefault() {
+        const value = Number(candlelightConfig.backlitAlphaDefault);
+        return Number.isFinite(value) ? clamp(value, 0, 1) : CANDLELIGHT_FALLBACKS.backlitAlphaDefault;
+      },
+      get backlitBlurDefault() {
+        const value = Number(candlelightConfig.backlitBlurDefault);
+        return Number.isFinite(value) ? Math.max(0, value) : CANDLELIGHT_FALLBACKS.backlitBlurDefault;
+      },
       get debugImmuneMasks()  { return DEBUG_IMMUNE_MASKS; },
       set debugImmuneMasks(v) { DEBUG_IMMUNE_MASKS = Boolean(v); },
       resolveSelectors(targetOrProjId, role) { return getCandleSelectors(targetOrProjId, role); },
@@ -7705,6 +7763,9 @@
       setBacklit(targetOrProjId, roleOrOn, maybeOn) { setCandleState(targetOrProjId, roleOrOn, maybeOn, 'backlit'); },
       setImmune(targetOrProjId, roleOrOn, maybeOn)  { setCandleState(targetOrProjId, roleOrOn, maybeOn, 'immune'); },
       selectors:           BACKLIT_SELECTORS,
+      trackedSelectors:    TRACKED_CANDLE_SELECTORS,
+      selectorGroups:      selectorGroups,
+      selectorDefaults:    candlelightSelectorDefaults,
       projIdMap:           PROJ_ID_TO_BACKLIT,
       projectionRoles:     candlelightProjectionRoles,
     };
@@ -7719,7 +7780,19 @@
         const txt = panelTitle.textContent || '';
         const sep = txt.indexOf(' · ');
         const projId = sep >= 0 ? txt.slice(sep + 3).trim() : null;
-        return projId ? window.__candleLight.projIdMap[projId] || null : null;
+        if (!projId) return null;
+        const selectedSourceEl = document.querySelector(`[data-proj-id="${projId}"]`);
+        const roleMapping = candlelightProjectionRoles?.[projId];
+        if (selectedSourceEl && roleMapping && typeof roleMapping === 'object') {
+          for (const [role, selectors] of Object.entries(roleMapping)) {
+            const roleSelectors = normalizeSelectorArray(selectors);
+            for (const selector of roleSelectors) {
+              if (selectedSourceEl.matches(selector) || selectedSourceEl.closest(selector)) return selector;
+            }
+            if (role === 'sub' && roleSelectors.length) return roleSelectors[0];
+          }
+        }
+        return window.__candleLight.projIdMap[projId] || null;
       }
 
       function buildSection() {

--- a/docs/DAY_NIGHT_LIGHTING.md
+++ b/docs/DAY_NIGHT_LIGHTING.md
@@ -237,6 +237,44 @@ This ensures smooth transitions and proper emissive material updates.
 - **Event-Driven**: Lighting only updates when time of day changes or during transitions
 - **Efficient Transitions**: Uses cubic ease-in-out for smooth, performant animations
 
+## Scratchbones Candlelight Overlay Config (2D HUD)
+
+The Scratchbones HUD candlelight overlay is configured from `docs/config/scratchbones-config.js` under:
+
+- `game.layout.lighting.candlelight.backlitAlphaDefault`
+- `game.layout.lighting.candlelight.backlitBlurDefault`
+- `game.layout.lighting.candlelight.selectorGroups`
+- `game.layout.lighting.candlelight.projectionMappings`
+- `game.layout.lighting.candlelight.selectorDefaults`
+
+`ScratchbonesBluffGame.html` consumes this config at runtime and only uses in-code fallbacks when keys are missing.
+When a fallback is used, the game logs a one-time warning in the console so config drift is visible during testing.
+
+### Selector groups and projection mappings
+
+- `selectorGroups.backlit` controls which selectors receive the amber backlight treatment.
+- `selectorGroups.immuneCapable` controls which selectors are allowed to toggle immunity.
+- `projectionMappings` maps projection ids (including sub-element ids) to role-specific selectors:
+  - `container`
+  - `avatar`
+  - `text`
+  - `sub`
+
+### Immune behavior
+
+Each selector can declare per-selector defaults in `selectorDefaults`:
+
+```js
+{
+  ".seatName": { backlit: true, immune: false }
+}
+```
+
+- `backlit: true` enables glow rendering for matching elements by default.
+- `immune: true` punches that element out of dark/glow passes (fully unaffected by candlelight).
+- Immune masking preserves text/avatar silhouettes where possible (instead of coarse box cutouts).
+- Sub-element selectors (for example betting anchors/buttons) can now be configured the same way as major panels.
+
 ## Example: Manual Candle Light Creation
 
 If you need to create candle lights manually:

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -392,21 +392,85 @@ window.SCRATCHBONES_CONFIG = {
           "contactAlpha": 0.2
         },
         "candlelight": {
+          "backlitAlphaDefault": 0.14,
+          "backlitBlurDefault": 0,
           "masking": {
             "gatherCadenceMs": 100,
             "debugImmuneMasks": false,
             "textMaskPaddingPx": 1
           },
-          "targets": {
+          "selectorDefaults": {
+            "#aiSidebar": { "backlit": true, "immune": false },
+            ".humanSeatZone": { "backlit": true, "immune": false },
+            ".turnSpotlight": { "backlit": true, "immune": false },
+            ".seatAvatarBox": { "backlit": true, "immune": false },
+            ".turnSpotlightAvatar": { "backlit": true, "immune": false },
+            ".cin-avatar": { "backlit": true, "immune": false },
+            ".seatName": { "backlit": true, "immune": false },
+            ".seatMeta": { "backlit": true, "immune": false },
+            ".seatStatus": { "backlit": true, "immune": false },
+            ".turnSpotlightNameBar": { "backlit": true, "immune": false },
+            ".cin-name": { "backlit": true, "immune": false },
+            "[data-stake-left-contribution-anchor]": { "backlit": true, "immune": false },
+            "[data-stake-right-contribution-anchor]": { "backlit": true, "immune": false },
+            "[data-stake-betting-choice-anchor]": { "backlit": true, "immune": false },
+            ".stakeTierBtnRow": { "backlit": true, "immune": false }
+          },
+          "selectorGroups": {
             "backlit": {
               "container": ["#aiSidebar", ".humanSeatZone", ".turnSpotlight"],
               "avatar": [".seatAvatarBox", ".turnSpotlightAvatar", ".cin-avatar"],
-              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"]
+              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"],
+              "sub": ["[data-stake-left-contribution-anchor]", "[data-stake-right-contribution-anchor]", "[data-stake-betting-choice-anchor]", ".stakeTierBtnRow"]
             },
             "immuneCapable": {
               "container": ["#aiSidebar", ".humanSeatZone", ".turnSpotlight"],
               "avatar": [".seatAvatarBox", ".turnSpotlightAvatar", ".cin-avatar"],
-              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"]
+              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"],
+              "sub": ["[data-stake-left-contribution-anchor]", "[data-stake-right-contribution-anchor]", "[data-stake-betting-choice-anchor]", ".stakeTierBtnRow"]
+            }
+          },
+          "projectionMappings": {
+            "sidebar": {
+              "container": ["#aiSidebar"],
+              "avatar": ["#aiSidebar .seatAvatarBox"],
+              "text": ["#aiSidebar .seatName", "#aiSidebar .seatMeta", "#aiSidebar .seatStatus"]
+            },
+            "human-seat-zone": {
+              "container": [".humanSeatZone"],
+              "avatar": [".humanSeatZone .seatAvatarBox"],
+              "text": [".humanSeatZone .seatName", ".humanSeatZone .seatMeta", ".humanSeatZone .seatStatus"]
+            },
+            "turn-spotlight": {
+              "container": [".turnSpotlight"],
+              "avatar": [".turnSpotlightAvatar"],
+              "text": [".turnSpotlightNameBar", ".cin-name"]
+            },
+            "betting-left-contribution-anchor": {
+              "sub": ["[data-stake-left-contribution-anchor]"]
+            },
+            "betting-right-contribution-anchor": {
+              "sub": ["[data-stake-right-contribution-anchor]"]
+            },
+            "betting-choice-anchor": {
+              "sub": ["[data-stake-betting-choice-anchor]"]
+            },
+            "betting-tier-buttons": {
+              "sub": [".stakeTierBtnRow"]
+            }
+          },
+          "targets": {
+            "backlit": {
+              "container": ["#aiSidebar", ".humanSeatZone", ".turnSpotlight"],
+              "avatar": [".seatAvatarBox", ".turnSpotlightAvatar", ".cin-avatar"],
+              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"],
+              "sub": ["[data-stake-left-contribution-anchor]", "[data-stake-right-contribution-anchor]", "[data-stake-betting-choice-anchor]", ".stakeTierBtnRow"]
+            },
+            "immuneCapable": {
+              "container": ["#aiSidebar", ".humanSeatZone", ".turnSpotlight"],
+              "avatar": [".seatAvatarBox", ".turnSpotlightAvatar", ".cin-avatar"],
+              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"],
+              "sub": ["[data-stake-left-contribution-anchor]", "[data-stake-right-contribution-anchor]", "[data-stake-betting-choice-anchor]", ".stakeTierBtnRow"]
             }
           },
           "projectionRoles": {
@@ -424,6 +488,18 @@ window.SCRATCHBONES_CONFIG = {
               "container": [".turnSpotlight"],
               "avatar": [".turnSpotlightAvatar"],
               "text": [".turnSpotlightNameBar", ".cin-name"]
+            },
+            "betting-left-contribution-anchor": {
+              "sub": ["[data-stake-left-contribution-anchor]"]
+            },
+            "betting-right-contribution-anchor": {
+              "sub": ["[data-stake-right-contribution-anchor]"]
+            },
+            "betting-choice-anchor": {
+              "sub": ["[data-stake-betting-choice-anchor]"]
+            },
+            "betting-tier-buttons": {
+              "sub": [".stakeTierBtnRow"]
             }
           }
         }


### PR DESCRIPTION
### Motivation

- Move hardcoded candlelight UI constants out of `ScratchbonesBluffGame.html` and make the overlay driven by a single source of truth in config so layouts and sub-elements can be customized without editing HTML.
- Add per-selector defaults and sub-element (betting anchors/buttons) support so backlit/immune behavior can be tuned per selector and for projection tooling.

### Description

- Added new config keys to `docs/config/scratchbones-config.js`: `backlitAlphaDefault`, `backlitBlurDefault`, `selectorDefaults`, `selectorGroups`, and `projectionMappings` including a `sub` role for sub-elements and betting anchors.
- Reworked runtime initialization in `ScratchbonesBluffGame.html` to consume `rawGameConfig.layout.lighting.candlelight` (supporting both new keys and legacy `targets`/`projectionRoles`) and to prefer config values with in-code fallbacks.
- Extended candlelight logic to support a `sub` role, build `TRACKED_CANDLE_SELECTORS` from `selectorDefaults` and projection mappings, and initialize `backlitState` from per-selector defaults (`{ backlit, immune }`).
- Exposed new inspection/runtime hooks on `window.__candleLight` including `backlitAlphaDefault`, `backlitBlurDefault`, `trackedSelectors`, `selectorGroups`, and `selectorDefaults`, and added one-time console warnings when required config keys are missing.
- Updated `docs/DAY_NIGHT_LIGHTING.md` to document the new Scratchbones candlelight config keys, selector groups/projection mappings, and immune behavior.

### Testing

- Ran `node -e "const fs=require('fs');const src=fs.readFileSync('docs/config/scratchbones-config.js','utf8');new Function(src);console.log('scratchbones-config.js parse ok');"` which completed successfully to validate the updated config file.
- Reviewed the produced diffs for `ScratchbonesBluffGame.html`, `docs/config/scratchbones-config.js`, and `docs/DAY_NIGHT_LIGHTING.md` to ensure the intended changes were applied and that fallbacks are present; no runtime browser tests were executed in this environment.
- No automated visual or browser tests were run; runtime behavior (one-time fallback warnings, selector resolution) was implemented with conservative fallbacks and logged notices for missing config.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef643e170c8326915a7812d4a8c4b3)