### PR TITLE
Enhance candlelight system: sub selectors, projection mappings, selector defaults and Vars UI toggle

### DIFF
--- a/ScratchbonesBluffGame.html
+++ b/ScratchbonesBluffGame.html
@@ -2431,35 +2431,7 @@
               contactAlpha: rawGameConfig.layout?.lighting?.cardShadow?.contactAlpha ?? 0.2,
             },
             candlelight: {
-              targets: {
-                backlit: {
-                  container: rawGameConfig.layout?.lighting?.candlelight?.targets?.backlit?.container ?? ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'],
-                  avatar: rawGameConfig.layout?.lighting?.candlelight?.targets?.backlit?.avatar ?? ['.seatAvatarBox', '.turnSpotlightAvatar', '.cin-avatar'],
-                  text: rawGameConfig.layout?.lighting?.candlelight?.targets?.backlit?.text ?? ['.seatName', '.seatMeta', '.seatStatus', '.turnSpotlightNameBar', '.cin-name'],
-                },
-                immuneCapable: {
-                  container: rawGameConfig.layout?.lighting?.candlelight?.targets?.immuneCapable?.container ?? ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'],
-                  avatar: rawGameConfig.layout?.lighting?.candlelight?.targets?.immuneCapable?.avatar ?? ['.seatAvatarBox', '.turnSpotlightAvatar', '.cin-avatar'],
-                  text: rawGameConfig.layout?.lighting?.candlelight?.targets?.immuneCapable?.text ?? ['.seatName', '.seatMeta', '.seatStatus', '.turnSpotlightNameBar', '.cin-name'],
-                },
-              },
-              projectionRoles: rawGameConfig.layout?.lighting?.candlelight?.projectionRoles ?? {
-                'sidebar': {
-                  container: ['#aiSidebar'],
-                  avatar: ['#aiSidebar .seatAvatarBox'],
-                  text: ['#aiSidebar .seatName', '#aiSidebar .seatMeta', '#aiSidebar .seatStatus'],
-                },
-                'human-seat-zone': {
-                  container: ['.humanSeatZone'],
-                  avatar: ['.humanSeatZone .seatAvatarBox'],
-                  text: ['.humanSeatZone .seatName', '.humanSeatZone .seatMeta', '.humanSeatZone .seatStatus'],
-                },
-                'turn-spotlight': {
-                  container: ['.turnSpotlight'],
-                  avatar: ['.turnSpotlightAvatar'],
-                  text: ['.turnSpotlightNameBar', '.cin-name'],
-                },
-              },
+              ...(rawGameConfig.layout?.lighting?.candlelight || {}),
             },
           },
           fitter: rawGameConfig.layout?.fitter ?? null,
@@ -6538,6 +6510,13 @@
         varsPanelTitle.textContent = `Sub Element · ${projId}`;
         const subSize = authored.subSizes?.[projId] || { width: 0, height: 0 };
         const liveSize = getLiveSubElementSize(projId);
+        const subImmuneState = (() => {
+          const candleApi = window.__candleLight;
+          if (!candleApi?.resolveSelectors || !candleApi?.getState) return null;
+          const resolvedSelector = candleApi.resolveSelectors({ projId, role: 'sub' })[0] || null;
+          if (!resolvedSelector) return null;
+          return { selector: resolvedSelector, state: candleApi.getState(resolvedSelector) || { backlit: true, immune: false } };
+        })();
         const field = (key, label, value) => `<label class="projVarRow sizePosVar"><span class="projVarLabel">${label}</span><input class="projVarInput" data-authored-sub-field="${key}" data-sub-proj-id="${escapeHtml(projId)}" type="number" step="1" value="${Math.round(value)}"><span class="projVarHint">px</span></label>`;
         varsPanelBody.innerHTML = `
           <div class="projVarHint">Sub-element offset (translate within parent).</div>
@@ -6545,6 +6524,7 @@
           ${field('dy', 'dy', offset.dy ?? 0)}
           ${field('width', 'width', subSize.width || liveSize.width)}
           ${field('height', 'height', subSize.height || liveSize.height)}
+          ${subImmuneState ? `<label class="projVarRow" style="gap:8px;align-items:center"><span class="projVarLabel">immune (candlelight)</span><input type="checkbox" data-authored-sub-immune="true" data-sub-proj-id="${escapeHtml(projId)}" ${subImmuneState.state?.immune ? 'checked' : ''}></label><div class="projVarHint">${escapeHtml(subImmuneState.selector)}</div>` : ''}
           ${varRows ? `<div class="projVarHint" style="margin-top:8px;">Linked CSS vars for ${escapeHtml(projId)}.</div>${varRows}` : ''}
         `;
         return;
@@ -6874,6 +6854,14 @@
         if (projectionUiState.varsPanelOpen) renderVarEditor();
       }, true);
       varsPanelBody.addEventListener('input', (event) => {
+        const authoredSubImmuneToggle = event.target.getAttribute('data-authored-sub-immune');
+        if (authoredSubImmuneToggle) {
+          const projId = event.target.getAttribute('data-sub-proj-id');
+          if (!projId || !window.__candleLight?.setProjectionImmune) return;
+          window.__candleLight.setProjectionImmune(projId, Boolean(event.target.checked), 'sub');
+          updateEditorStatus(`Sub candlelight immunity ${projId}=${event.target.checked ? 'on' : 'off'}.`);
+          return;
+        }
         const authoredSubField = event.target.getAttribute('data-authored-sub-field');
         if (authoredSubField) {
           const projId = event.target.getAttribute('data-sub-proj-id');
@@ -7124,11 +7112,73 @@
     // ── Backlit UI panels ─────────────────────────────────────────────────────
     // Each panel gets its own element-shaped light source: the box IS the core,
     // glow spills from the edges via blur-blit (no hard edge, low desaturation).
-    const CANDLELIGHT_ROLE_KEYS = ['container', 'avatar', 'text'];
+    const CANDLELIGHT_ROLE_KEYS = ['container', 'avatar', 'text', 'sub'];
     const candlelightConfig = SCRATCHBONES_GAME.layout?.lighting?.candlelight || {};
     const candlelightMaskingConfig = candlelightConfig.masking || {};
-    const candlelightTargets = candlelightConfig.targets || {};
-    const candlelightProjectionRoles = candlelightConfig.projectionRoles || {};
+    const CANDLELIGHT_FALLBACKS = {
+      backlitAlphaDefault: 0.14,
+      backlitBlurDefault: 0,
+      selectorGroups: {
+        backlit: {
+          container: ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'],
+          avatar: ['.seatAvatarBox', '.turnSpotlightAvatar', '.cin-avatar'],
+          text: ['.seatName', '.seatMeta', '.seatStatus', '.turnSpotlightNameBar', '.cin-name'],
+          sub: ['[data-stake-left-contribution-anchor]', '[data-stake-right-contribution-anchor]', '[data-stake-betting-choice-anchor]', '.stakeTierBtnRow'],
+        },
+        immuneCapable: {
+          container: ['#aiSidebar', '.humanSeatZone', '.turnSpotlight'],
+          avatar: ['.seatAvatarBox', '.turnSpotlightAvatar', '.cin-avatar'],
+          text: ['.seatName', '.seatMeta', '.seatStatus', '.turnSpotlightNameBar', '.cin-name'],
+          sub: ['[data-stake-left-contribution-anchor]', '[data-stake-right-contribution-anchor]', '[data-stake-betting-choice-anchor]', '.stakeTierBtnRow'],
+        },
+      },
+      projectionMappings: {
+        'sidebar': {
+          container: ['#aiSidebar'],
+          avatar: ['#aiSidebar .seatAvatarBox'],
+          text: ['#aiSidebar .seatName', '#aiSidebar .seatMeta', '#aiSidebar .seatStatus'],
+        },
+        'human-seat-zone': {
+          container: ['.humanSeatZone'],
+          avatar: ['.humanSeatZone .seatAvatarBox'],
+          text: ['.humanSeatZone .seatName', '.humanSeatZone .seatMeta', '.humanSeatZone .seatStatus'],
+        },
+        'turn-spotlight': {
+          container: ['.turnSpotlight'],
+          avatar: ['.turnSpotlightAvatar'],
+          text: ['.turnSpotlightNameBar', '.cin-name'],
+        },
+        'betting-left-contribution-anchor': { sub: ['[data-stake-left-contribution-anchor]'] },
+        'betting-right-contribution-anchor': { sub: ['[data-stake-right-contribution-anchor]'] },
+        'betting-choice-anchor': { sub: ['[data-stake-betting-choice-anchor]'] },
+        'betting-tier-buttons': { sub: ['.stakeTierBtnRow'] },
+        'avatar-*': { sub: ['[data-proj-id="{projId}"]'] },
+      },
+      selectorDefaults: {},
+    };
+    const candlelightTargets = candlelightConfig.selectorGroups || candlelightConfig.targets || {};
+    const candlelightProjectionRoles = candlelightConfig.projectionMappings || candlelightConfig.projectionRoles || {};
+    const candlelightSelectorDefaults = candlelightConfig.selectorDefaults && typeof candlelightConfig.selectorDefaults === 'object'
+      ? candlelightConfig.selectorDefaults
+      : CANDLELIGHT_FALLBACKS.selectorDefaults;
+    const candlelightFallbackNotices = new Set();
+    function warnCandlelightFallbackOnce(key, fallbackValue) {
+      if (candlelightFallbackNotices.has(key)) return;
+      candlelightFallbackNotices.add(key);
+      console.warn(`[CandleLight] Missing config "${key}" in docs/config/scratchbones-config.js. Using fallback.`, fallbackValue);
+    }
+    if (!Number.isFinite(Number(candlelightConfig.backlitAlphaDefault))) {
+      warnCandlelightFallbackOnce('layout.lighting.candlelight.backlitAlphaDefault', CANDLELIGHT_FALLBACKS.backlitAlphaDefault);
+    }
+    if (!Number.isFinite(Number(candlelightConfig.backlitBlurDefault))) {
+      warnCandlelightFallbackOnce('layout.lighting.candlelight.backlitBlurDefault', CANDLELIGHT_FALLBACKS.backlitBlurDefault);
+    }
+    if (!candlelightConfig.selectorGroups && !candlelightConfig.targets) {
+      warnCandlelightFallbackOnce('layout.lighting.candlelight.selectorGroups', CANDLELIGHT_FALLBACKS.selectorGroups);
+    }
+    if (!candlelightConfig.projectionMappings && !candlelightConfig.projectionRoles) {
+      warnCandlelightFallbackOnce('layout.lighting.candlelight.projectionMappings', CANDLELIGHT_FALLBACKS.projectionMappings);
+    }
     const LEGACY_PROJ_ID_TO_BACKLIT = {
       'sidebar': '#aiSidebar',
       'human-seat-zone': '.humanSeatZone',
@@ -7147,20 +7197,37 @@
     function uniqSelectors(selectors) {
       return Array.from(new Set(normalizeSelectorArray(selectors)));
     }
+    function matchesProjPattern(pattern, projId) {
+      if (typeof pattern !== 'string' || typeof projId !== 'string') return false;
+      return pattern.endsWith('*') ? projId.startsWith(pattern.slice(0, -1)) : pattern === projId;
+    }
+    function applyProjectionSelectorTemplate(selector, projId) {
+      return String(selector || '').replaceAll('{projId}', projId || '');
+    }
     function getProjectionRoleSelectors(projId, role = 'container') {
-      const byRole = candlelightProjectionRoles[projId] || {};
-      const roleSelectors = normalizeSelectorArray(byRole[role]);
-      if (roleSelectors.length) return roleSelectors;
+      const roleSelectors = [];
+      for (const [pattern, byRole] of Object.entries(candlelightProjectionRoles || {})) {
+        if (!matchesProjPattern(pattern, projId)) continue;
+        normalizeSelectorArray(byRole?.[role]).forEach(sel => {
+          roleSelectors.push(applyProjectionSelectorTemplate(sel, projId));
+        });
+      }
+      const deduped = uniqSelectors(roleSelectors);
+      if (deduped.length) return deduped;
       if (role !== 'container') return [];
       const legacySelector = LEGACY_PROJ_ID_TO_BACKLIT[projId];
       return legacySelector ? [legacySelector] : [];
     }
+    const selectorGroups = {
+      backlit: candlelightTargets.backlit || CANDLELIGHT_FALLBACKS.selectorGroups.backlit,
+      immuneCapable: candlelightTargets.immuneCapable || CANDLELIGHT_FALLBACKS.selectorGroups.immuneCapable,
+    };
     const BACKLIT_SELECTORS = uniqSelectors([
-      ...flattenTargetSelectors(candlelightTargets.backlit),
+      ...flattenTargetSelectors(selectorGroups.backlit),
       ...Object.values(LEGACY_PROJ_ID_TO_BACKLIT),
     ]);
     const IMMUNE_CAPABLE_SELECTORS = uniqSelectors([
-      ...flattenTargetSelectors(candlelightTargets.immuneCapable),
+      ...flattenTargetSelectors(selectorGroups.immuneCapable),
       ...BACKLIT_SELECTORS,
     ]);
     const BACKLIT_SELECTOR_SET = new Set(BACKLIT_SELECTORS);
@@ -7174,8 +7241,8 @@
         });
       });
     }
-    registerSelectorRoles(candlelightTargets.backlit);
-    registerSelectorRoles(candlelightTargets.immuneCapable);
+    registerSelectorRoles(selectorGroups.backlit);
+    registerSelectorRoles(selectorGroups.immuneCapable);
     BACKLIT_SELECTORS.forEach(sel => {
       if (!CANDLE_SELECTOR_ROLES.has(sel)) CANDLE_SELECTOR_ROLES.set(sel, 'container');
     });
@@ -7183,11 +7250,24 @@
       Object.keys(LEGACY_PROJ_ID_TO_BACKLIT).map(projId => [projId, getProjectionRoleSelectors(projId, 'container')[0] || LEGACY_PROJ_ID_TO_BACKLIT[projId]])
     );
     // Mutable runtime parameters (exposed on window.__candleLight for the UI)
-    let BACKLIT_ALPHA = 0.14;   // overall glow opacity (screen blend)
-    let BACKLIT_BLUR  = 0;      // px; 0 = auto (35% of element min-dimension)
+    let BACKLIT_ALPHA = clamp(Number(candlelightConfig.backlitAlphaDefault), 0, 1);
+    if (!Number.isFinite(BACKLIT_ALPHA)) BACKLIT_ALPHA = CANDLELIGHT_FALLBACKS.backlitAlphaDefault;
+    let BACKLIT_BLUR = Math.max(0, Number(candlelightConfig.backlitBlurDefault));
+    if (!Number.isFinite(BACKLIT_BLUR)) BACKLIT_BLUR = CANDLELIGHT_FALLBACKS.backlitBlurDefault;
     // Per-selector state
-    const TRACKED_CANDLE_SELECTORS = uniqSelectors([...BACKLIT_SELECTORS, ...IMMUNE_CAPABLE_SELECTORS]);
-    const backlitState = new Map(TRACKED_CANDLE_SELECTORS.map(s => [s, { backlit: true, immune: false }]));
+    const TRACKED_CANDLE_SELECTORS = uniqSelectors([
+      ...BACKLIT_SELECTORS,
+      ...IMMUNE_CAPABLE_SELECTORS,
+      ...Object.keys(candlelightSelectorDefaults),
+      ...Object.values(candlelightProjectionRoles).flatMap(entry => flattenTargetSelectors(entry)),
+    ]);
+    const backlitState = new Map(TRACKED_CANDLE_SELECTORS.map(s => {
+      const cfg = candlelightSelectorDefaults[s] || {};
+      return [s, {
+        backlit: cfg.backlit !== false,
+        immune: cfg.immune === true,
+      }];
+    }));
     const IMMUNE_GATHER_CADENCE_MS = Math.max(16, Number(candlelightMaskingConfig.gatherCadenceMs) || 100);
     const IMMUNE_TEXT_MASK_PADDING_PX = Math.max(0, Number(candlelightMaskingConfig.textMaskPaddingPx) || 1);
     let DEBUG_IMMUNE_MASKS = Boolean(candlelightMaskingConfig.debugImmuneMasks);
@@ -7322,9 +7402,16 @@
       if (typeof on !== 'boolean') return;
       const selectors = getCandleSelectors(targetOrProjId, role || undefined);
       selectors.forEach(sel => {
+        if (!sel) return;
+        if (!backlitState.has(sel)) {
+          TRACKED_CANDLE_SELECTORS.push(sel);
+          backlitState.set(sel, { backlit: true, immune: false });
+        }
         const state = backlitState.get(sel);
         if (!state) return;
-        if (field === 'immune' && !IMMUNE_CAPABLE_SELECTOR_SET.has(sel)) return;
+        if (field === 'immune' && !IMMUNE_CAPABLE_SELECTOR_SET.has(sel) && !role) return;
+        if (field === 'immune') IMMUNE_CAPABLE_SELECTOR_SET.add(sel);
+        if (field === 'backlit') BACKLIT_SELECTOR_SET.add(sel);
         state[field] = on;
       });
       lastBacklitMs = 0;
@@ -7694,6 +7781,14 @@
       set backlitAlpha(v)  { BACKLIT_ALPHA = clamp(Number(v) || 0, 0, 1); },
       get backlitBlur()    { return BACKLIT_BLUR; },
       set backlitBlur(v)   { BACKLIT_BLUR = Math.max(0, Number(v) || 0); },
+      get backlitAlphaDefault() {
+        const value = Number(candlelightConfig.backlitAlphaDefault);
+        return Number.isFinite(value) ? clamp(value, 0, 1) : CANDLELIGHT_FALLBACKS.backlitAlphaDefault;
+      },
+      get backlitBlurDefault() {
+        const value = Number(candlelightConfig.backlitBlurDefault);
+        return Number.isFinite(value) ? Math.max(0, value) : CANDLELIGHT_FALLBACKS.backlitBlurDefault;
+      },
       get debugImmuneMasks()  { return DEBUG_IMMUNE_MASKS; },
       set debugImmuneMasks(v) { DEBUG_IMMUNE_MASKS = Boolean(v); },
       resolveSelectors(targetOrProjId, role) { return getCandleSelectors(targetOrProjId, role); },
@@ -7704,7 +7799,11 @@
       },
       setBacklit(targetOrProjId, roleOrOn, maybeOn) { setCandleState(targetOrProjId, roleOrOn, maybeOn, 'backlit'); },
       setImmune(targetOrProjId, roleOrOn, maybeOn)  { setCandleState(targetOrProjId, roleOrOn, maybeOn, 'immune'); },
+      setProjectionImmune(projId, on, role = 'sub') { setCandleState({ projId, role }, Boolean(on), undefined, 'immune'); },
       selectors:           BACKLIT_SELECTORS,
+      trackedSelectors:    TRACKED_CANDLE_SELECTORS,
+      selectorGroups:      selectorGroups,
+      selectorDefaults:    candlelightSelectorDefaults,
       projIdMap:           PROJ_ID_TO_BACKLIT,
       projectionRoles:     candlelightProjectionRoles,
     };
@@ -7719,7 +7818,18 @@
         const txt = panelTitle.textContent || '';
         const sep = txt.indexOf(' · ');
         const projId = sep >= 0 ? txt.slice(sep + 3).trim() : null;
-        return projId ? window.__candleLight.projIdMap[projId] || null : null;
+        if (!projId) return null;
+        const selectedSourceEl = document.querySelector(`[data-proj-id="${projId}"]`);
+        if (selectedSourceEl) {
+          for (const role of CANDLELIGHT_ROLE_KEYS) {
+            const roleSelectors = getProjectionRoleSelectors(projId, role);
+            for (const selector of roleSelectors) {
+              if (selectedSourceEl.matches(selector) || selectedSourceEl.closest(selector)) return selector;
+            }
+            if (role === 'sub' && roleSelectors.length) return roleSelectors[0];
+          }
+        }
+        return window.__candleLight.projIdMap[projId] || null;
       }
 
       function buildSection() {

--- a/docs/DAY_NIGHT_LIGHTING.md
+++ b/docs/DAY_NIGHT_LIGHTING.md
@@ -237,6 +237,47 @@ This ensures smooth transitions and proper emissive material updates.
 - **Event-Driven**: Lighting only updates when time of day changes or during transitions
 - **Efficient Transitions**: Uses cubic ease-in-out for smooth, performant animations
 
+## Scratchbones Candlelight Overlay Config (2D HUD)
+
+The Scratchbones HUD candlelight overlay is configured from `docs/config/scratchbones-config.js` under:
+
+- `game.layout.lighting.candlelight.backlitAlphaDefault`
+- `game.layout.lighting.candlelight.backlitBlurDefault`
+- `game.layout.lighting.candlelight.selectorGroups`
+- `game.layout.lighting.candlelight.projectionMappings`
+- `game.layout.lighting.candlelight.selectorDefaults`
+
+`ScratchbonesBluffGame.html` consumes this config at runtime and only uses in-code fallbacks when keys are missing.
+When a fallback is used, the game logs a one-time warning in the console so config drift is visible during testing.
+
+### Selector groups and projection mappings
+
+- `selectorGroups.backlit` controls which selectors receive the amber backlight treatment.
+- `selectorGroups.immuneCapable` controls which selectors are allowed to toggle immunity.
+- `projectionMappings` maps projection ids (including sub-element ids) to role-specific selectors:
+  - `container`
+  - `avatar`
+  - `text`
+  - `sub`
+- projection id patterns support `*` suffix (for example `avatar-*`) and selectors may include `{projId}` templates (for example `[data-proj-id="{projId}"]`) to target a specific element instance.
+
+### Immune behavior
+
+Each selector can declare per-selector defaults in `selectorDefaults`:
+
+```js
+{
+  ".seatName": { backlit: true, immune: false }
+}
+```
+
+- `backlit: true` enables glow rendering for matching elements by default.
+- `immune: true` punches that element out of dark/glow passes (fully unaffected by candlelight).
+- Immune masking preserves text/avatar silhouettes where possible (instead of coarse box cutouts).
+- Sub-element selectors (for example betting anchors/buttons) can now be configured the same way as major panels.
+- You can make individual avatars immune (e.g., `avatar-1`, `avatar-2`, `avatar-3`) by mapping `avatar-*` to a selector template and toggling immunity on those projection ids, without making the whole sidebar container immune.
+- In Scratchbones authored layout mode, the per-sub-element Vars inspector (`Map` → `Sub` → select element → `Vars`) now includes an **immune (candlelight)** checkbox for that selected sub projection id.
+
 ## Example: Manual Candle Light Creation
 
 If you need to create candle lights manually:

--- a/docs/config/scratchbones-config.js
+++ b/docs/config/scratchbones-config.js
@@ -392,21 +392,88 @@ window.SCRATCHBONES_CONFIG = {
           "contactAlpha": 0.2
         },
         "candlelight": {
+          "backlitAlphaDefault": 0.14,
+          "backlitBlurDefault": 0,
           "masking": {
             "gatherCadenceMs": 100,
             "debugImmuneMasks": false,
             "textMaskPaddingPx": 1
           },
-          "targets": {
+          "selectorDefaults": {
+            "#aiSidebar": { "backlit": true, "immune": false },
+            ".humanSeatZone": { "backlit": true, "immune": false },
+            ".turnSpotlight": { "backlit": true, "immune": false },
+            ".seatAvatarBox": { "backlit": true, "immune": false },
+            ".turnSpotlightAvatar": { "backlit": true, "immune": false },
+            ".cin-avatar": { "backlit": true, "immune": false },
+            ".seatName": { "backlit": true, "immune": false },
+            ".seatMeta": { "backlit": true, "immune": false },
+            ".seatStatus": { "backlit": true, "immune": false },
+            ".turnSpotlightNameBar": { "backlit": true, "immune": false },
+            ".cin-name": { "backlit": true, "immune": false },
+            "[data-stake-left-contribution-anchor]": { "backlit": true, "immune": false },
+            "[data-stake-right-contribution-anchor]": { "backlit": true, "immune": false },
+            "[data-stake-betting-choice-anchor]": { "backlit": true, "immune": false },
+            ".stakeTierBtnRow": { "backlit": true, "immune": false }
+          },
+          "selectorGroups": {
             "backlit": {
               "container": ["#aiSidebar", ".humanSeatZone", ".turnSpotlight"],
               "avatar": [".seatAvatarBox", ".turnSpotlightAvatar", ".cin-avatar"],
-              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"]
+              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"],
+              "sub": ["[data-stake-left-contribution-anchor]", "[data-stake-right-contribution-anchor]", "[data-stake-betting-choice-anchor]", ".stakeTierBtnRow"]
             },
             "immuneCapable": {
               "container": ["#aiSidebar", ".humanSeatZone", ".turnSpotlight"],
               "avatar": [".seatAvatarBox", ".turnSpotlightAvatar", ".cin-avatar"],
-              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"]
+              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"],
+              "sub": ["[data-stake-left-contribution-anchor]", "[data-stake-right-contribution-anchor]", "[data-stake-betting-choice-anchor]", ".stakeTierBtnRow"]
+            }
+          },
+          "projectionMappings": {
+            "sidebar": {
+              "container": ["#aiSidebar"],
+              "avatar": ["#aiSidebar .seatAvatarBox"],
+              "text": ["#aiSidebar .seatName", "#aiSidebar .seatMeta", "#aiSidebar .seatStatus"]
+            },
+            "human-seat-zone": {
+              "container": [".humanSeatZone"],
+              "avatar": [".humanSeatZone .seatAvatarBox"],
+              "text": [".humanSeatZone .seatName", ".humanSeatZone .seatMeta", ".humanSeatZone .seatStatus"]
+            },
+            "turn-spotlight": {
+              "container": [".turnSpotlight"],
+              "avatar": [".turnSpotlightAvatar"],
+              "text": [".turnSpotlightNameBar", ".cin-name"]
+            },
+            "betting-left-contribution-anchor": {
+              "sub": ["[data-stake-left-contribution-anchor]"]
+            },
+            "betting-right-contribution-anchor": {
+              "sub": ["[data-stake-right-contribution-anchor]"]
+            },
+            "betting-choice-anchor": {
+              "sub": ["[data-stake-betting-choice-anchor]"]
+            },
+            "betting-tier-buttons": {
+              "sub": [".stakeTierBtnRow"]
+            },
+            "avatar-*": {
+              "sub": ["[data-proj-id=\"{projId}\"]"]
+            }
+          },
+          "targets": {
+            "backlit": {
+              "container": ["#aiSidebar", ".humanSeatZone", ".turnSpotlight"],
+              "avatar": [".seatAvatarBox", ".turnSpotlightAvatar", ".cin-avatar"],
+              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"],
+              "sub": ["[data-stake-left-contribution-anchor]", "[data-stake-right-contribution-anchor]", "[data-stake-betting-choice-anchor]", ".stakeTierBtnRow"]
+            },
+            "immuneCapable": {
+              "container": ["#aiSidebar", ".humanSeatZone", ".turnSpotlight"],
+              "avatar": [".seatAvatarBox", ".turnSpotlightAvatar", ".cin-avatar"],
+              "text": [".seatName", ".seatMeta", ".seatStatus", ".turnSpotlightNameBar", ".cin-name"],
+              "sub": ["[data-stake-left-contribution-anchor]", "[data-stake-right-contribution-anchor]", "[data-stake-betting-choice-anchor]", ".stakeTierBtnRow"]
             }
           },
           "projectionRoles": {
@@ -424,6 +491,21 @@ window.SCRATCHBONES_CONFIG = {
               "container": [".turnSpotlight"],
               "avatar": [".turnSpotlightAvatar"],
               "text": [".turnSpotlightNameBar", ".cin-name"]
+            },
+            "betting-left-contribution-anchor": {
+              "sub": ["[data-stake-left-contribution-anchor]"]
+            },
+            "betting-right-contribution-anchor": {
+              "sub": ["[data-stake-right-contribution-anchor]"]
+            },
+            "betting-choice-anchor": {
+              "sub": ["[data-stake-betting-choice-anchor]"]
+            },
+            "betting-tier-buttons": {
+              "sub": [".stakeTierBtnRow"]
+            },
+            "avatar-*": {
+              "sub": ["[data-proj-id=\"{projId}\"]"]
             }
           }
         }


### PR DESCRIPTION
### Motivation
- Extend the 2D HUD candlelight overlay to support sub-element selectors, projection id patterns/templates, and per-selector defaults so fine-grained elements (like betting anchors and individual avatars) can be backlit or marked immune. 
- Provide robust config fallbacks and visibility when keys are missing so the runtime is tolerant to config drift. 

### Description
- Added support for a new `sub` role and expanded `CANDLELIGHT_ROLE_KEYS` to include `sub`, and wired `projectionMappings` to match projection ids using pattern suffix (`*`) and `{projId}` templates. 
- Introduced `selectorDefaults`, `selectorGroups` and `projectionMappings` parsing with in-code `CANDLELIGHT_FALLBACKS`, one-time console warnings for missing config keys, and defaulting logic for `backlitAlpha` / `backlitBlur`. 
- Made the candlelight runtime state more flexible by tracking extra selectors, applying defaults when initializing `backlitState`, and allowing dynamic addition of selectors via `setCandleState` / `setProjectionImmune`. 
- Extended the public API on `window.__candleLight` with `backlitAlphaDefault`, `backlitBlurDefault`, `setProjectionImmune`, `trackedSelectors`, `selectorGroups`, and `selectorDefaults`, and updated the Vars panel to expose an "immune (candlelight)" checkbox for authored sub-elements with input handling to toggle immunity. 
- Updated `docs/DAY_NIGHT_LIGHTING.md` and `docs/config/scratchbones-config.js` to document and ship example entries for `selectorDefaults`, `selectorGroups`, `projectionMappings`, and default values. 

### Testing
- Ran the project's lint and static checks and they completed successfully. 
- Built the dev bundle and verified the application starts and the candlelight runtime exposes the new API properties. 
- Exercised the Vars panel in authored mode to confirm the new "immune (candlelight)" checkbox toggles immunity via `window.__candleLight.setProjectionImmune` and updates editor status messages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef643e170c8326915a7812d4a8c4b3)